### PR TITLE
fix(cli): Add missing positional argument to CaptureVideoCommand signature

### DIFF
--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Core/CaptureCommand+CommanderMetadata.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Core/CaptureCommand+CommanderMetadata.swift
@@ -47,6 +47,9 @@ extension CaptureLiveCommand: CommanderSignatureProviding {
 extension CaptureVideoCommand: CommanderSignatureProviding {
     static func commanderSignature() -> CommandSignature {
         CommandSignature(
+            arguments: [
+                .make(label: "input", help: "Input video file", isOptional: false),
+            ],
             options: [
                 .commandOption("sampleFps", help: "Sample FPS (default 2)", long: "sample-fps"),
                 .commandOption("everyMs", help: "Sample every N ms", long: "every-ms"),


### PR DESCRIPTION
## Problem

Running `peekaboo capture video <file>` crashes with:

```
Commander/PropertyWrappers.swift:98: Fatal error: Commander argument 'String' accessed before being bound
```

## Root Cause

The `CaptureVideoCommand.commanderSignature()` in `CaptureCommand+CommanderMetadata.swift` was missing the `arguments:` array declaration for the required `input` positional parameter. While the `applyCommanderValues` method correctly reads the positional argument via `values.requiredPositional(0, label: "input")`, the Commander framework was never told about this positional argument in the signature.

## Fix

Added the missing `arguments` array to `CaptureVideoCommand.commanderSignature()`:

```swift
CommandSignature(
    arguments: [
        .make(label: "input", help: "Input video file", isOptional: false),
    ],
    options: [
        // ... existing options
    ],
    // ...
)
```

This matches the pattern used by other commands with positional arguments, such as `MCPCommand.Call`, `MCPCommand.Add`, `SleepCommand`, etc.

## Testing

After this fix, `peekaboo capture video /path/to/video.mp4` correctly parses the positional argument without crashing.