### PR TITLE
fix(docs): deploy well-known security file

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -35,6 +35,13 @@ jobs:
       - name: Build docs site
         run: node scripts/build-docs-site.mjs
 
+      - name: Validate docs site artifact
+        run: |
+          test -f _site/.nojekyll
+          test -f _site/.well-known/security.txt
+          test -f _site/security.txt
+          test -f _site/llms.txt
+
       - name: Configure Pages
         uses: actions/configure-pages@v6
 
@@ -42,6 +49,7 @@ jobs:
         uses: actions/upload-pages-artifact@v5
         with:
           path: _site
+          include-hidden-files: true
 
   deploy:
     needs: build


### PR DESCRIPTION
## Summary

- Include hidden files when uploading the GitHub Pages artifact so `.well-known/security.txt` is deployed.
- Add a build artifact assertion for `.nojekyll`, `.well-known/security.txt`, `security.txt`, and `llms.txt` before upload.

## Why

GitHub `actions/upload-pages-artifact` excludes hidden files and directories by default. PR #115 added `docs/static/.well-known/security.txt`, and the docs build copies it to `_site/.well-known/security.txt`, but the deployed site still returns 404 because the upload step drops dot-prefixed paths.

## Checks

- `node scripts/build-docs-site.mjs`
- `node scripts/docs-lint.mjs`
- `git diff --check`
- `test -f _site/.nojekyll`
- `test -f _site/.well-known/security.txt`
- `test -f _site/security.txt`
- `test -f _site/llms.txt`