### PR TITLE
fix(mac): surface google and grok providers in settings

### DIFF
--- a/Apps/Mac/Peekaboo/Core/Settings.swift
+++ b/Apps/Mac/Peekaboo/Core/Settings.swift
@@ -22,6 +22,15 @@ final class PeekabooSettings {
     // API Configuration - Now synced with config.json
     var selectedProvider: String = "anthropic" {
         didSet {
+            let canonicalProvider = Self.canonicalProviderIdentifier(self.selectedProvider)
+            if canonicalProvider != self.selectedProvider {
+                let wasLoading = self.isLoading
+                self.isLoading = true
+                self.selectedProvider = canonicalProvider
+                self.isLoading = wasLoading
+                return
+            }
+
             self.save()
             self.updateConfigFile()
         }
@@ -38,6 +47,20 @@ final class PeekabooSettings {
         didSet {
             self.save()
             self.saveAPIKeyToCredentials("ANTHROPIC_API_KEY", self.anthropicAPIKey)
+        }
+    }
+
+    var grokAPIKey: String = "" {
+        didSet {
+            self.save()
+            self.saveAPIKeyToCredentials("X_AI_API_KEY", self.grokAPIKey)
+        }
+    }
+
+    var geminiAPIKey: String = "" {
+        didSet {
+            self.save()
+            self.saveAPIKeyToCredentials("GEMINI_API_KEY", self.geminiAPIKey)
         }
     }
 
@@ -337,13 +360,20 @@ final class PeekabooSettings {
     var hasValidAPIKey: Bool {
         switch self.selectedProvider {
         case "openai":
-            return !self.openAIAPIKey.isEmpty || self.isUsingOpenAIEnvironment
+            return !self.openAIAPIKey.isEmpty || self.isUsingOpenAIEnvironment ||
+                self.hasCredentialValue(forAny: ["OPENAI_ACCESS_TOKEN", "OPENAI_API_KEY"])
         case "anthropic":
-            return !self.anthropicAPIKey.isEmpty || self.isUsingAnthropicEnvironment
+            return !self.anthropicAPIKey.isEmpty || self.isUsingAnthropicEnvironment ||
+                self.hasCredentialValue(forAny: ["ANTHROPIC_ACCESS_TOKEN", "ANTHROPIC_API_KEY"])
+        case "grok":
+            return !self.grokAPIKey.isEmpty || self.isUsingGrokEnvironment ||
+                self.hasCredentialValue(forAny: ["X_AI_API_KEY", "XAI_API_KEY", "GROK_API_KEY"])
+        case "google":
+            return !self.geminiAPIKey.isEmpty || self.isUsingGeminiEnvironment ||
+                self.hasCredentialValue(forAny: ["GEMINI_API_KEY", "GOOGLE_API_KEY", "GOOGLE_APPLICATION_CREDENTIALS"])
         case "ollama":
             return true // Ollama doesn't require API key
         default:
-            // Check if it's a custom provider
             if let customProvider = customProviders[selectedProvider] {
                 return !customProvider.options.apiKey.isEmpty
             }
@@ -362,8 +392,20 @@ final class PeekabooSettings {
         self.anthropicAPIKey.isEmpty && ProcessInfo.processInfo.environment["ANTHROPIC_API_KEY"] != nil
     }
 
+    var isUsingGrokEnvironment: Bool {
+        self.grokAPIKey.isEmpty && ["X_AI_API_KEY", "XAI_API_KEY", "GROK_API_KEY"].contains {
+            ProcessInfo.processInfo.environment[$0]?.isEmpty == false
+        }
+    }
+
+    var isUsingGeminiEnvironment: Bool {
+        self.geminiAPIKey.isEmpty && ["GEMINI_API_KEY", "GOOGLE_API_KEY", "GOOGLE_APPLICATION_CREDENTIALS"].contains {
+            ProcessInfo.processInfo.environment[$0]?.isEmpty == false
+        }
+    }
+
     var allAvailableProviders: [String] {
-        let builtIn = ["openai", "anthropic", "ollama"]
+        let builtIn = ["openai", "anthropic", "grok", "google", "ollama"]
         let custom = Array(customProviders.keys)
         return builtIn + custom.sorted()
     }
@@ -392,9 +434,12 @@ extension PeekabooSettings {
     }
 
     private func loadProviderSettings() {
-        self.selectedProvider = self.userDefaults.string(forKey: self.namespaced("selectedProvider")) ?? "anthropic"
+        self.selectedProvider = Self.canonicalProviderIdentifier(
+            self.userDefaults.string(forKey: self.namespaced("selectedProvider")) ?? "anthropic")
         self.openAIAPIKey = self.userDefaults.string(forKey: self.namespaced("openAIAPIKey")) ?? ""
         self.anthropicAPIKey = self.userDefaults.string(forKey: self.namespaced("anthropicAPIKey")) ?? ""
+        self.grokAPIKey = self.userDefaults.string(forKey: self.namespaced("grokAPIKey")) ?? ""
+        self.geminiAPIKey = self.userDefaults.string(forKey: self.namespaced("geminiAPIKey")) ?? ""
         self.ollamaBaseURL = self.userDefaults.string(forKey: self.namespaced(
             "ollamaBaseURL")) ?? "http://localhost:11434"
 
@@ -477,6 +522,8 @@ extension PeekabooSettings {
         self.userDefaults.set(self.selectedProvider, forKey: "\(self.keyPrefix)selectedProvider")
         self.userDefaults.set(self.openAIAPIKey, forKey: "\(self.keyPrefix)openAIAPIKey")
         self.userDefaults.set(self.anthropicAPIKey, forKey: "\(self.keyPrefix)anthropicAPIKey")
+        self.userDefaults.set(self.grokAPIKey, forKey: "\(self.keyPrefix)grokAPIKey")
+        self.userDefaults.set(self.geminiAPIKey, forKey: "\(self.keyPrefix)geminiAPIKey")
         self.userDefaults.set(self.ollamaBaseURL, forKey: "\(self.keyPrefix)ollamaBaseURL")
         self.userDefaults.set(self.selectedModel, forKey: "\(self.keyPrefix)selectedModel")
         self.userDefaults.set(self.useCustomVisionModel, forKey: "\(self.keyPrefix)useCustomVisionModel")
@@ -541,7 +588,7 @@ extension PeekabooSettings {
         // This allows proper environment variable detection in the UI
 
         // Load provider and model from config
-        let selectedProvider = self.configManager.getSelectedProvider()
+        let selectedProvider = Self.canonicalProviderIdentifier(self.configManager.getSelectedProvider())
         if !selectedProvider.isEmpty {
             self.selectedProvider = selectedProvider
         }
@@ -597,6 +644,10 @@ extension PeekabooSettings {
                     "openai/\(self.selectedModel)"
                 case "anthropic":
                     "anthropic/\(self.selectedModel)"
+                case "grok":
+                    "grok/\(self.selectedModel)"
+                case "google":
+                    "google/\(self.selectedModel)"
                 case "ollama":
                     "ollama/\(self.selectedModel)"
                 default:
@@ -645,10 +696,13 @@ extension PeekabooSettings {
                     "openai/\(self.selectedModel)"
                 case "anthropic":
                     "anthropic/\(self.selectedModel)"
+                case "grok":
+                    "grok/\(self.selectedModel)"
+                case "google":
+                    "google/\(self.selectedModel)"
                 case "ollama":
                     "ollama/\(self.selectedModel)"
                 default:
-                    // Check if it's a custom provider
                     if self.customProviders[self.selectedProvider] != nil {
                         "\(self.selectedProvider)/\(self.selectedModel)"
                     } else {
@@ -666,7 +720,7 @@ extension PeekabooSettings {
                     // Add other providers that aren't the same type
                     for provider in providers.dropFirst() {
                         let providerType = provider.split(separator: "/").first.map(String.init) ?? ""
-                        if providerType != self.selectedProvider {
+                        if Self.canonicalProviderIdentifier(providerType) != self.selectedProvider {
                             newProviders.append(provider)
                         }
                     }
@@ -694,18 +748,23 @@ extension PeekabooSettings {
     @MainActor
     private func saveAPIKeyToCredentials(_ key: String, _ value: String) {
         do {
-            if value.isEmpty {
-                // Don't save empty keys
+            guard let provider = self.provider(forCredentialKey: key) else {
                 return
             }
-            try self.configManager.setCredential(key: key, value: value)
 
-            // Configure Tachikoma with the new API key
-            if key == "OPENAI_API_KEY" {
-                TachikomaConfiguration.current.setAPIKey(value, for: .openai)
-            } else if key == "ANTHROPIC_API_KEY" {
-                TachikomaConfiguration.current.setAPIKey(value, for: .anthropic)
+            if value.isEmpty {
+                try self.configManager.removeCredential(key: key)
+                if let environmentValue = provider.loadAPIKeyFromEnvironment() {
+                    TachikomaConfiguration.current.setAPIKey(environmentValue, for: provider)
+                } else {
+                    TachikomaConfiguration.current.removeAPIKey(for: provider)
+                }
+                self.services?.refreshAgentService()
+                return
             }
+
+            try self.configManager.setCredential(key: key, value: value)
+            TachikomaConfiguration.current.setAPIKey(value, for: provider)
 
             // Refresh the agent service to pick up new API keys
             self.services?.refreshAgentService()
@@ -777,14 +836,44 @@ extension PeekabooSettings {
         }
     }
 
+    private func hasCredentialValue(forAny keys: [String]) -> Bool {
+        keys.contains { key in
+            guard let value = self.configManager.credentialValue(for: key) else { return false }
+            return !value.isEmpty
+        }
+    }
+
     private func defaultModel(for provider: String) -> String {
         switch provider {
         case "openai":
             "gpt-5.1"
         case "anthropic":
             "claude-sonnet-4-5-20250929"
+        case "grok":
+            "grok-4"
+        case "google":
+            "gemini-3-flash"
         default:
             "llava:latest"
+        }
+    }
+
+    private func provider(forCredentialKey key: String) -> Provider? {
+        switch key {
+        case "OPENAI_API_KEY": .openai
+        case "ANTHROPIC_API_KEY": .anthropic
+        case "X_AI_API_KEY": .grok
+        case "GEMINI_API_KEY": .google
+        default: nil
+        }
+    }
+
+    private static func canonicalProviderIdentifier(_ provider: String) -> String {
+        switch provider.lowercased() {
+        case "gemini", "google":
+            "google"
+        default:
+            provider
         }
     }
 

--- a/Apps/Mac/Peekaboo/Features/Settings/APIKeyField.swift
+++ b/Apps/Mac/Peekaboo/Features/Settings/APIKeyField.swift
@@ -9,25 +9,41 @@ import SwiftUI
 struct ProviderInfo {
     let name: String
     let displayName: String
-    let environmentVariable: String
+    let environmentVariables: [String]
     let requiresAPIKey: Bool
+
+    var primaryEnvironmentVariable: String {
+        self.environmentVariables.first ?? ""
+    }
 
     static let openai = ProviderInfo(
         name: "openai",
         displayName: "OpenAI",
-        environmentVariable: "OPENAI_API_KEY",
+        environmentVariables: ["OPENAI_API_KEY"],
         requiresAPIKey: true)
 
     static let anthropic = ProviderInfo(
         name: "anthropic",
         displayName: "Anthropic",
-        environmentVariable: "ANTHROPIC_API_KEY",
+        environmentVariables: ["ANTHROPIC_API_KEY"],
+        requiresAPIKey: true)
+
+    static let grok = ProviderInfo(
+        name: "grok",
+        displayName: "Grok",
+        environmentVariables: ["X_AI_API_KEY", "XAI_API_KEY", "GROK_API_KEY"],
+        requiresAPIKey: true)
+
+    static let gemini = ProviderInfo(
+        name: "google",
+        displayName: "Gemini",
+        environmentVariables: ["GEMINI_API_KEY", "GOOGLE_API_KEY", "GOOGLE_APPLICATION_CREDENTIALS"],
         requiresAPIKey: true)
 
     static let ollama = ProviderInfo(
         name: "ollama",
         displayName: "Ollama",
-        environmentVariable: "OLLAMA_API_KEY",
+        environmentVariables: ["OLLAMA_API_KEY"],
         requiresAPIKey: false)
 }
 
@@ -35,7 +51,7 @@ struct ProviderInfo {
 struct APIKeyField: View {
     let provider: ProviderInfo
     @Binding var apiKey: String
-    @State private var hasEnvironmentKey: Bool = false
+    @State private var detectedEnvironmentVariable: String?
     @State private var showEnvironmentStatus: Bool = false
 
     var body: some View {
@@ -52,13 +68,12 @@ struct APIKeyField: View {
             }
 
             if self.hasEnvironmentKey, self.apiKey.isEmpty {
-                // Show environment variable status when no override is set
                 HStack {
                     Image(systemName: "checkmark.shield.fill")
                         .foregroundColor(.green)
 
                     VStack(alignment: .leading, spacing: 2) {
-                        Text("Using key from \(self.provider.environmentVariable)")
+                        Text("Using key from \(self.detectedEnvironmentVariable ?? self.provider.primaryEnvironmentVariable)")
                             .font(.callout)
                             .foregroundColor(.secondary)
 
@@ -71,7 +86,6 @@ struct APIKeyField: View {
                     Spacer()
 
                     Button("Override") {
-                        // Focus on the text field by setting a placeholder
                         self.showEnvironmentStatus = true
                     }
                     .buttonStyle(.link)
@@ -86,7 +100,6 @@ struct APIKeyField: View {
                         .textFieldStyle(.roundedBorder)
                 }
             } else {
-                // Normal text field for manual API key entry
                 SecureField(self.environmentPlaceholder, text: self.$apiKey)
                     .textFieldStyle(.roundedBorder)
 
@@ -95,7 +108,7 @@ struct APIKeyField: View {
                         Image(systemName: "exclamationmark.triangle.fill")
                             .foregroundColor(.orange)
 
-                        Text("Overriding environment variable \(self.provider.environmentVariable)")
+                        Text("Overriding environment variable \(self.detectedEnvironmentVariable ?? self.provider.primaryEnvironmentVariable)")
                             .font(.caption)
                             .foregroundColor(.orange)
 
@@ -118,9 +131,13 @@ struct APIKeyField: View {
         }
     }
 
+    private var hasEnvironmentKey: Bool {
+        self.detectedEnvironmentVariable != nil
+    }
+
     private var environmentPlaceholder: String {
         if self.hasEnvironmentKey {
-            "Override \(self.provider.environmentVariable) or leave empty"
+            "Override \(self.detectedEnvironmentVariable ?? self.provider.primaryEnvironmentVariable) or leave empty"
         } else if self.provider.requiresAPIKey {
             "Enter your \(self.provider.displayName) API key"
         } else {
@@ -130,6 +147,8 @@ struct APIKeyField: View {
 
     private func checkEnvironmentVariable() {
         let environment = ProcessInfo.processInfo.environment
-        self.hasEnvironmentKey = environment[self.provider.environmentVariable]?.isEmpty == false
+        self.detectedEnvironmentVariable = self.provider.environmentVariables.first { key in
+            environment[key]?.isEmpty == false
+        }
     }
 }

--- a/Apps/Mac/Peekaboo/Features/Settings/SettingsWindow.swift
+++ b/Apps/Mac/Peekaboo/Features/Settings/SettingsWindow.swift
@@ -166,6 +166,12 @@ struct AISettingsView: View {
                 ("claude-sonnet-4-5-20250929", "Claude Sonnet 4.5"),
                 ("claude-haiku-4.5", "Claude Haiku 4.5"),
             ]),
+            ("grok", [
+                ("grok-4", "Grok 4"),
+            ]),
+            ("google", [
+                ("gemini-3-flash", "Gemini 3 Flash"),
+            ]),
             ("ollama", self.ollamaModelOptions),
         ]
 
@@ -198,6 +204,8 @@ struct AISettingsView: View {
                 "tuned for long-running automation tasks.",
             "claude-haiku-4.5": "Claude Haiku 4.5 for ultra-low latency assistant tasks with " +
                 "the updated reasoning stack.",
+            "grok-4": "xAI's latest Grok model for reasoning-heavy automation and visual tasks.",
+            "gemini-3-flash": "Google Gemini Flash tuned for fast, lower-latency multimodal agent runs.",
             // Ollama models
             "llava:latest": "Open-source multimodal model that runs locally. Good for " +
                 "privacy-conscious users and offline usage.",
@@ -276,6 +284,22 @@ struct AISettingsView: View {
                     apiKey: Binding(
                         get: { self.settings.anthropicAPIKey },
                         set: { self.settings.anthropicAPIKey = $0 }))
+            }
+
+            Section("Grok Configuration") {
+                APIKeyField(
+                    provider: .grok,
+                    apiKey: Binding(
+                        get: { self.settings.grokAPIKey },
+                        set: { self.settings.grokAPIKey = $0 }))
+            }
+
+            Section("Gemini Configuration") {
+                APIKeyField(
+                    provider: .gemini,
+                    apiKey: Binding(
+                        get: { self.settings.geminiAPIKey },
+                        set: { self.settings.geminiAPIKey = $0 }))
             }
 
             Section("Ollama Configuration") {

--- a/Apps/Mac/Peekaboo/PeekabooApp.swift
+++ b/Apps/Mac/Peekaboo/PeekabooApp.swift
@@ -37,6 +37,12 @@ struct PeekabooApp: App {
         if !self.settings.anthropicAPIKey.isEmpty { TachikomaConfiguration.current.setAPIKey(
             self.settings.anthropicAPIKey,
             for: .anthropic) }
+        if !self.settings.grokAPIKey.isEmpty { TachikomaConfiguration.current.setAPIKey(
+            self.settings.grokAPIKey,
+            for: .grok) }
+        if !self.settings.geminiAPIKey.isEmpty { TachikomaConfiguration.current.setAPIKey(
+            self.settings.geminiAPIKey,
+            for: .google) }
         if self.settings.ollamaBaseURL != "http://localhost:11434" { TachikomaConfiguration.current.setBaseURL(
             self.settings.ollamaBaseURL,
             for: .ollama) }

--- a/Core/PeekabooCore/Sources/PeekabooAutomation/Configuration/ConfigurationManager.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAutomation/Configuration/ConfigurationManager.swift
@@ -449,13 +449,17 @@ public final class ConfigurationManager: @unchecked Sendable {
     /// Get Gemini API key with proper precedence
     public func getGeminiAPIKey() -> String? {
         // 1. Environment variable (highest priority)
-        if let envValue = self.environmentValue(for: "GEMINI_API_KEY") {
-            return envValue
+        for key in ["GEMINI_API_KEY", "GOOGLE_API_KEY", "GOOGLE_APPLICATION_CREDENTIALS"] {
+            if let envValue = self.environmentValue(for: key) {
+                return envValue
+            }
         }
 
         // 2. Credentials file
-        if let credValue = credentials["GEMINI_API_KEY"] {
-            return credValue
+        for key in ["GEMINI_API_KEY", "GOOGLE_API_KEY", "GOOGLE_APPLICATION_CREDENTIALS"] {
+            if let credValue = credentials[key] {
+                return credValue
+            }
         }
 
         return nil
@@ -538,6 +542,20 @@ public final class ConfigurationManager: @unchecked Sendable {
         try self.saveCredentials([key: value])
     }
 
+    public func removeCredential(key: String) throws {
+        self.loadCredentials()
+        self.credentials.removeValue(forKey: key)
+
+        if self.credentials.isEmpty {
+            if FileManager.default.fileExists(atPath: Self.credentialsPath) {
+                try FileManager.default.removeItem(atPath: Self.credentialsPath)
+            }
+            return
+        }
+
+        try self.saveCredentials([:])
+    }
+
     private func validOAuthAccessToken(prefix: String) -> String? {
         self.loadCredentials()
         guard let token = self.credentials["\(prefix)_ACCESS_TOKEN"] else { return nil }
@@ -558,9 +576,17 @@ public final class ConfigurationManager: @unchecked Sendable {
 
     /// Get selected AI provider
     public func getSelectedProvider() -> String {
-        // Extract provider from providers string (e.g., "anthropic/model" -> "anthropic")
-        let providers = self.getAIProviders()
-        return self.parseFirstProvider(providers) ?? "anthropic"
+        guard let providers = self.configuration?.aiProviders?.providers,
+              let provider = self.parseFirstProvider(providers) else {
+            return ""
+        }
+
+        switch provider.lowercased() {
+        case "gemini", "google":
+            return "google"
+        default:
+            return Provider.from(identifier: provider).identifier
+        }
     }
 
     private func parseFirstProvider(_ providers: String) -> String? {

--- a/Core/PeekabooCore/Tests/PeekabooTests/ConfigurationEnvironmentTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/ConfigurationEnvironmentTests.swift
@@ -1,3 +1,4 @@
+import Darwin
 import Foundation
 import Testing
 @testable import PeekabooAgentRuntime
@@ -32,4 +33,46 @@ struct ConfigurationManagerEnvironmentTests {
             defaultValue: "fallback")
         #expect(resolved == "env-choice")
     }
+
+    @Test("getSelectedProvider canonicalizes Google aliases from config")
+    func getSelectedProviderCanonicalizesGoogleAlias() throws {
+        try withIsolatedConfigurationEnvironment { configDir in
+            let configPath = configDir.appendingPathComponent("config.json")
+            let configJSON = """
+            {
+              "aiProviders": {
+                "providers": "gemini/gemini-3-flash,ollama/llava:latest"
+              }
+            }
+            """
+            try configJSON.write(to: configPath, atomically: true, encoding: .utf8)
+
+            self.manager.resetForTesting()
+            _ = self.manager.loadConfiguration()
+            #expect(self.manager.getSelectedProvider() == "google")
+        }
+    }
+}
+
+private func withIsolatedConfigurationEnvironment(_ body: (URL) throws -> Void) throws {
+    let fileManager = FileManager.default
+    let configDir = fileManager.temporaryDirectory
+        .appendingPathComponent("peekaboo-config-tests-\(UUID().uuidString)", isDirectory: true)
+    try fileManager.createDirectory(at: configDir, withIntermediateDirectories: true)
+
+    let previousConfigDir = getenv("PEEKABOO_CONFIG_DIR").map { String(cString: $0) }
+    setenv("PEEKABOO_CONFIG_DIR", configDir.path, 1)
+    ConfigurationManager.shared.resetForTesting()
+
+    defer {
+        if let previousConfigDir {
+            setenv("PEEKABOO_CONFIG_DIR", previousConfigDir, 1)
+        } else {
+            unsetenv("PEEKABOO_CONFIG_DIR")
+        }
+        ConfigurationManager.shared.resetForTesting()
+        try? fileManager.removeItem(at: configDir)
+    }
+
+    try body(configDir)
 }


### PR DESCRIPTION
Fixes #80.

Adds Grok and Gemini/Google to the macOS settings UI and canonicalizes the selected provider so the app reflects the same provider set the runtime already supports. It also wires the matching API key fields through app settings and config resolution so the selected provider and model stop drifting between UI and runtime.

Built `Apps/Mac` locally and ran `swift test --package-path Core/PeekabooCore --scratch-path /tmp/peekaboo-core-provider-tests --filter ConfigurationManagerEnvironmentTests` for the added canonicalization coverage.