### PR TITLE
fix(cli): Add missing input argument binding for capture video command

### DIFF
--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Core/CaptureCommand+CommanderMetadata.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Core/CaptureCommand+CommanderMetadata.swift
@@ -47,6 +47,9 @@ extension CaptureLiveCommand: CommanderSignatureProviding {
 extension CaptureVideoCommand: CommanderSignatureProviding {
     static func commanderSignature() -> CommandSignature {
         CommandSignature(
+            arguments: [
+                .make(label: "input", help: "Input video file", isOptional: false)
+            ],
             options: [
                 .commandOption("sampleFps", help: "Sample FPS (default 2)", long: "sample-fps"),
                 .commandOption("everyMs", help: "Sample every N ms", long: "every-ms"),

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Core/CaptureCommand.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Core/CaptureCommand.swift
@@ -532,6 +532,7 @@ extension CaptureVideoCommand: AsyncRuntimeCommand {}
 @MainActor
 extension CaptureVideoCommand: CommanderBindableCommand {
     mutating func applyCommanderValues(_ values: CommanderBindableValues) throws {
+        self.input = try values.requiredPositional(0, label: "input")
         self.sampleFps = try values.decodeOption("sampleFps", as: Double.self)
         self.everyMs = try values.decodeOption("everyMs", as: Int.self)
         self.startMs = try values.decodeOption("startMs", as: Int.self)

--- a/Apps/CLI/Tests/CLIAutomationTests/CaptureVideoCommandTests.swift
+++ b/Apps/CLI/Tests/CLIAutomationTests/CaptureVideoCommandTests.swift
@@ -1,3 +1,4 @@
+import Commander
 import CoreGraphics
 import Foundation
 import PeekabooCore
@@ -14,5 +15,34 @@ struct CaptureVideoCommandTests {
         #expect(opts.maxFrames >= 1)
         #expect(opts.resolutionCap == 1440)
         #expect(opts.diffStrategy == .fast)
+    }
+
+    @Test("parsing requires input positional")
+    func parsingRequiresInput() async throws {
+        #expect(throws: (any Error).self) {
+            _ = try CaptureVideoCommand.parse([])
+        }
+    }
+
+    @Test("parsing sets input positional")
+    func parsingSetsInput() async throws {
+        let cmd = try CaptureVideoCommand.parse(["/tmp/demo.mov"])
+        #expect(cmd.input == "/tmp/demo.mov")
+    }
+
+    @Test("commanderSignature includes input argument")
+    func signatureIncludesInputArgument() async throws {
+        let signature = CaptureVideoCommand.commanderSignature()
+        #expect(signature.arguments.count == 1)
+        #expect(signature.arguments.first?.label == "input")
+        #expect(signature.arguments.first?.isOptional == false)
+    }
+
+    @Test("parsing sets input with options")
+    func parsingSetsInputWithOptions() async throws {
+        let cmd = try CaptureVideoCommand.parse(["/path/to/video.mp4", "--max-frames", "10", "--sample-fps", "5"])
+        #expect(cmd.input == "/path/to/video.mp4")
+        #expect(cmd.maxFrames == 10)
+        #expect(cmd.sampleFps == 5)
     }
 }


### PR DESCRIPTION
## Summary
The `CaptureVideoCommand` was missing proper argument binding for the required `input` positional parameter, causing a crash when invoking the command.

**Error:** `Commander argument 'String' accessed before being bound`

## Root Cause
Two issues:
1. `commanderSignature()` was missing the `arguments` array for the `input` positional parameter
2. `applyCommanderValues()` was not binding `self.input` from parsed values

## Changes
- `CaptureCommand+CommanderMetadata.swift`: Added `arguments` array with `input` definition
- `CaptureCommand.swift`: Added `self.input = try values.requiredPositional(0, label: "input")`
- `CaptureVideoCommandTests.swift`: Added 4 test cases for argument parsing and signature validation

## Testing
```bash
# Before fix - crashes
peekaboo capture video /path/to/video.mp4
# Commander argument 'String' accessed before being bound

# After fix - works
peekaboo capture video /path/to/video.mp4 --max-frames 10
# Command executes and processes video
```