### PR TITLE
Fix CI workflow for new project structure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,14 +8,14 @@ on:
 
 jobs:
   test:
-    runs-on: macos-15
+    runs-on: macos-latest
     
     strategy:
       matrix:
         node-version: [20.x, 22.x]
     
     env:
-      DEVELOPER_DIR: /Applications/Xcode_16.1.app/Contents/Developer
+      DEVELOPER_DIR: /Applications/Xcode_16.4.app/Contents/Developer
     
     steps:
     - uses: actions/checkout@v4
@@ -77,11 +77,11 @@ jobs:
         fail_ci_if_error: false
 
   build-swift:
-    runs-on: macos-15
+    runs-on: macos-latest
     timeout-minutes: 30
     
     env:
-      DEVELOPER_DIR: /Applications/Xcode_16.1.app/Contents/Developer
+      DEVELOPER_DIR: /Applications/Xcode_16.4.app/Contents/Developer
     
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,13 +30,8 @@ jobs:
     
     - name: Build Swift CLI for tests
       run: |
-        cd Apps/CLI
-        swift build -c release
-        # Copy the binary to the expected location
-        cp .build/release/peekaboo ../../peekaboo
-        cd ../..
-        # Make it executable
-        chmod +x peekaboo
+        # Use the build script that injects version
+        ./scripts/build-swift-universal.sh
         # Verify it exists
         ls -la peekaboo
     
@@ -98,8 +93,8 @@ jobs:
     
     - name: Build Swift CLI
       run: |
-        cd Apps/CLI
-        swift build -c release
+        # Use the build script that injects version
+        ./scripts/build-swift-universal.sh
     
     - name: Run Swift tests
       timeout-minutes: 15

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,15 +14,17 @@ jobs:
       matrix:
         node-version: [20.x, 22.x]
     
-    env:
-      DEVELOPER_DIR: /Applications/Xcode_16.4.app/Contents/Developer
-    
     steps:
     - uses: actions/checkout@v4
     
     - name: Set up Xcode
       run: |
-        sudo xcode-select -s $DEVELOPER_DIR
+        # List available Xcode versions
+        ls -la /Applications | grep Xcode || true
+        # Use the latest available Xcode
+        LATEST_XCODE=$(ls /Applications | grep Xcode | sort -V | tail -1)
+        echo "Found Xcode: $LATEST_XCODE"
+        sudo xcode-select -s /Applications/$LATEST_XCODE/Contents/Developer
         xcodebuild -version
         swift --version
     
@@ -80,15 +82,17 @@ jobs:
     runs-on: macos-latest
     timeout-minutes: 30
     
-    env:
-      DEVELOPER_DIR: /Applications/Xcode_16.4.app/Contents/Developer
-    
     steps:
     - uses: actions/checkout@v4
     
     - name: Set up Xcode
       run: |
-        sudo xcode-select -s $DEVELOPER_DIR
+        # List available Xcode versions
+        ls -la /Applications | grep Xcode || true
+        # Use the latest available Xcode
+        LATEST_XCODE=$(ls /Applications | grep Xcode | sort -V | tail -1)
+        echo "Found Xcode: $LATEST_XCODE"
+        sudo xcode-select -s /Applications/$LATEST_XCODE/Contents/Developer
         xcodebuild -version
         swift --version
     

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
         node-version: [20.x, 22.x]
     
     env:
-      DEVELOPER_DIR: /Applications/Xcode_16.4.app/Contents/Developer
+      DEVELOPER_DIR: /Applications/Xcode_16.1.app/Contents/Developer
     
     steps:
     - uses: actions/checkout@v4
@@ -43,18 +43,27 @@ jobs:
       with:
         node-version: ${{ matrix.node-version }}
         cache: 'npm'
+        cache-dependency-path: Server/package-lock.json
     
     - name: Install dependencies
-      run: npm ci
+      run: |
+        cd Server
+        npm ci
     
     - name: Build TypeScript
-      run: npm run build
+      run: |
+        cd Server
+        npm run build
     
     - name: Run linter
-      run: npm run lint --if-present
+      run: |
+        cd Server
+        npm run lint --if-present
     
     - name: Run tests with coverage
-      run: npm run test:coverage
+      run: |
+        cd Server
+        npm run test:coverage
       env:
         CI: true
     
@@ -62,7 +71,7 @@ jobs:
       uses: codecov/codecov-action@v4
       if: matrix.node-version == '20.x'
       with:
-        file: ./coverage/lcov.info
+        file: ./Server/coverage/lcov.info
         flags: unittests
         name: codecov-umbrella
         fail_ci_if_error: false
@@ -72,7 +81,7 @@ jobs:
     timeout-minutes: 30
     
     env:
-      DEVELOPER_DIR: /Applications/Xcode_16.4.app/Contents/Developer
+      DEVELOPER_DIR: /Applications/Xcode_16.1.app/Contents/Developer
     
     steps:
     - uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 ![Peekaboo Banner](https://raw.githubusercontent.com/steipete/peekaboo/main/assets/banner.png)
 
 [![npm version](https://badge.fury.io/js/%40steipete%2Fpeekaboo-mcp.svg)](https://www.npmjs.com/package/@steipete/peekaboo-mcp)
+[![CI](https://github.com/steipete/Peekaboo/actions/workflows/ci.yml/badge.svg)](https://github.com/steipete/Peekaboo/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![macOS](https://img.shields.io/badge/macOS-14.0%2B-blue.svg)](https://www.apple.com/macos/)
 [![Swift](https://img.shields.io/badge/Swift-5.9%2B-orange.svg)](https://swift.org/)


### PR DESCRIPTION
## Summary
- Updates CI workflow to work with the new project structure after the spec-v3 merge
- Adds CI status badge to README

## Changes
- Fixed npm commands to run in the `Server` directory
- Updated npm cache path to use `Server/package-lock.json`
- Fixed coverage upload path to `Server/coverage/lcov.info`
- Changed Xcode version from 16.4 to 16.1 (which should be available on macOS-15 runners)
- Added CI status badge to README to show build status

## Test plan
- [x] Updated CI workflow paths
- [x] Fixed Xcode version
- [ ] CI should run successfully on this PR
- [ ] Both Node.js test matrix (20.x, 22.x) should pass
- [ ] Swift tests should pass

🤖 Generated with [Claude Code](https://claude.ai/code)