### PR TITLE
fix(mcp): return isError for image tool screen recording permission failure

### DIFF
--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/ImageTool.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/ImageTool.swift
@@ -50,6 +50,14 @@ public struct ImageTool: MCPTool {
 
     @MainActor
     public func execute(arguments: ToolArguments) async throws -> ToolResponse {
+        // Check screen recording permission before attempting capture
+        let hasPermission = await self.context.screenCapture.hasScreenRecordingPermission()
+        if !hasPermission {
+            let responseText = "Screen Recording permission is required. Grant via: System Settings > Privacy & Security > Screen Recording"
+            let summary = ToolEventSummary(actionDescription: "Image Capture", notes: "Screen Recording missing")
+            return ToolResponse.error(responseText, meta: ToolEventSummary.merge(summary: summary, into: nil))
+        }
+
         let request = try ImageRequest(arguments: arguments)
         let captureResults = try await self.captureImages(for: request)
         let savedFiles = try self.saveCaptures(captureResults, request: request)


### PR DESCRIPTION
Fixes #108

## Problem

When the `image` tool is invoked without macOS Screen Recording permission, it throws a `PeekabooError.permissionDeniedScreenRecording` exception. The MCP server maps unhandled exceptions to `-32603` (internal error), which MCP clients treat as a server crash. Agents cannot self-correct from internal errors the way they can from `isError: true` responses.

## Changes

- **File**: `Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/ImageTool.swift`
- Added upfront screen recording permission check in `execute()` method before attempting any capture
- When permission is missing, returns `ToolResponse.error(...)` with `isError: true` instead of throwing an exception
- Error message includes actionable guidance: "Grant via: System Settings > Privacy & Security > Screen Recording"

## Behavior

| Before | After |
|--------|-------|
| `internal error: Internal error: Screen Recording permission is required` (MCP -32603) | `{"isError": true, "text": "Screen Recording permission is required. Grant via: System Settings > Privacy & Security > Screen Recording"}` |

## Testing

- Code change follows the exact same error-handling pattern used by `PermissionsTool` (lines 65-68)
- No breaking changes to successful capture workflow
- No debug statements or unnecessary dependencies added
