### PR TITLE
Switch to self-hosted runners for CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   test:
-    runs-on: macos-15
+    runs-on: self-hosted
     
     strategy:
       matrix:
@@ -68,7 +68,7 @@ jobs:
         fail_ci_if_error: false
 
   build-swift:
-    runs-on: macos-15
+    runs-on: self-hosted
     timeout-minutes: 30
     
     env:


### PR DESCRIPTION
## Summary
This PR switches our GitHub Actions CI from GitHub-hosted runners to self-hosted runners.

## Changes
- Changed `runs-on: macos-15` to `runs-on: self-hosted` in both test jobs

## Benefits
- 🚀 Better performance with local caching
- 🎮 More control over the build environment
- 💰 Reduced GitHub Actions usage costs
- ⚡ Faster build times with pre-configured environment
- 🛠️ Ability to test with specific hardware/software configurations

## Requirements
Before merging, ensure that:
- [ ] Self-hosted runner is properly configured and registered with the repository
- [ ] Runner has Xcode 16.3 installed at `/Applications/Xcode_16.3.app`
- [ ] Runner has Node.js 20.x and 22.x available
- [ ] Runner has appropriate permissions for screen recording tests

🤖 Generated with [Claude Code](https://claude.ai/code)