### PR TITLE
Fix incorrect command examples in help text

### DIFF
--- a/peekaboo-cli/Sources/peekaboo/main.swift
+++ b/peekaboo-cli/Sources/peekaboo/main.swift
@@ -12,9 +12,9 @@ struct PeekabooCommand: AsyncParsableCommand {
         abstract: "Lightning-fast macOS screenshots and AI vision analysis (v\(Version.current))",
         discussion: """
             EXAMPLES:
-              peekaboo --app Safari                          # Capture Safari window
-              peekaboo --mode screen                         # Capture entire screen
-              peekaboo --mode frontmost                      # Capture active window
+              peekaboo image --app Safari                    # Capture Safari window
+              peekaboo image --mode screen                   # Capture entire screen
+              peekaboo image --mode frontmost                # Capture active window
               peekaboo image --app "Visual Studio Code"      # Capture VS Code
               peekaboo image --app Chrome --window-title "Gmail" # Capture specific window
               peekaboo image --app Finder --path ~/Desktop/finder.png
@@ -29,15 +29,15 @@ struct PeekabooCommand: AsyncParsableCommand {
 
             COMMON WORKFLOWS:
               # Capture and analyze in one command (NEW!)
-              peekaboo --app Safari --analyze "What's on this page?"
-              peekaboo --mode frontmost --analyze "What UI issues do you see?"
+              peekaboo image --app Safari --analyze "What's on this page?"
+              peekaboo image --mode frontmost --analyze "What UI issues do you see?"
               
               # Or use separate commands for more control
-              peekaboo --app Safari --path /tmp/page.png && peekaboo analyze /tmp/page.png "What's on this page?"
+              peekaboo image --app Safari --path /tmp/page.png && peekaboo analyze /tmp/page.png "What's on this page?"
               
               # Document all windows
               for app in Safari Chrome "Visual Studio Code"; do
-                peekaboo --app "$app" --mode multi --path ~/Screenshots/
+                peekaboo image --app "$app" --mode multi --path ~/Screenshots/
               done
 
             PERMISSIONS:


### PR DESCRIPTION
## Summary
- Fixed incorrect command examples in the root help text that were causing "Unknown option" errors
- Updated all examples to use the correct `peekaboo image` subcommand syntax
- Ensured consistency across all help examples

## Problem
Users following the help examples would encounter errors like:
```
Error: Unknown option '--app'
```

This was because the examples showed direct options on the root command (e.g., `peekaboo --app Safari`) instead of the correct subcommand syntax (`peekaboo image --app Safari`).

## Changes
- Fixed basic capture examples to use `peekaboo image` subcommand
- Updated COMMON WORKFLOWS section with correct syntax
- All examples now match the actual command structure

## Test plan
- [x] Built the Swift CLI with changes
- [x] Verified help text displays correctly
- [x] Tested each corrected command example to ensure it works:
  - `peekaboo image --app Safari` ✅
  - `peekaboo image --mode screen` ✅
  - `peekaboo image --mode frontmost` ✅
  - `peekaboo image --app Safari --analyze "What's on this page?"` ✅

🤖 Generated with [Claude Code](https://claude.ai/code)