### PR TITLE
fix(mcp): keep stdio server on local runtime

### DIFF
--- a/Apps/CLI/CHANGELOG.md
+++ b/Apps/CLI/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `peekaboo agent --model` now understands the GPT-5.1 identifiers and defaults to `gpt-5.1`, matching the latest OpenAI release while keeping backward-compatible aliases for GPT-5 and GPT-4o inputs.
 
 ### Fixed
+- MCP stdio servers now default to the local runtime instead of probing an existing Bridge host, avoiding recursive capture timeouts for `see` and `image` tool calls.
 - MCP `image` now returns an `isError: true` tool result when Screen Recording permission is missing instead of surfacing an internal server error.
 - MCP `analyze` now honors configured AI providers and per-call `provider_config` models instead of hardcoding OpenAI GPT-5.1.
 - Peekaboo.app now signs with the AppleEvents automation entitlement so macOS can prompt for Automation permission.

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Base/CommanderBinder.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Base/CommanderBinder.swift
@@ -92,6 +92,7 @@ enum CommanderCLIBinder {
     private static func prefersLocalFastRuntime(_ commandType: (any ParsableCommand.Type)?) -> Bool {
         commandType == ImageCommand.self ||
             commandType == SeeCommand.self ||
+            commandType == MCPCommand.Serve.self ||
             commandType == ToolsCommand.self ||
             commandType == ListCommand.AppsSubcommand.self ||
             commandType == ListCommand.WindowsSubcommand.self ||

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/System/DialogCommand.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/System/DialogCommand.swift
@@ -171,6 +171,8 @@ func handleDialogServiceError(_ error: DialogError, jsonOutput: Bool, logger: Lo
         .FILE_IO_ERROR
     case .fileSavedToUnexpectedDirectory:
         .FILE_IO_ERROR
+    case .inputSuppressedUnderTests:
+        .INVALID_INPUT
     }
 
     if jsonOutput {

--- a/Apps/CLI/Tests/CoreCLITests/CommanderBinderProgramResolutionMcpTests.swift
+++ b/Apps/CLI/Tests/CoreCLITests/CommanderBinderProgramResolutionMcpTests.swift
@@ -22,6 +22,17 @@ struct CommanderBinderMCPWindowTests {
 
     @Test
     @MainActor
+    func `MCP serve defaults to local runtime`() throws {
+        let options = try CommanderCLIBinder.makeRuntimeOptions(
+            from: ParsedValues(positional: [], options: [:], flags: []),
+            commandType: MCPCommand.Serve.self
+        )
+
+        #expect(!options.preferRemote)
+    }
+
+    @Test
+    @MainActor
     func `Commander program resolves window close options`() throws {
         let descriptors = CommanderRegistryBuilder.buildDescriptors()
         let program = Program(descriptors: descriptors.map(\.metadata))


### PR DESCRIPTION
## Summary
- make `peekaboo mcp` prefer the same local fast runtime as `see` and `image`
- add a Commander binder regression test for MCP runtime selection
- handle the new dialog test-suppression error case so the CLI package builds

Fixes #116.

## Proof
- `swift test --package-path Apps/CLI --filter CommanderBinderMCPWindowTests`
- `pnpm run build:cli`
- `mcporter call --stdio Apps/CLI/.build/debug/peekaboo --stdio-arg mcp --output json --timeout 30000 --server peekaboo --tool see --args '{"app_target":"frontmost","annotate":false}'` -> `Elements found: 287`\n- `mcporter call --stdio Apps/CLI/.build/debug/peekaboo --stdio-arg mcp --output json --timeout 30000 --server peekaboo --tool image --args '{"app_target":"frontmost"}'` -> `isError: false`, `Captured 1 image(s)`