### PR TITLE
fix(agent): honor Gemini-only credentials in agent service refresh

### DIFF
--- a/Core/PeekabooCore/Sources/PeekabooCore/Support/PeekabooServices+Agent.swift
+++ b/Core/PeekabooCore/Sources/PeekabooCore/Support/PeekabooServices+Agent.swift
@@ -18,9 +18,10 @@ extension PeekabooServices {
         let hasOpenAI = self.configuration.getOpenAIAPIKey() != nil && !self.configuration.getOpenAIAPIKey()!.isEmpty
         let hasAnthropic = self.configuration.getAnthropicAPIKey() != nil && !self.configuration.getAnthropicAPIKey()!
             .isEmpty
+        let hasGemini = self.configuration.getGeminiAPIKey() != nil && !self.configuration.getGeminiAPIKey()!.isEmpty
         let hasOllama = false
 
-        if hasOpenAI || hasAnthropic || hasOllama {
+        if hasOpenAI || hasAnthropic || hasGemini || hasOllama {
             let agentConfig = self.configuration.getConfiguration()
             let providers = self.configuration.getAIProviders()
             let environmentProviders = EnvironmentVariables.value(for: "PEEKABOO_AI_PROVIDERS")
@@ -29,6 +30,7 @@ extension PeekabooServices {
                 providers: providers,
                 hasOpenAI: hasOpenAI,
                 hasAnthropic: hasAnthropic,
+                hasGemini: hasGemini,
                 hasOllama: hasOllama,
                 configuredDefault: agentConfig?.agent?.defaultModel,
                 isEnvironmentProvided: environmentProviders != nil)
@@ -99,6 +101,8 @@ extension PeekabooServices {
             "claude-opus-4-7"
         } else if sources.hasOpenAI {
             "gpt-5.5"
+        } else if sources.hasGemini {
+            "gemini-3-flash"
         } else if sources.hasOllama {
             "gpt-5.5"
         } else {
@@ -132,6 +136,7 @@ private struct ModelSources {
     let providers: String
     let hasOpenAI: Bool
     let hasAnthropic: Bool
+    let hasGemini: Bool
     let hasOllama: Bool
     let configuredDefault: String?
     let isEnvironmentProvided: Bool


### PR DESCRIPTION
## Summary

Closes #131.

`peekaboo agent` reported `Agent service not available. Please set OPENAI_API_KEY, ANTHROPIC_API_KEY, or GEMINI_API_KEY.` for setups with only a Gemini key, even though:

- `ConfigurationManager.getGeminiAPIKey()` already reads `GEMINI_API_KEY`/`GOOGLE_API_KEY` from env and credentials store
- `PeekabooAgentService` already handles the `.google` provider
- `AgentCommand.hasConfiguredAIProvider(...)` already advertises Gemini

The only gap was `PeekabooServices+Agent.swift::refreshAgentService()`, which gated agent construction on OpenAI/Anthropic/Ollama only and silently skipped Gemini-only credentials.

## Changes

- Add `hasGemini` check alongside `hasOpenAI`/`hasAnthropic` in `refreshAgentService()`
- Extend `ModelSources` with `hasGemini`
- Add a `gemini-3-flash` default branch in `determineDefaultModelWithConflict(_:)` so a Gemini-only setup picks a Gemini model instead of landing on `gpt-5.5` (which would fail without an OpenAI key)

Purely additive — no behavior change for existing OpenAI/Anthropic/Ollama users.

## Test plan

- [ ] `pnpm run lint`
- [ ] `pnpm run format`
- [ ] `pnpm run test:safe`
- [ ] Manual: with only `GEMINI_API_KEY` set, run `peekaboo agent --model gemini-3-flash "open Safari"` and confirm the agent starts instead of erroring.