### PR TITLE
ci: sync the Homebrew tap on release

### DIFF
--- a/.github/workflows/update-homebrew.yml
+++ b/.github/workflows/update-homebrew.yml
@@ -16,9 +16,9 @@ jobs:
       - name: Resolve release tag
         run: |
           if [ "${{ github.event_name }}" = "release" ]; then
-            echo "RELEASE_TAG=${{ github.event.release.tag_name }}" >> $GITHUB_ENV
+            echo "RELEASE_TAG=${{ github.event.release.tag_name }}" >> "$GITHUB_ENV"
           else
-            echo "RELEASE_TAG=v${{ github.event.inputs.version }}" >> $GITHUB_ENV
+            echo "RELEASE_TAG=v${{ github.event.inputs.version }}" >> "$GITHUB_ENV"
           fi
 
       - name: Dispatch tap formula update
@@ -30,9 +30,6 @@ jobs:
             exit 1
           fi
 
-          # Strip leading v from tag for filename compatibility if needed
-          CLEAN_TAG="${RELEASE_TAG#v}"
-          
           request_id="peekaboo-${RELEASE_TAG}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
           expected_title="Update peekaboo for ${RELEASE_TAG} (${request_id})"
 

--- a/.github/workflows/update-homebrew.yml
+++ b/.github/workflows/update-homebrew.yml
@@ -13,104 +13,60 @@ jobs:
   update-homebrew-formula:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v6
-
-      - name: Set version
-        id: version
+      - name: Resolve release tag
         run: |
           if [ "${{ github.event_name }}" = "release" ]; then
-            VERSION="${{ github.event.release.tag_name }}"
+            echo "RELEASE_TAG=${{ github.event.release.tag_name }}" >> $GITHUB_ENV
           else
-            VERSION="v${{ github.event.inputs.version }}"
-          fi
-          # Remove 'v' prefix if present
-          VERSION="${VERSION#v}"
-          echo "version=${VERSION}" >> $GITHUB_OUTPUT
-          echo "tag=v${VERSION}" >> $GITHUB_OUTPUT
-
-      - name: Download release artifact
-        run: |
-          VERSION="${{ steps.version.outputs.version }}"
-          TAG="${{ steps.version.outputs.tag }}"
-          echo "Downloading release artifact for ${TAG}..."
-          curl -L -o peekaboo-macos-arm64.tar.gz \
-            "https://github.com/steipete/peekaboo/releases/download/${TAG}/peekaboo-macos-arm64.tar.gz"
-
-      - name: Calculate SHA256
-        id: sha256
-        run: |
-          SHA256=$(sha256sum peekaboo-macos-arm64.tar.gz | cut -d' ' -f1)
-          echo "sha256=${SHA256}" >> $GITHUB_OUTPUT
-          echo "SHA256: ${SHA256}"
-
-      - name: Update Homebrew formula
-        run: |
-          VERSION="${{ steps.version.outputs.version }}"
-          SHA256="${{ steps.sha256.outputs.sha256 }}"
-          
-          # Update the formula file
-          sed -i "s|url \".*\"|url \"https://github.com/steipete/peekaboo/releases/download/v${VERSION}/peekaboo-macos-arm64.tar.gz\"|" homebrew/peekaboo.rb
-          sed -i "s|sha256 \".*\"|sha256 \"${SHA256}\"|" homebrew/peekaboo.rb
-          sed -i "s|version \".*\"|version \"${VERSION}\"|" homebrew/peekaboo.rb
-
-      - name: Detect tap token
-        run: |
-          if [ -n "${{ secrets.HOMEBREW_TAP_TOKEN }}" ]; then
-            echo "HOMEBREW_TAP_TOKEN_SET=true" >> "$GITHUB_ENV"
-          else
-            echo "HOMEBREW_TAP_TOKEN_SET=false" >> "$GITHUB_ENV"
+            echo "RELEASE_TAG=v${{ github.event.inputs.version }}" >> $GITHUB_ENV
           fi
 
-      - name: Checkout homebrew tap
-        uses: actions/checkout@v6
-        if: env.HOMEBREW_TAP_TOKEN_SET == 'true'
-        with:
-          repository: steipete/homebrew-tap
-          token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
-          path: homebrew-tap
-
-      - name: Skip tap update (missing HOMEBREW_TAP_TOKEN)
-        if: env.HOMEBREW_TAP_TOKEN_SET == 'false'
-        run: echo "::warning::HOMEBREW_TAP_TOKEN not set; skipping tap update."
-
-      - name: Copy updated formula to tap
-        if: env.HOMEBREW_TAP_TOKEN_SET == 'true'
-        run: |
-          mkdir -p homebrew-tap/Formula
-          cp homebrew/peekaboo.rb homebrew-tap/Formula/
-
-      - name: Commit and push to tap
-        if: env.HOMEBREW_TAP_TOKEN_SET == 'true'
-        run: |
-          cd homebrew-tap
-          git config user.name "GitHub Actions"
-          git config user.email "actions@github.com"
-          
-          VERSION="${{ steps.version.outputs.version }}"
-          git add Formula/peekaboo.rb
-          git commit -m "Update Peekaboo to v${VERSION}" || echo "No changes to commit"
-          git push
-
-      - name: Update formula in main repo
-        if: github.event_name == 'release' && env.HOMEBREW_TAP_TOKEN_SET == 'true'
-        run: |
-          git config user.name "GitHub Actions"
-          git config user.email "actions@github.com"
-          
-          VERSION="${{ steps.version.outputs.version }}"
-          git add homebrew/peekaboo.rb
-          git commit -m "Update Homebrew formula for v${VERSION}" || echo "No changes to commit"
-          
-          # Create a PR instead of pushing directly to main
-          git checkout -b update-homebrew-formula-v${VERSION}
-          git push origin update-homebrew-formula-v${VERSION}
-          
-          # Create PR using GitHub CLI
-          gh pr create \
-            --title "Update Homebrew formula for v${VERSION}" \
-            --body "Automated update of Homebrew formula to version ${VERSION}" \
-            --base main \
-            --head update-homebrew-formula-v${VERSION}
+      - name: Dispatch tap formula update
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+        run: |
+          if [ -z "$GH_TOKEN" ]; then
+            echo "::error::Set HOMEBREW_TAP_TOKEN with workflow access to steipete/homebrew-tap"
+            exit 1
+          fi
+
+          # Strip leading v from tag for filename compatibility if needed
+          CLEAN_TAG="${RELEASE_TAG#v}"
+          
+          request_id="peekaboo-${RELEASE_TAG}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          expected_title="Update peekaboo for ${RELEASE_TAG} (${request_id})"
+
+          gh workflow run update-formula.yml \
+            --repo steipete/homebrew-tap \
+            --ref main \
+            -f formula=peekaboo \
+            -f tag="$RELEASE_TAG" \
+            -f repository=steipete/peekaboo \
+            -f macos_artifact="peekaboo-macos-arm64.tar.gz" \
+            -f request_id="$request_id"
+
+          run_id=""
+          for _ in {1..30}; do
+            run_id=$(gh run list \
+              --repo steipete/homebrew-tap \
+              --workflow update-formula.yml \
+              --branch main \
+              --event workflow_dispatch \
+              --limit 20 \
+              --json databaseId,displayTitle \
+              --jq ".[] | select(.displayTitle == \"$expected_title\") | .databaseId" | head -n1)
+            if [ -n "$run_id" ]; then
+              break
+            fi
+            sleep 5
+          done
+
+          if [ -z "$run_id" ]; then
+            echo "::error::Could not find tap workflow run with title: $expected_title"
+            exit 1
+          fi
+
+          gh run watch "$run_id" \
+            --repo steipete/homebrew-tap \
+            --exit-status \
+            --interval 10


### PR DESCRIPTION
Refactors the Homebrew update workflow to use the new centralized updater built by `mavam` in `steipete/homebrew-tap`. This replaces the brittle regex scripts with a secure `workflow_dispatch` signal that maintains synchronous failure reporting via `gh run watch`.

Depends on steipete/homebrew-tap#29