### PR TITLE
Add PeekabooWin to community projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,10 @@ Set providers via `PEEKABOO_AI_PROVIDERS` or `peekaboo config add`.
 - Agent chat loop: [docs/agent-chat.md](docs/agent-chat.md)
 - Service API reference: [docs/service-api-reference.md](docs/service-api-reference.md)
 
+## Community
+
+- [PeekabooWin](https://github.com/FelixKruger/PeekabooWin) — Windows-first rewrite of the Peekaboo automation loop (JavaScript + PowerShell) by [@FelixKruger](https://github.com/FelixKruger)
+
 ## Development basics
 - Requirements: macOS 15+, Xcode 16+/Swift 6.2. Node 22+ only if you run the pnpm docs/build helper scripts (core CLI/app/MCP are Swift-only).
 - Install deps: `pnpm install` then `pnpm run build:cli` or `pnpm run test:safe`.


### PR DESCRIPTION
Hi Peter / devs — I built a Windows version of Peekaboo's automation loop using JavaScript and PowerShell.

It covers the same core workflow on Windows: capture, OCR, click/scroll by label, harvest long on-screen text, and bridge into AI tooling through an MCP server and CLI.

Repo: https://github.com/FelixKruger/PeekabooWin

You're credited throughout (CREDITS.md, README, and acknowledgments). This is an independent implementation — no code was ported from your Swift project.

This PR just adds a one-line link under a "Community" section. Happy to adjust the placement or wording if you'd prefer it somewhere else.

