### PR TITLE
docs: Add Claude Code install guide to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,30 @@ Edit your Claude Desktop configuration:
 }
 ```
 
+### For Claude Code
+
+Run the following command:
+
+```bash
+claude mcp add-json peekaboo '{
+  "command": "npx",
+  "args": [
+      "-y",
+      "@steipete/peekaboo-mcp"
+    ],
+    "env": {
+      "PEEKABOO_AI_PROVIDERS": "openai/gpt-4o,ollama/llava:latest",
+      "OPENAI_API_KEY": "your-openai-api-key-here"
+    }
+}'
+```
+
+Alternatively, if you've already installed the server via Claude desktop, you can run:
+
+```bash
+claude mcp add-from-claude-desktop
+```
+
 ### For Cursor IDE
 
 Add to your Cursor settings:


### PR DESCRIPTION
## Overview

Currently `README.md` includes MCP server installation guides for Claude Desktop and Cursor. Claude Code's syntax for adding new MCP servers isn't intuitive for new users. 

## Changes

- Updates `README.md` to include installation instructions for Claude code.  

Closes #26.
