### PR TITLE
fix: verify target app is frontmost before coordinate click

### DIFF
--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Interaction/ClickCommand.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Interaction/ClickCommand.swift
@@ -5,6 +5,128 @@ import Foundation
 import PeekabooCore
 import PeekabooFoundation
 
+struct FrontmostApplicationIdentity: Equatable, Sendable {
+    let name: String?
+    let bundleIdentifier: String?
+    let processIdentifier: Int32?
+
+    init(
+        name: String? = nil,
+        bundleIdentifier: String? = nil,
+        processIdentifier: Int32? = nil
+    ) {
+        self.name = name?.nilIfEmpty
+        self.bundleIdentifier = bundleIdentifier?.nilIfEmpty
+        self.processIdentifier = processIdentifier
+    }
+
+    init(application: NSRunningApplication?) {
+        self.init(
+            name: application?.localizedName,
+            bundleIdentifier: application?.bundleIdentifier,
+            processIdentifier: application?.processIdentifier
+        )
+    }
+
+    var displayDescription: String {
+        var components: [String] = []
+        if let name = self.name {
+            components.append("'\(name)'")
+        }
+        if let bundleIdentifier = self.bundleIdentifier {
+            components.append(bundleIdentifier)
+        }
+        if let processIdentifier = self.processIdentifier {
+            components.append("PID \(processIdentifier)")
+        }
+        if components.isEmpty {
+            return "unknown application"
+        }
+        return components.joined(separator: " ")
+    }
+}
+
+enum CoordinateClickFocusVerifier {
+    static func mismatchMessage(
+        targetApp: String?,
+        targetPID: Int32?,
+        frontmost: FrontmostApplicationIdentity
+    ) -> String? {
+        guard targetApp != nil || targetPID != nil else {
+            return nil
+        }
+
+        if let targetPID, frontmost.processIdentifier == targetPID {
+            return nil
+        }
+
+        if let targetApp, self.matches(targetApp: targetApp, frontmost: frontmost) {
+            return nil
+        }
+
+        let targetDescription = self.targetDescription(targetApp: targetApp, targetPID: targetPID)
+        let frontmostDescription = frontmost.displayDescription
+
+        return """
+        \(targetDescription) is not frontmost after the focus attempt. Currently frontmost: \(frontmostDescription).
+        The coordinate click would land on the frontmost window instead.
+
+        Hints:
+          - Ensure no other window is overlapping the target
+          - Try clicking by element ID (--on) instead of coordinates
+          - Close or minimize interfering windows first
+        """
+    }
+
+    static func targetDescription(targetApp: String?, targetPID: Int32?) -> String {
+        if let targetApp {
+            return "Target app '\(targetApp)'"
+        }
+        if let targetPID {
+            return "Target PID \(targetPID)"
+        }
+        return "Target application"
+    }
+
+    private static func matches(targetApp: String, frontmost: FrontmostApplicationIdentity) -> Bool {
+        let trimmedTarget = targetApp.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedTarget.isEmpty else {
+            return false
+        }
+
+        if let pid = self.parsePID(trimmedTarget), frontmost.processIdentifier == pid {
+            return true
+        }
+
+        if let bundleIdentifier = frontmost.bundleIdentifier,
+           bundleIdentifier.caseInsensitiveCompare(trimmedTarget) == .orderedSame
+        {
+            return true
+        }
+
+        if let name = frontmost.name,
+           name.caseInsensitiveCompare(trimmedTarget) == .orderedSame
+        {
+            return true
+        }
+
+        return false
+    }
+
+    private static func parsePID(_ identifier: String) -> Int32? {
+        guard identifier.hasPrefix("PID:") else {
+            return nil
+        }
+        return Int32(identifier.dropFirst(4))
+    }
+}
+
+private extension String {
+    var nilIfEmpty: String? {
+        self.isEmpty ? nil : self
+    }
+}
+
 /// Click on UI elements identified in the current snapshot using intelligent element finding and smart waiting.
 @available(macOS 14.0, *)
 @MainActor
@@ -315,35 +437,25 @@ struct ClickCommand: ErrorHandlingCommand, OutputFormattable {
     /// the target window to the front (common with Electron apps like Claude Desktop, VS Code),
     /// the click will land on whatever window happens to be at that screen position.
     ///
-    /// This method checks that the frontmost app matches the `--app` target and logs a warning
-    /// if it doesn't, giving the agent actionable feedback instead of silently clicking the wrong app.
+    /// This method checks that the frontmost app matches any explicit `--app` / `--pid` target
+    /// and throws if it does not, giving actionable feedback instead of silently clicking the wrong app.
     private func verifyFocusForCoordinateClick() throws {
-        // Only verify when --app is explicitly specified
-        guard let targetApp = self.target.app else { return }
-
-        let frontmost = NSWorkspace.shared.frontmostApplication
-        let frontmostName = frontmost?.localizedName ?? ""
-        let frontmostBundle = frontmost?.bundleIdentifier ?? ""
-
-        let nameMatches = frontmostName.localizedCaseInsensitiveContains(targetApp)
-        let bundleMatches = frontmostBundle.localizedCaseInsensitiveContains(targetApp)
-
-        if !nameMatches && !bundleMatches {
-            self.logger.warning(
-                "Focus mismatch: target app '\(targetApp)' is not frontmost. " +
-                "Frontmost is '\(frontmostName)' (\(frontmostBundle)). " +
-                "Coordinate click may land on the wrong window."
+        let frontmost = FrontmostApplicationIdentity(application: NSWorkspace.shared.frontmostApplication)
+        if let message = CoordinateClickFocusVerifier.mismatchMessage(
+            targetApp: self.target.app,
+            targetPID: self.target.pid,
+            frontmost: frontmost
+        ) {
+            let targetDescription = CoordinateClickFocusVerifier.targetDescription(
+                targetApp: self.target.app,
+                targetPID: self.target.pid
             )
-            // Throw so the agent gets clear feedback instead of silently clicking wrong app
-            throw PeekabooError.elementNotFound(
-                "Target app '\(targetApp)' is not frontmost after focus attempt. " +
-                "Currently frontmost: '\(frontmostName)'. " +
-                "The coordinate click would land on '\(frontmostName)' instead.\n\n" +
-                "💡 Hints:\n" +
-                "  • Ensure no other window is overlapping the target\n" +
-                "  • Try clicking by element ID (--on) instead of coordinates\n" +
-                "  • Close or minimize interfering windows first"
+            self.logger.warn(
+                "Coordinate click focus mismatch for " +
+                    "\(targetDescription). " +
+                    "Frontmost is \(frontmost.displayDescription)."
             )
+            throw PeekabooError.clickFailed(message)
         }
     }
 

--- a/Apps/CLI/Tests/CoreCLITests/ClickCommandFocusVerificationTests.swift
+++ b/Apps/CLI/Tests/CoreCLITests/ClickCommandFocusVerificationTests.swift
@@ -1,0 +1,100 @@
+import Testing
+@testable import PeekabooCLI
+
+@Suite("ClickCommand focus verification")
+struct ClickCommandFocusVerificationTests {
+    @Test("Exact app name match passes")
+    func exactAppNameMatchPasses() {
+        let frontmost = FrontmostApplicationIdentity(
+            name: "Claude",
+            bundleIdentifier: "com.anthropic.claudedesktop",
+            processIdentifier: 41
+        )
+
+        let message = CoordinateClickFocusVerifier.mismatchMessage(
+            targetApp: "Claude",
+            targetPID: nil,
+            frontmost: frontmost
+        )
+
+        #expect(message == nil)
+    }
+
+    @Test("Exact bundle identifier match passes")
+    func exactBundleIdentifierMatchPasses() {
+        let frontmost = FrontmostApplicationIdentity(
+            name: "Claude",
+            bundleIdentifier: "com.anthropic.claudedesktop",
+            processIdentifier: 41
+        )
+
+        let message = CoordinateClickFocusVerifier.mismatchMessage(
+            targetApp: "com.anthropic.claudedesktop",
+            targetPID: nil,
+            frontmost: frontmost
+        )
+
+        #expect(message == nil)
+    }
+
+    @Test("PID targets pass when the frontmost PID matches")
+    func pidTargetPasses() {
+        let frontmost = FrontmostApplicationIdentity(
+            name: "Claude",
+            bundleIdentifier: "com.anthropic.claudedesktop",
+            processIdentifier: 41
+        )
+
+        let directPIDMessage = CoordinateClickFocusVerifier.mismatchMessage(
+            targetApp: nil,
+            targetPID: 41,
+            frontmost: frontmost
+        )
+        #expect(directPIDMessage == nil)
+
+        let pidStringMessage = CoordinateClickFocusVerifier.mismatchMessage(
+            targetApp: "PID:41",
+            targetPID: nil,
+            frontmost: frontmost
+        )
+        #expect(pidStringMessage == nil)
+    }
+
+    @Test("Partial app-name matches still fail")
+    func partialAppNameMatchesStillFail() {
+        let frontmost = FrontmostApplicationIdentity(
+            name: "Xcode",
+            bundleIdentifier: "com.apple.dt.Xcode",
+            processIdentifier: 99
+        )
+
+        let message = CoordinateClickFocusVerifier.mismatchMessage(
+            targetApp: "Code",
+            targetPID: nil,
+            frontmost: frontmost
+        )
+
+        #expect(message != nil)
+        #expect(message?.contains("'Xcode'") == true)
+    }
+
+    @Test("Mismatch includes the frontmost application details")
+    func mismatchIncludesFrontmostDetails() {
+        let frontmost = FrontmostApplicationIdentity(
+            name: "Google Chrome",
+            bundleIdentifier: "com.google.Chrome",
+            processIdentifier: 512
+        )
+
+        let message = CoordinateClickFocusVerifier.mismatchMessage(
+            targetApp: "Claude",
+            targetPID: nil,
+            frontmost: frontmost
+        )
+
+        #expect(message?.contains("Target app 'Claude'") == true)
+        #expect(message?.contains("'Google Chrome'") == true)
+        #expect(message?.contains("com.google.Chrome") == true)
+        #expect(message?.contains("PID 512") == true)
+    }
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 - CLI agent runtime now prefers local execution by default; thanks @0xble for [#83](https://github.com/steipete/Peekaboo/pull/83).
 - Screen recording permission checks are more reliable, and MCP Swift SDK compatibility is restored; thanks @romanr for [#94](https://github.com/steipete/Peekaboo/pull/94).
+- Coordinate clicks now fail fast when the requested target app is not actually frontmost after focus; thanks @shawny011717 for [#91](https://github.com/steipete/Peekaboo/pull/91).
 
 ## [3.0.0-beta4] (unreleased)
 


### PR DESCRIPTION
## Summary

Fixes #90 — `peekaboo click --app "AppName" --coords x,y` silently clicks the wrong app when the target window isn't actually frontmost after the focus attempt.

### The Problem

`InputDriver.click(at:)` sends a `CGEvent` at screen-absolute coordinates. The existing focus chain (`focusApplicationIfNeeded` → `ensureFocused` → `FocusManagementService.focusWindow`) attempts to raise the target window, but **never verifies success before dispatching the click**. 

When the raise fails (common with Electron apps like Claude Desktop, VS Code, Slack), the click silently lands on whatever window is at that screen position — typically Chrome.

### The Fix

Added `verifyFocusForCoordinateClick()` in `ClickCommand.swift` that runs **after** focus and **before** the click dispatch:

1. Checks if `--app` was explicitly specified
2. Reads `NSWorkspace.shared.frontmostApplication` 
3. Compares against the target app name and bundle ID
4. If mismatch → throws a clear error with actionable hints instead of clicking the wrong app

### What it changes

- **Before**: Click silently lands on wrong app, output shows `🎯 App: Google Chrome` when you targeted Claude
- **After**: Clear error: `"Target app 'Claude' is not frontmost after focus attempt. Currently frontmost: 'Google Chrome'."` with hints to use element ID clicking or close interfering windows

### Scope

- Only affects **coordinate-based clicks** (`--coords`) where `--app` is explicitly specified
- Element-based clicks (`--on`, `--query`) are unaffected (they resolve coordinates from snapshots which are already scoped to the correct app)
- No behavioral change when focus succeeds (the common case)

### Testing

Discovered through real-world agent automation: an OpenClaw AI agent trying to automate Claude Desktop's Cowork feature via peekaboo. The agent tried 7+ click variations, all hitting Chrome instead of Claude. With this fix, the agent would get immediate, actionable feedback on the first attempt.