### PR TITLE
Update permissions docs

### DIFF
--- a/docs/permissions.md
+++ b/docs/permissions.md
@@ -26,7 +26,7 @@ read_when:
 
 3. **Automation Check**
    ```bash
-   peekaboo permissions check
+   peekaboo permissions status
    peekaboo permissions request screen-recording
    peekaboo permissions request accessibility
    ```


### PR DESCRIPTION
This pull request updates the documentation for the permissions automation check command. The change clarifies the command used to check permissions status.

* Documentation update:
  * In `docs/permissions.md`, replaced the `peekaboo permissions check` command with `peekaboo permissions status` under the Automation Check section to better reflect the intended usage.
  
  Thanks for this @steipete!