### PR TITLE
fix(agent-runtime): support MCP 0.11 resource content

### DIFF
--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/Agent/PeekabooAgentService+Tools.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/Agent/PeekabooAgentService+Tools.swift
@@ -580,16 +580,49 @@ func convertToolResponseToAgentToolResult(_ response: ToolResponse) -> AnyAgentT
         case let .image(data, mimeType, _):
             // For images, return a descriptive string
             return AnyAgentToolValue(string: "[Image: \(mimeType), size: \(data.count) bytes]")
-        case let .resource(uri, _, text):
-            // For resources, return the text content if available
-            return AnyAgentToolValue(string: text ?? "[Resource: \(uri)]")
+        case let .resource(resourceValue, _, thirdValue):
+            return convertResourceContentSummary(
+                resourceValue: resourceValue,
+                thirdValue: thirdValue)
         case let .audio(data, mimeType):
             return AnyAgentToolValue(string: "[Audio: \(mimeType), size: \(data.count) bytes]")
+        @unknown default:
+            return AnyAgentToolValue(string: String(describing: firstContent))
         }
     }
 
     // No content
     return AnyAgentToolValue(string: "Success")
+}
+
+func convertResourceContentSummary<ResourceValue, ThirdValue>(
+    resourceValue: ResourceValue,
+    thirdValue: ThirdValue
+) -> AnyAgentToolValue {
+    // MCP 0.10.x exposes `.resource(uri:mimeType:text:)` while 0.11.x exposes
+    // `.resource(resource: Resource.Content, annotations:..., _meta:...)`.
+    if let uri = resourceValue as? String {
+        let text = thirdValue as? String
+        return AnyAgentToolValue(string: text ?? "[Resource: \(uri)]")
+    }
+
+    let uri = extractStringProperty(named: "uri", from: resourceValue) ?? "[resource]"
+    let text = extractStringProperty(named: "text", from: resourceValue)
+    return AnyAgentToolValue(string: text ?? "[Resource: \(uri)]")
+}
+
+private func extractStringProperty<Value>(named name: String, from value: Value) -> String? {
+    for child in Mirror(reflecting: value).children {
+        guard child.label == name else { continue }
+        return unwrapOptionalValue(child.value) as? String
+    }
+    return nil
+}
+
+private func unwrapOptionalValue(_ value: Any) -> Any? {
+    let mirror = Mirror(reflecting: value)
+    guard mirror.displayStyle == .optional else { return value }
+    return mirror.children.first?.value
 }
 
 @preconcurrency

--- a/Core/PeekabooCore/Tests/PeekabooAgentRuntimeTests/ToolResponseResourceCompatibilityTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooAgentRuntimeTests/ToolResponseResourceCompatibilityTests.swift
@@ -1,0 +1,47 @@
+import Foundation
+@testable import PeekabooAgentRuntime
+import Testing
+
+@Suite("Tool response resource compatibility")
+struct ToolResponseResourceCompatibilityTests {
+    @Test("Legacy MCP resource format prefers text")
+    func legacyResourceFormatPrefersText() {
+        let result = convertResourceContentSummary(
+            resourceValue: "file:///tmp/legacy.txt",
+            thirdValue: "legacy text")
+
+        #expect(result.stringValue == "legacy text")
+    }
+
+    @Test("Legacy MCP resource format falls back to URI")
+    func legacyResourceFormatFallsBackToURI() {
+        let result = convertResourceContentSummary(
+            resourceValue: "file:///tmp/legacy.bin",
+            thirdValue: Optional<String>.none)
+
+        #expect(result.stringValue == "[Resource: file:///tmp/legacy.bin]")
+    }
+
+    @Test("MCP 0.11-style resource format prefers text")
+    func modernResourceFormatPrefersText() {
+        let result = convertResourceContentSummary(
+            resourceValue: MockResourceContent(uri: "file:///tmp/new.txt", text: "new text"),
+            thirdValue: Optional<String>.none)
+
+        #expect(result.stringValue == "new text")
+    }
+
+    @Test("MCP 0.11-style resource format falls back to URI")
+    func modernResourceFormatFallsBackToURI() {
+        let result = convertResourceContentSummary(
+            resourceValue: MockResourceContent(uri: "file:///tmp/new.bin", text: nil),
+            thirdValue: Optional<String>.none)
+
+        #expect(result.stringValue == "[Resource: file:///tmp/new.bin]")
+    }
+}
+
+private struct MockResourceContent {
+    let uri: String
+    let text: String?
+}


### PR DESCRIPTION
## Summary
- fix `convertToolResponseToAgentToolResult` so `.resource` content works with both MCP signatures:
  - MCP 0.10.x: `.resource(uri:mimeType:text:)`
  - MCP 0.11.x: `.resource(resource:annotations:_meta:)`
- add `@unknown default` handling for future enum expansion safety
- add focused runtime tests covering both legacy and modern resource shapes

## Why
`peekaboo` currently crashes/returns bad values when resource content comes from MCP 0.11-style payloads because the switch assumes the older tuple shape.

## Changes
- `Core/PeekabooCore/Sources/PeekabooAgentRuntime/Agent/PeekabooAgentService+Tools.swift`
  - normalize resource extraction through a compatibility helper
  - preserve old behavior for 0.10 payloads
  - add fallback extraction by reflection for 0.11 `Resource.Content` shape
- `Core/PeekabooCore/Tests/PeekabooAgentRuntimeTests/ToolResponseResourceCompatibilityTests.swift`
  - legacy format: text + URI fallback
  - modern format: text + URI fallback

## Validation
- `swift test --package-path Core/PeekabooCore --filter ToolResponseResourceCompatibilityTests --no-parallel` (passed)
- `swift test --package-path Core/PeekabooCore --filter PeekabooAgentRuntimeTests --no-parallel` (passed)
- `swift test --package-path Apps/CLI -Xswiftc -DPEEKABOO_SKIP_AUTOMATION --no-parallel --filter ToolResponseResourceCompatibilityTests` (blocked)
  - currently blocked by existing Tachikoma MCP 0.11 incompatibilities on `upstream/main` (`MCPToolProvider.swift`, `MCPToolAdapter.swift`, `TypeConversions.swift`), unrelated to this file-level fix.
