### PR TITLE
fix(capture): Use display-based capture for window screenshots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@
 ### Fixed
 - Visualizer previews now respect their full duration before fading out; overlays no longer disappear in ~0.3s regardless of requested timing.
 - App resolution now prioritizes exact name matches over bundleID-contains matches, preventing `--app Safari` from accidentally matching helper processes with “Safari” in their bundle ID.
+- ScreenCaptureKit window capture no longer returns black frames for GPU-rendered windows (notably iOS Simulator), and display-bound crops now use display-local `sourceRect` coordinates on secondary monitors (thanks @bheemreddy-samsara).
 - `peekaboo see` is now bounded for “single action” use:
   - Without `--analyze`, the overall wall-clock timeout is **10 seconds**.
   - `--json` output skips menubar enumeration unless `--verbose` is set, and timeouts surface as `TIMEOUT` exit codes instead of silent hangs.

--- a/Core/PeekabooCore/Tests/PeekabooTests/ScreenCaptureServiceFlowTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/ScreenCaptureServiceFlowTests.swift
@@ -196,6 +196,30 @@ struct ScreenCaptureServiceFlowTests {
         let recordedCalls = await permission.callCount
         #expect(recordedCalls == 1)
     }
+
+    @Test("displayLocalSourceRect converts global to display-local")
+    func displayLocalSourceRectUsesDisplayOrigin() {
+        // ScreenCaptureKit expects `sourceRect` in display-local coordinates (origin at (0,0) for that display),
+        // but `SCDisplay.frame` / `SCWindow.frame` are global desktop coordinates (matching `NSScreen.frame`).
+        //
+        // This is especially important for secondary displays whose frames have non-zero (or negative) origins.
+        let displayFrame = CGRect(x: 1920, y: 200, width: 2560, height: 1440)
+        let globalRect = CGRect(x: 2000, y: 260, width: 300, height: 200)
+
+        let local = ScreenCaptureService.displayLocalSourceRect(globalRect: globalRect, displayFrame: displayFrame)
+
+        #expect(local == CGRect(x: 80, y: 60, width: 300, height: 200))
+    }
+
+    @Test("displayLocalSourceRect handles negative display origins")
+    func displayLocalSourceRectHandlesNegativeOrigins() {
+        let displayFrame = CGRect(x: -3008, y: 0, width: 3008, height: 1692)
+        let globalRect = CGRect(x: -2998, y: 10, width: 200, height: 150)
+
+        let local = ScreenCaptureService.displayLocalSourceRect(globalRect: globalRect, displayFrame: displayFrame)
+
+        #expect(local == CGRect(x: 10, y: 10, width: 200, height: 150))
+    }
 }
 
 // MARK: - Test Doubles


### PR DESCRIPTION
## Summary

Fixes #49 - iOS Simulator window capture returns black image.

## Problem

When capturing windows using `SCContentFilter(desktopIndependentWindow:)`, GPU-rendered windows like iOS Simulator return black images because they render through Metal/GPU compositing that bypasses the standard window backing store.

## Solution

Switch to `SCContentFilter(display:including:[window])` for all window captures. This approach:

- Works reliably for **all** windows including GPU-rendered ones
- The `including:` filter ensures only the target window is captured, even if occluded
- Simpler implementation than the previous approach (no fallback logic required)

## Changes

```swift
// Before (fails for Simulator):
let filter = SCContentFilter(desktopIndependentWindow: window)

// After (works for all windows):
let filter = SCContentFilter(display: display, including: [window])
config.sourceRect = window.frame
```

## Testing

Verified iOS Simulator windows now capture correctly.