### PR TITLE
feat: allow MAX_FILE_SIZE_BYTES override via environment variable

### DIFF
--- a/Core/PeekabooCore/Sources/PeekabooAutomation/Services/Audio/AudioInputService.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAutomation/Services/Audio/AudioInputService.swift
@@ -66,8 +66,15 @@ public final class AudioInputService {
     public private(set) var recordingDuration: TimeInterval = 0
 
     // Maximum file size: 25MB (OpenAI Whisper limit)
+    // Override via PEEKABOO_MAX_FILE_SIZE environment variable (in bytes)
     @ObservationIgnored
-    private let maxFileSize = 25 * 1024 * 1024
+    private let maxFileSize: Int = {
+        if let envValue = ProcessInfo.processInfo.environment["PEEKABOO_MAX_FILE_SIZE"],
+           let parsed = Int(envValue), parsed > 0 {
+            return parsed
+        }
+        return 25 * 1024 * 1024
+    }()
 
     // Supported audio formats for transcription
     @ObservationIgnored

--- a/README.md
+++ b/README.md
@@ -100,6 +100,13 @@ npx -y @steipete/peekaboo
 
 Set providers via `PEEKABOO_AI_PROVIDERS` or `peekaboo config add`.
 
+### Environment Variables
+
+| Variable | Description | Default |
+|---|---|---|
+| `PEEKABOO_AI_PROVIDERS` | Comma-separated list of AI providers | — |
+| `PEEKABOO_MAX_FILE_SIZE` | Maximum audio file size in bytes for transcription | `26214400` (25 MB) |
+
 ## Learn more
 - Command reference: [docs/commands/](docs/commands/)
 - Architecture: [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md)


### PR DESCRIPTION
## Summary

The maximum audio file size for transcription (25 MB, OpenAI Whisper limit) is currently hardcoded. This PR makes it configurable via the `PEEKABOO_MAX_FILE_SIZE` environment variable.

## Changes

- **AudioInputService.swift**: `maxFileSize` now reads from `PEEKABOO_MAX_FILE_SIZE` env var (value in bytes), falling back to the existing 25 MB default when unset or invalid.
- **README.md**: Added an Environment Variables section documenting `PEEKABOO_MAX_FILE_SIZE`.

## Usage

```bash
# Override to 50 MB
export PEEKABOO_MAX_FILE_SIZE=52428800
```

Closes #76