### PR TITLE
Fix documentation: Remove incorrect PID targeting claim

### DIFF
--- a/README.md
+++ b/README.md
@@ -606,7 +606,7 @@ For detailed parameter documentation, see [docs/spec.md](./docs/spec.md).
 ### Window Management  
 - **Application listing**: Complete list of running applications
 - **Window enumeration**: List all windows for specific apps
-- **Flexible matching**: Find apps by partial name, bundle ID, or PID
+- **Flexible matching**: Find apps by partial name or bundle ID
 - **Status monitoring**: Active/inactive status, window counts
 
 ### AI Integration
@@ -705,6 +705,7 @@ cd peekaboo-cli && swift build
 
 - **FileHandle warning**: Non-critical Swift warning about TextOutputStream conformance
 - **AI Provider Config**: Requires `PEEKABOO_AI_PROVIDERS` environment variable for analysis features
+- **PID-based targeting not supported**: Although PIDs are shown in the application list (e.g., "Ghostty - PID: 663"), you cannot target applications using `PID:XXX` syntax. Use application names or bundle IDs instead
 
 
 ## License


### PR DESCRIPTION
## Summary
This PR fixes the documentation to accurately reflect that PID-based targeting is not supported.

## Problem
The README incorrectly stated that applications can be found "by partial name, bundle ID, or PID". However, attempting to use PID-based targeting (e.g., `app_target: "PID:663"`) results in an error: "Application with identifier 'PID:663' not found".

## Solution
- Removed the incorrect claim from the README
- Added a "Known Issues" entry documenting this limitation
- Clarified that while PIDs are displayed in list output, they cannot be used for targeting

## Current Behavior
- PIDs are shown in application lists (e.g., "Ghostty - PID: 663")
- PID-based targeting is NOT implemented
- Users must use application names or bundle IDs for targeting

This is a documentation-only change to prevent user confusion.

🤖 Generated with [Claude Code](https://claude.ai/code)