### PR TITLE
support custom ai providers in image analyze

### DIFF
--- a/Apps/CLI/Sources/PeekabooCLI/CLI/PeekabooEntryPoint.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/CLI/PeekabooEntryPoint.swift
@@ -3,6 +3,7 @@ import CoreGraphics
 import Darwin
 import Foundation
 import PeekabooCore
+import Tachikoma
 
 /// Shared entry point used by the executable target.
 @MainActor
@@ -20,6 +21,9 @@ func executePeekabooCLI(arguments: [String]) async -> Int32 {
 
     // Initialize CoreGraphics silently to prevent CGS_REQUIRE_INIT error
     _ = CGMainDisplayID()
+
+    // Keep Tachikoma's profile dir aligned with Peekaboo's config dir.
+    TachikomaConfiguration.profileDirectoryName = ".peekaboo"
 
     // Load configuration at startup
     _ = ConfigurationManager.shared.loadConfiguration()

--- a/Core/PeekabooCore/Sources/PeekabooAutomation/Services/AI/PeekabooAIService.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAutomation/Services/AI/PeekabooAIService.swift
@@ -164,7 +164,26 @@ public final class PeekabooAIService {
             case "lmstudio":
                 return .lmstudio(.custom(modelString))
             default:
-                return nil
+                CustomProviderRegistry.shared.loadFromProfile()
+                guard let custom = CustomProviderRegistry.shared.get(provider) else {
+                    return nil
+                }
+                let modelId = custom.models[modelString] ?? modelString
+                switch custom.kind {
+                case .openai:
+                    return .custom(provider: OpenAICompatibleProvider(
+                        modelId: modelId,
+                        baseURL: custom.baseURL,
+                        apiKey: custom.apiKey,
+                        headers: custom.headers
+                    ))
+                case .anthropic:
+                    return .custom(provider: AnthropicCompatibleProvider(
+                        modelId: modelId,
+                        baseURL: custom.baseURL,
+                        apiKey: custom.apiKey
+                    ))
+                }
             }
         }
 

--- a/Core/PeekabooCore/Tests/PeekabooCoreTests/Services/AI/PeekabooAIServiceTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooCoreTests/Services/AI/PeekabooAIServiceTests.swift
@@ -173,6 +173,68 @@ struct PeekabooAIServiceTests {
         #expect(service.resolvedDefaultModel == .anthropic(.sonnet45))
     }
 
+    @Test("Resolves custom OpenAI-compatible providers from config")
+    @MainActor
+    func resolvesCustomOpenAICompatibleProvider() async throws {
+        let tempHome = FileManager.default.temporaryDirectory
+            .appendingPathComponent("peekaboo-home-\(UUID().uuidString)", isDirectory: true)
+        let configDir = tempHome.appendingPathComponent(".peekaboo", isDirectory: true)
+        try FileManager.default.createDirectory(at: configDir, withIntermediateDirectories: true)
+        let configPath = configDir.appendingPathComponent("config.json")
+        try """
+        {
+          "aiProviders": { "providers": "local-proxy/gpt-5.4-mini" },
+          "customProviders": {
+            "local-proxy": {
+              "name": "Local Proxy",
+              "type": "openai",
+              "options": {
+                "baseURL": "http://localhost:8317/v1",
+                "apiKey": "dummy-not-used"
+              }
+            }
+          }
+        }
+        """.write(to: configPath, atomically: true, encoding: .utf8)
+
+        let previousHome = ProcessInfo.processInfo.environment["HOME"]
+        let previousConfigDir = ProcessInfo.processInfo.environment["PEEKABOO_CONFIG_DIR"]
+        setenv("HOME", tempHome.path, 1)
+        unsetenv("PEEKABOO_CONFIG_DIR")
+        defer {
+            if let previousHome {
+                setenv("HOME", previousHome, 1)
+            } else {
+                unsetenv("HOME")
+            }
+            if let previousConfigDir {
+                setenv("PEEKABOO_CONFIG_DIR", previousConfigDir, 1)
+            } else {
+                unsetenv("PEEKABOO_CONFIG_DIR")
+            }
+            ConfigurationManager.shared.resetForTesting()
+            try? FileManager.default.removeItem(at: tempHome)
+        }
+
+        ConfigurationManager.shared.resetForTesting()
+        _ = ConfigurationManager.shared.loadConfiguration()
+
+        let service = PeekabooAIService()
+        #expect(service.availableModels().count == 1)
+
+        let imagePath = try self.createTestImageFile()
+        defer { self.cleanupTestFile(imagePath) }
+
+        let result = try await service.analyzeImageFileDetailed(
+            at: imagePath,
+            question: "Is there an image? Answer briefly."
+        )
+
+        #expect(result.provider == "custom")
+        #expect(result.model == "gpt-5.4-mini")
+        #expect(!result.text.isEmpty)
+    }
+
     @Test("Falls back to Anthropic when only Anthropic key is present")
     @MainActor
     func fallbackAnthropicWithKey() async throws {


### PR DESCRIPTION
## what i expected

`image --analyze` should honor custom providers configured in `~/.peekaboo/config.json`, eg entries like:

- `local-proxy/gpt-5.4-mini`

that matches the documented custom-provider setup and is especially useful for local openai-compatible proxies.

## what i ran into

`image --analyze` ignored custom providers and silently fell back to built-in providers/models instead.

in practice, that meant my local proxy config never actually took effect for image analysis.

## root cause

`PeekabooAIService.parseProviderEntry` only handled built-in provider names like:

- `openai`
- `anthropic`
- `gemini`
- etc

for anything else, it returned `nil`.

there was also a cli/config mismatch: tachikoma needed to look in `.peekaboo` for the same config profile the cli uses.

## fix

- teach `PeekabooAIService` to resolve custom providers through `CustomProviderRegistry`
- map `provider/model` entries like `local-proxy/gpt-5.4-mini` into real custom provider instances
- align cli startup with the `.peekaboo` profile dir
- add a regression test covering a custom openai-compatible provider

## result

after this change, `image --analyze` can use a custom provider from config instead of falling back to built-ins.

## note

depends on the tachikoma custom-provider credential/init fix first.