### PR TITLE
Improve browser window focus stabilization

### DIFF
--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Utilities/FocusUtilities.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Utilities/FocusUtilities.swift
@@ -165,38 +165,48 @@ public final class FocusManagementService {
 
     /// Focus a window by its CGWindowID
     public func focusWindow(windowID: CGWindowID, options: FocusOptions = FocusOptions()) async throws {
-        // Attempting to focus window
-
-        // Verify window exists
+        // Verify window exists before any focus work starts.
         guard self.windowIdentityService.windowExists(windowID: windowID) else {
             throw FocusError.windowNotFound(windowID)
         }
 
-        // Handle Space switching if needed
+        // Handle Space switching if needed.
         if options.switchSpace || options.bringToCurrentSpace {
             try await self.handleSpaceFocus(windowID: windowID, bringToCurrentSpace: options.bringToCurrentSpace)
         }
 
-        // Find the window handle (app + element)
-        guard let handle = windowIdentityService.findWindow(byID: windowID) else {
+        // Resolve the handle once, primarily so we know which app owns the window.
+        guard let initialHandle = self.windowIdentityService.findWindow(byID: windowID) else {
             throw FocusError.axElementNotFound(windowID)
         }
 
-        let runningApp = handle.app.application
+        let runningApp = initialHandle.app.application
 
-        // Activate the application
-        if !runningApp.isActive {
-            runningApp.activate()
-
-            // Wait for activation
-            try await self.waitForCondition(
-                timeout: 2.0,
-                interval: 0.1,
-                condition: { runningApp.isActive })
+        // Activate using both the shared application service and NSRunningApplication directly.
+        // Some browser windows/tabs are slow to surface as frontmost after a simple activate().
+        if let appIdentifier = runningApp.bundleIdentifier ?? runningApp.localizedName {
+            try? await self.applications.activateApplication(identifier: appIdentifier)
         }
 
-        // Focus the window
-        try await self.focusWindowElement(handle.element, windowID: windowID, options: options)
+        if !runningApp.isActive {
+            _ = runningApp.activate()
+        }
+
+        try await self.waitForCondition(
+            timeout: 3.0,
+            interval: 0.1,
+            condition: {
+                runningApp.isActive || NSWorkspace.shared.frontmostApplication?.processIdentifier == runningApp.processIdentifier
+            })
+
+        // Re-resolve after activation/space changes because AX window handles can go stale,
+        // especially in browsers when tabs/windows are recreated or promoted.
+        guard let refreshedHandle = self.windowIdentityService.findWindow(byID: windowID) else {
+            throw FocusError.axElementNotFound(windowID)
+        }
+
+        // Focus the refreshed window element.
+        try await self.focusWindowElement(refreshedHandle.element, windowID: windowID, options: options)
     }
 
     // MARK: - Private Helpers
@@ -259,22 +269,28 @@ public final class FocusManagementService {
         let startTime = Date()
 
         while Date().timeIntervalSince(startTime) < timeout {
-            // Check if window is main/focused
-            // We check the main attribute directly
-            if let isMain = windowElement.isMain(), isMain {
-                // Also verify it's not minimized
-                if let isMinimized = windowElement.isMinimized(),
-                   !isMinimized
-                {
-                    return // Success
-                }
+            let isMain = windowElement.isMain() ?? false
+            let isMinimized = windowElement.isMinimized() ?? false
+            let frontmostMatches = self.frontmostApplicationMatchesWindow(windowID: windowID)
+
+            // Browsers and some web-heavy apps do not always mark the AX window as main quickly,
+            // even when the correct owning app is clearly frontmost and the window is not minimized.
+            if !isMinimized, (isMain || frontmostMatches) {
+                return
             }
 
-            // Wait before next check
             try await Task.sleep(nanoseconds: 100_000_000) // 0.1s
         }
 
         throw FocusError.focusVerificationTimeout(windowID)
+    }
+
+    private func frontmostApplicationMatchesWindow(windowID: CGWindowID) -> Bool {
+        guard let handle = self.windowIdentityService.findWindow(byID: windowID) else {
+            return false
+        }
+
+        return NSWorkspace.shared.frontmostApplication?.processIdentifier == handle.app.application.processIdentifier
     }
 
     private func prioritizeWindows(_ windows: [WindowIdentityInfo]) -> [WindowIdentityInfo] {


### PR DESCRIPTION
## Summary
- re-resolve the AX window handle after activation/space changes
- strengthen application activation before focus verification
- relax focus verification to accept frontmost-app matches for browser-style windows

## Why
Browser windows can be flaky during automation because AX window handles may go stale after activation and some web-heavy apps do not mark the target window as main quickly enough.

## Validation
- built successfully with [0/1] Planning build
Building for debugging...
[0/1] Write swift-version--1AB21518FC5DEDBE.txt
Build complete! (1.43s)
