### PR TITLE
feat(cli): support custom providers in agent command

### DIFF
--- a/Apps/CLI/Sources/PeekabooCLI/Commands/AI/AgentCommand.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/AI/AgentCommand.swift
@@ -920,7 +920,8 @@ extension AgentCommand {
         let hasOpenAI = configuration.getOpenAIAPIKey()?.isEmpty == false
         let hasAnthropic = configuration.getAnthropicAPIKey()?.isEmpty == false
         let hasGemini = configuration.getGeminiAPIKey()?.isEmpty == false
-        return hasOpenAI || hasAnthropic || hasGemini
+        let hasCustom = configuration.listCustomProviders().values.contains { $0.enabled }
+        return hasOpenAI || hasAnthropic || hasGemini || hasCustom
     }
 
     private func emitAgentUnavailableMessage() {
@@ -977,12 +978,43 @@ extension AgentCommand {
 
     func validatedModelSelection() throws -> LanguageModel? {
         guard let modelString = self.model else { return nil }
+
+        // Check for custom provider format: "providerId/modelName"
+        if let customModel = self.resolveCustomProviderModel(modelString) {
+            return customModel
+        }
+
         guard let parsed = self.parseModelString(modelString) else {
             throw PeekabooError.invalidInput(
                 "Unsupported model '\(modelString)'. Allowed values: \(Self.allowedModelList)"
             )
         }
         return parsed
+    }
+
+    /// Resolve a "providerId/modelName" string against configured custom providers.
+    @MainActor
+    private func resolveCustomProviderModel(_ modelString: String) -> LanguageModel? {
+        let parts = modelString.split(separator: "/", maxSplits: 1)
+        guard parts.count == 2 else { return nil }
+
+        let providerId = String(parts[0])
+        let modelName = String(parts[1])
+
+        let configuration = self.services.configuration
+        guard let provider = configuration.getCustomProvider(id: providerId),
+              provider.enabled
+        else {
+            return nil
+        }
+
+        let baseURL = provider.options.baseURL
+        switch provider.type {
+        case .openai:
+            return .openaiCompatible(modelId: modelName, baseURL: baseURL)
+        case .anthropic:
+            return .anthropicCompatible(modelId: modelName, baseURL: baseURL)
+        }
     }
 
     private static let supportedOpenAIInputs: Set<LanguageModel.OpenAI> = [
@@ -1031,6 +1063,8 @@ extension AgentCommand {
             return configuration.getAnthropicAPIKey()?.isEmpty == false
         case .google:
             return configuration.getGeminiAPIKey()?.isEmpty == false
+        case .openaiCompatible, .anthropicCompatible, .custom:
+            return true // Custom providers carry their own credentials in config
         default:
             return false
         }

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/Agent/PeekabooAgentService+Tools.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/Agent/PeekabooAgentService+Tools.swift
@@ -580,9 +580,11 @@ func convertToolResponseToAgentToolResult(_ response: ToolResponse) -> AnyAgentT
         case let .image(data, mimeType, _):
             // For images, return a descriptive string
             return AnyAgentToolValue(string: "[Image: \(mimeType), size: \(data.count) bytes]")
-        case let .resource(uri, _, text):
+        case let .resource(resource, _, _):
             // For resources, return the text content if available
-            return AnyAgentToolValue(string: text ?? "[Resource: \(uri)]")
+            return AnyAgentToolValue(string: resource.text ?? "[Resource: \(resource.uri)]")
+        case let .resourceLink(uri, name, _, _, _, _):
+            return AnyAgentToolValue(string: "[ResourceLink: \(name) (\(uri))]")
         case let .audio(data, mimeType):
             return AnyAgentToolValue(string: "[Audio: \(mimeType), size: \(data.count) bytes]")
         }

--- a/Core/PeekabooCore/Sources/PeekabooCore/Support/PeekabooServices.swift
+++ b/Core/PeekabooCore/Sources/PeekabooCore/Support/PeekabooServices.swift
@@ -404,8 +404,9 @@ public final class PeekabooServices {
         let hasAnthropic = self.configuration.getAnthropicAPIKey() != nil && !self.configuration.getAnthropicAPIKey()!
             .isEmpty
         let hasOllama = false
+        let hasCustomProvider = self.configuration.listCustomProviders().values.contains { $0.enabled }
 
-        if hasOpenAI || hasAnthropic || hasOllama {
+        if hasOpenAI || hasAnthropic || hasOllama || hasCustomProvider {
             let agentConfig = self.configuration.getConfiguration()
             let providers = self.configuration.getAIProviders()
             let environmentProviders = EnvironmentVariables.value(for: "PEEKABOO_AI_PROVIDERS")

--- a/docs/provider.md
+++ b/docs/provider.md
@@ -37,6 +37,7 @@ Peekaboo supports custom AI providers through configuration-based setup. This al
 - **Groq**: Ultra-fast inference with LPU technology
 - **Together AI**: High-performance open-source models
 - **Perplexity**: AI-powered search with citations
+- **AWS Bedrock**: Claude, Llama, Mistral, Titan via LiteLLM proxy (see `providers/bedrock.md`)
 - **Self-hosted**: Your own AI endpoints
 
 ## Configuration
@@ -202,6 +203,26 @@ peekaboo config add-provider \
   --api-key TOGETHER_API_KEY
 
 peekaboo config set-credential TOGETHER_API_KEY your-key-here
+```
+
+### AWS Bedrock (via LiteLLM)
+
+Uses [LiteLLM](https://github.com/BerriAI/litellm) as a local proxy to expose Bedrock models through an OpenAI-compatible API. See `providers/bedrock.md` for full setup instructions.
+
+```bash
+# Start LiteLLM proxy (must be running)
+litellm --config ~/.peekaboo/litellm_config.yaml --port 4000
+
+# Add provider
+peekaboo config add-provider \
+  --id bedrock \
+  --name "AWS Bedrock (via LiteLLM)" \
+  --type openai \
+  --url "http://localhost:4000/v1" \
+  --api-key "sk-1234"
+
+# Use it
+peekaboo agent "take a screenshot" --model bedrock/claude-3-5-sonnet
 ```
 
 ### Self-hosted

--- a/docs/providers/README.md
+++ b/docs/providers/README.md
@@ -11,6 +11,7 @@ read_when:
 - **Anthropic** — `anthropic.md`: plan/status, streaming/tool notes, and Claude CLI examples.
 - **Grok** — `grok.md`: Grok 4 implementation guide and checkpoints.
 - **Ollama** — `ollama.md`: local model configuration; `ollama-models.md` for model catalog notes.
+- **Bedrock** — `bedrock.md`: AWS Bedrock models via LiteLLM proxy (custom provider, no code changes needed).
 
 Use these with `docs/provider.md` for global provider configuration syntax and env var reference.
 
@@ -22,5 +23,6 @@ Use these with `docs/provider.md` for global provider configuration syntax and e
 | Anthropic | Yes | Yes (Sonnet/Opus vision) | Yes (SSE) | No | API key or OAuth (Claude Pro/Max) |
 | Grok | Yes | Limited | Yes | No | API key |
 | Ollama | Yes (via local server) | Model-dependent | Yes | **Yes** (local) | None (local daemon) |
+| Bedrock (LiteLLM) | Yes | Model-dependent | Yes | No | AWS credentials |
 
 See individual pages for model lists, quirks, and test coverage expectations.

--- a/docs/providers/bedrock.md
+++ b/docs/providers/bedrock.md
@@ -1,0 +1,189 @@
+---
+summary: 'Connect Peekaboo to AWS Bedrock models via LiteLLM proxy'
+read_when:
+  - 'configuring AWS Bedrock as an AI provider'
+  - 'using LiteLLM proxy with Peekaboo'
+---
+
+# AWS Bedrock via LiteLLM Proxy
+
+Peekaboo has no built-in AWS Bedrock provider, but supports OpenAI-compatible custom providers. [LiteLLM](https://github.com/BerriAI/litellm) acts as a proxy that exposes Bedrock models through an OpenAI-compatible API, letting Peekaboo use Claude, Llama, Mistral, Titan, and other models hosted on Bedrock.
+
+## Prerequisites
+
+- AWS CLI configured with a profile that has `bedrock:InvokeModel` permission (`~/.aws/credentials`)
+- Bedrock models enabled in your AWS account (request access via AWS Console > Bedrock > Model access)
+- Docker or pip available for running LiteLLM
+
+## Step 1: Install LiteLLM Proxy
+
+With pip:
+
+```bash
+pip install 'litellm[proxy]'
+```
+
+Or Docker:
+
+```bash
+docker pull ghcr.io/berriai/litellm:main-latest
+```
+
+## Step 2: Create LiteLLM Config
+
+Create `~/.peekaboo/litellm_config.yaml`:
+
+```yaml
+model_list:
+  # Claude models
+  - model_name: claude-3-5-sonnet
+    litellm_params:
+      model: bedrock/anthropic.claude-3-5-sonnet-20241022-v2:0
+      aws_profile_name: default    # your AWS profile
+      aws_region_name: us-east-1   # your Bedrock region
+
+  - model_name: claude-3-haiku
+    litellm_params:
+      model: bedrock/anthropic.claude-3-haiku-20240307-v1:0
+      aws_profile_name: default
+      aws_region_name: us-east-1
+
+  # Llama models
+  - model_name: llama3-70b
+    litellm_params:
+      model: bedrock/meta.llama3-70b-instruct-v1:0
+      aws_profile_name: default
+      aws_region_name: us-east-1
+
+  # Mistral models
+  - model_name: mistral-large
+    litellm_params:
+      model: bedrock/mistral.mistral-large-2407-v1:0
+      aws_profile_name: default
+      aws_region_name: us-east-1
+```
+
+Adjust `model_name` (your alias), `model` (Bedrock model ID), `aws_profile_name`, and `aws_region_name` to match your setup.
+
+## Step 3: Start LiteLLM Proxy
+
+With pip:
+
+```bash
+litellm --config ~/.peekaboo/litellm_config.yaml --port 4000
+```
+
+With Docker:
+
+```bash
+docker run -d \
+  -v ~/.aws:/root/.aws:ro \
+  -v ~/.peekaboo/litellm_config.yaml:/app/config.yaml:ro \
+  -p 4000:4000 \
+  ghcr.io/berriai/litellm:main-latest \
+  --config /app/config.yaml --port 4000
+```
+
+Verify the proxy is running:
+
+```bash
+curl http://localhost:4000/health
+```
+
+For persistent operation, consider running LiteLLM via `launchd` (macOS) or Docker with `--restart=always`.
+
+## Step 4: Configure Peekaboo Provider
+
+### Option A: CLI
+
+```bash
+peekaboo config add-provider \
+  --id bedrock \
+  --name "AWS Bedrock (via LiteLLM)" \
+  --type openai \
+  --url "http://localhost:4000/v1" \
+  --api-key "sk-1234"
+```
+
+> LiteLLM does not require a real API key by default, but Peekaboo requires a non-empty `apiKey`. Use a placeholder value, or the actual master key if you configured one in LiteLLM.
+
+### Option B: Edit config directly
+
+Add to `~/.peekaboo/config.json`:
+
+```json
+{
+  "customProviders": {
+    "bedrock": {
+      "name": "AWS Bedrock (via LiteLLM)",
+      "description": "Bedrock models proxied through LiteLLM",
+      "type": "openai",
+      "options": {
+        "baseURL": "http://localhost:4000/v1",
+        "apiKey": "sk-1234"
+      },
+      "models": {
+        "claude-3-5-sonnet": {
+          "name": "Claude 3.5 Sonnet (Bedrock)",
+          "maxTokens": 8192,
+          "supportsTools": true,
+          "supportsVision": true
+        },
+        "claude-3-haiku": {
+          "name": "Claude 3 Haiku (Bedrock)",
+          "maxTokens": 4096,
+          "supportsTools": true,
+          "supportsVision": true
+        },
+        "llama3-70b": {
+          "name": "Llama 3 70B (Bedrock)",
+          "maxTokens": 4096,
+          "supportsTools": true,
+          "supportsVision": false
+        },
+        "mistral-large": {
+          "name": "Mistral Large (Bedrock)",
+          "maxTokens": 8192,
+          "supportsTools": true,
+          "supportsVision": false
+        }
+      },
+      "enabled": true
+    }
+  }
+}
+```
+
+## Step 5: Verify
+
+```bash
+# Check LiteLLM exposes models
+curl http://localhost:4000/v1/models
+
+# Test Peekaboo provider connection
+peekaboo config test-provider bedrock
+
+# Discover available models
+peekaboo config models-provider bedrock --refresh
+
+# Run an agent task
+peekaboo agent "take a screenshot" --model bedrock/claude-3-5-sonnet
+```
+
+## Notes
+
+- **LiteLLM must stay running** for the provider to work. Use Docker `--restart=always` or a `launchd` plist for persistence.
+- **`model_name`** in `litellm_config.yaml` is your custom alias; the `model` field is the actual Bedrock model ID.
+- **Region matters**: Bedrock model availability varies by AWS region. Check the [Bedrock model access page](https://docs.aws.amazon.com/bedrock/latest/userguide/model-access.html).
+- **Costs**: Bedrock usage is billed by AWS per token/request. LiteLLM itself is free.
+- **Security**: The LiteLLM proxy listens on localhost by default. If you expose it on a network, configure a `master_key` in the LiteLLM config and use that as the `apiKey` in Peekaboo.
+
+## Troubleshooting
+
+| Symptom | Fix |
+| --- | --- |
+| `Connection refused` on port 4000 | LiteLLM not running — start it |
+| `AccessDeniedException` from Bedrock | Check AWS profile has `bedrock:InvokeModel`; verify model access is enabled in console |
+| `Model not found` in LiteLLM | Verify `model` field matches an actual Bedrock model ID for your region |
+| Peekaboo says provider unreachable | Confirm `baseURL` ends with `/v1` and proxy health check passes |
+| Slow first request | Bedrock cold-starts models on first invocation; subsequent calls are faster |


### PR DESCRIPTION
## Summary

- Agent command now works with custom providers (e.g. AWS Bedrock via LiteLLM proxy)
- `PeekabooServices.refreshAgentService()` creates agent service when only custom providers are configured
- `AgentCommand.validatedModelSelection()` resolves `providerId/model` format against custom provider config
- `hasConfiguredAIProvider()` and `hasCredentials()` recognize enabled custom providers
- Fixes MCP SDK 0.11 `Tool.Content.resource` API breakage (prerequisite for build)
- Adds `docs/providers/bedrock.md` with full LiteLLM proxy setup guide

## Usage

```bash
# Configure LiteLLM proxy for Bedrock
peekaboo config add-provider bedrock --type openai \
  --name "AWS Bedrock" --base-url "http://localhost:4000/v1" --api-key "sk-1234"

# Use Bedrock models
peekaboo agent "take a screenshot" --model bedrock/claude-sonnet-4-6
```

## Test plan

- [x] `curl http://localhost:4000/health` — LiteLLM proxy healthy (4 models)
- [x] `peekaboo config test-provider bedrock` — connection OK
- [x] `peekaboo config models-provider bedrock --discover` — 4 models found
- [x] `peekaboo agent --model bedrock/claude-sonnet-4-6` — chat works
- [x] `peekaboo agent --model bedrock/claude-opus-4-6` — chat works
- [x] Tool calling (screenshot + vision) via Bedrock — works
- [x] `swift build --package-path Apps/CLI` — Build complete

🤖 Generated with [Claude Code](https://claude.com/claude-code)