### PR TITLE
feat(mcp): add structured_output parameter to see and list tools

### DIFF
--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/ListTool.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/ListTool.swift
@@ -51,6 +51,14 @@ public struct ListTool: MCPTool {
                     Extra data for each window (application_windows only).
                     Choose any combination of `ids`, `bounds`, or `off_screen`.
                     """),
+                "structured_output": SchemaBuilder.boolean(
+                    description: """
+                    Optional. When true, returns the full structured JSON output instead of
+                    human-readable text. Includes all fields (bundle IDs, paths, bounds,
+                    active/hidden state, metadata, timing) that are otherwise summarized.
+                    Useful for programmatic consumers that need machine-parseable data.
+                    """,
+                    default: false),
             ],
             required: [])
     }
@@ -70,7 +78,7 @@ public struct ListTool: MCPTool {
 
         switch request.itemType {
         case .runningApplications:
-            return try await self.listRunningApplications()
+            return try await self.listRunningApplications(structured: request.structuredOutput)
         case .applicationWindows:
             return try await self.listApplicationWindows(request: request)
         case .serverStatus:
@@ -78,9 +86,15 @@ public struct ListTool: MCPTool {
         }
     }
 
-    private func listRunningApplications() async throws -> ToolResponse {
+    private func listRunningApplications(structured: Bool = false) async throws -> ToolResponse {
         do {
             let output = try await self.context.applications.listApplications()
+
+            if structured {
+                let json = try output.toJSON()
+                return ToolResponse.text(json)
+            }
+
             let apps = output.data.applications
             var lines: [String] = []
             let countSuffix = apps.count == 1 ? "" : "s"
@@ -125,6 +139,12 @@ public struct ListTool: MCPTool {
         do {
             let identifier = request.app ?? ""
             let output = try await self.context.applications.listWindows(for: identifier, timeout: nil)
+
+            if request.structuredOutput {
+                let json = try output.toJSON()
+                return ToolResponse.text(json)
+            }
+
             let formatter = WindowListFormatter(
                 appInfo: output.data.targetApplication,
                 identifier: identifier,
@@ -239,10 +259,12 @@ private struct ListRequest {
     let itemType: ListItemType
     let app: String?
     let windowDetails: Set<WindowDetail>
+    let structuredOutput: Bool
 
     init(arguments: ToolArguments) throws {
         let app = arguments.getString("app")
         self.app = app
+        self.structuredOutput = arguments.getBool("structured_output") ?? false
 
         if let typeString = arguments.getString("item_type"),
            let type = ListItemType(rawValue: typeString)

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/SeeTool.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/SeeTool.swift
@@ -176,6 +176,14 @@ public struct SeeTool: MCPTool {
                     Optional. Generate an annotated screenshot with interaction markers and IDs.
                     """,
                     default: false),
+                "structured_output": SchemaBuilder.boolean(
+                    description: """
+                    Optional. When true, returns the full structured JSON output instead of
+                    human-readable text. Includes element details (IDs, roles, labels, frames,
+                    actionable state), snapshot metadata, and capture timing. Useful for
+                    programmatic consumers that need machine-parseable element data.
+                    """,
+                    default: false),
             ],
             required: [])
     }
@@ -210,7 +218,8 @@ public struct SeeTool: MCPTool {
                     screenshotPath: screenshotPath,
                     annotatedPath: annotatedPath,
                     annotate: request.annotate),
-                target: target)
+                target: target,
+                structured: request.structuredOutput)
         } catch {
             self.logger.error("See tool execution failed: \(error.localizedDescription)")
             return ToolResponse.error("Failed to capture UI state: \(error.localizedDescription)")
@@ -397,8 +406,20 @@ public struct SeeTool: MCPTool {
         snapshot: UISnapshot,
         elements: [UIElement],
         output: ScreenshotOutput,
-        target: CaptureTarget) async throws -> ToolResponse
+        target: CaptureTarget,
+        structured: Bool = false) async throws -> ToolResponse
     {
+        if structured {
+            let structuredData = await self.buildStructuredOutput(
+                snapshot: snapshot, elements: elements, output: output)
+            var content: [MCP.Tool.Content] = [.text(structuredData)]
+            if output.annotate, let annotatedPath = output.annotatedPath {
+                let imageData = try Data(contentsOf: URL(fileURLWithPath: annotatedPath))
+                content.append(.image(data: imageData.base64EncodedString(), mimeType: "image/png", metadata: nil))
+            }
+            return ToolResponse(content: content)
+        }
+
         let finalScreenshot = output.annotatedPath ?? output.screenshotPath
         let summaryText = await buildSummary(
             snapshot: snapshot,
@@ -423,6 +444,73 @@ public struct SeeTool: MCPTool {
 
         let mergedMeta = ToolEventSummary.merge(summary: summary, into: baseMeta)
         return ToolResponse(content: content, meta: mergedMeta)
+    }
+
+    @MainActor
+    private func buildStructuredOutput(
+        snapshot: UISnapshot,
+        elements: [UIElement],
+        output: ScreenshotOutput) async -> String
+    {
+        struct StructuredElement: Codable {
+            let id: String
+            let role: String
+            let title: String?
+            let label: String?
+            let value: String?
+            let frame: FrameData
+            let isActionable: Bool
+
+            struct FrameData: Codable {
+                let x: Double
+                let y: Double
+                let width: Double
+                let height: Double
+            }
+        }
+
+        struct StructuredSeeOutput: Codable {
+            let snapshotId: String
+            let applicationName: String?
+            let windowTitle: String?
+            let screenshotPath: String
+            let elementCount: Int
+            let actionableCount: Int
+            let elements: [StructuredElement]
+        }
+
+        let structuredElements = elements.map { el in
+            StructuredElement(
+                id: el.id,
+                role: el.role,
+                title: el.title,
+                label: el.label,
+                value: el.value,
+                frame: StructuredElement.FrameData(
+                    x: el.frame.origin.x,
+                    y: el.frame.origin.y,
+                    width: el.frame.width,
+                    height: el.frame.height),
+                isActionable: el.isActionable)
+        }
+
+        let result = StructuredSeeOutput(
+            snapshotId: snapshot.id,
+            applicationName: snapshot.applicationName,
+            windowTitle: snapshot.windowTitle,
+            screenshotPath: output.screenshotPath,
+            elementCount: elements.count,
+            actionableCount: elements.count(where: { $0.isActionable }),
+            elements: structuredElements)
+
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        guard let data = try? encoder.encode(result),
+              let json = String(data: data, encoding: .utf8)
+        else {
+            return "{\"error\": \"Failed to encode structured output\"}"
+        }
+        return json
     }
 
     private func makeMetadata(snapshot: UISnapshot, elements: [UIElement]) -> Value {
@@ -503,12 +591,14 @@ private struct SeeRequest {
     let path: String?
     let snapshotId: String?
     let annotate: Bool
+    let structuredOutput: Bool
 
     init(arguments: ToolArguments) {
         self.appTarget = arguments.getString("app_target")
         self.path = arguments.getString("path")
         self.snapshotId = arguments.getString("snapshot")
         self.annotate = arguments.getBool("annotate") ?? false
+        self.structuredOutput = arguments.getBool("structured_output") ?? false
     }
 }
 


### PR DESCRIPTION
## Summary

When `structured_output=true`, MCP tools return full structured JSON instead of human-readable text summaries. This exposes data that was previously available only through the CLI `--json-output` flag.

## Motivation

Programmatic MCP consumers (AI agents, automation scripts) benefit from machine-parseable data. The current text format requires regex/string parsing to extract element IDs, coordinates, or application metadata.

For example, the `list` tool currently returns:
```
[ok] Found 26 running applications:
1. Finder (com.apple.finder) - PID: 1113 - Windows: 0
```

With `structured_output: true`, it returns the same `UnifiedToolOutput.toJSON()` used by the CLI:
```json
{
  "data": {
    "applications": [{
      "bundleIdentifier": "com.apple.finder",
      "bundlePath": "/System/Library/CoreServices/Finder.app",
      "isActive": false,
      "isHidden": false,
      "name": "Finder",
      "processIdentifier": 1113,
      "windowCount": 0
    }]
  },
  "metadata": { "duration": 0, "hints": [], "warnings": [] },
  "summary": { "brief": "Found 26 apps", "status": "success" }
}
```

Similarly, `see` with `structured_output: true` returns element details as a JSON array with IDs, roles, labels, frame bounds, and actionable state — instead of formatted text lines.

## Changes

- **ListTool**: Added `structured_output` boolean parameter. When true, `listRunningApplications()` and `listApplicationWindows()` return `UnifiedToolOutput.toJSON()` directly.
- **SeeTool**: Added `structured_output` boolean parameter. When true, returns a structured JSON object with snapshot ID, app/window info, and a full element array with frame coordinates.

Default behavior (omitted or false) is completely unchanged.

## Note on _meta passthrough

We also noticed that `PeekabooMCPServer.swift` drops `response.meta` when constructing `CallTool.Result` — the tools already build metadata (snapshot_id, element_count, etc.) but it's silently discarded. This appears to be because `CallTool.Result` in swift-sdk v0.10.2 doesn't have a `_meta` field yet. Once the Swift MCP SDK adds `_meta` support, the server could pass this through as well.