### PR TITLE
fix(mac): release NSStatusItem and make connectToState idempotent

### DIFF
--- a/Apps/Mac/Peekaboo/Features/StatusBar/StatusBarController.swift
+++ b/Apps/Mac/Peekaboo/Features/StatusBar/StatusBarController.swift
@@ -22,6 +22,16 @@ final class StatusBarController: NSObject, NSMenuDelegate {
     /// Icon animation
     private let animationController = MenuBarAnimationController()
 
+    deinit {
+        // NSStatusBar.system retains the NSStatusItem until it is explicitly
+        // removed, so a deallocated controller would otherwise leave a ghost
+        // icon in the menu bar. Removal must happen on the main actor.
+        let item = self.statusItem
+        Task { @MainActor in
+            NSStatusBar.system.removeStatusItem(item)
+        }
+    }
+
     init(
         agent: PeekabooAgent,
         sessionStore: SessionStore,

--- a/Apps/Mac/Peekaboo/PeekabooApp.swift
+++ b/Apps/Mac/Peekaboo/PeekabooApp.swift
@@ -213,6 +213,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     fileprivate func connectToState(_ context: AppStateConnectionContext) {
+        // The HiddenWindow scene's `.task` re-runs whenever macOS routes a
+        // reopen event to it (e.g. Dock-icon click). Without this guard a
+        // second StatusBarController would be installed on every reopen,
+        // orphaning the previous controller's NSStatusItem and adding a new
+        // ghost icon to the menu bar each time.
+        guard self.statusBarController == nil else { return }
+
         self.settings = context.settings
         self.sessionStore = context.sessionStore
         self.permissions = context.permissions


### PR DESCRIPTION
## Summary

Closes #129.

Every Dock-icon reopen added another ghost icon to the menu bar because two cooperating bugs:

1. `StatusBarController` had no `deinit`, so its `NSStatusItem` was never removed. `NSStatusBar.system` retains items until `removeStatusItem(_:)` is called.
2. `AppDelegate.connectToState(_:)` unconditionally reassigned `self.statusBarController`. SwiftUI's `WindowGroup(\"HiddenWindow\").task` re-runs whenever macOS routes a reopen event to that scene, so each Dock-click rebuilt the controller and orphaned the previous one's status item.

The issue author verified the leak with `peekaboo list windows --app Peekaboo` showing N×3 menu-bar host windows for N status items across three displays.

## Changes

- `StatusBarController.swift`: add `deinit` that removes the `NSStatusItem` on the main actor.
- `PeekabooApp.swift`: guard `connectToState(_:)` against re-entry so reopen events do not rebuild the menu-bar item.

The guard alone fixes the user-visible regression; the `deinit` is belt-and-suspenders cleanup for any legitimate teardown path and matches Apple's documented contract for `NSStatusItem`.

## Test plan

Manual (this is AppKit/SwiftUI lifecycle, not unit-testable in a meaningful way):

- [ ] Build the Mac app via \`Apps/Peekaboo.xcworkspace\`.
- [ ] Launch Peekaboo; confirm one menu-bar icon.
- [ ] Click the Dock icon 5+ times.
- [ ] Confirm exactly one menu-bar icon remains.
- [ ] \`peekaboo list windows --app Peekaboo\` no longer multiplies the 1920×30 menu-bar host windows on reopen.