### PR TITLE
fix(capture): retry see-window SCScreenshotManager on transient failure

### DIFF
--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Capture/LegacyScreenCaptureOperator+Support.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Capture/LegacyScreenCaptureOperator+Support.swift
@@ -66,60 +66,71 @@ extension LegacyScreenCaptureOperator {
         windowID: CGWindowID,
         correlationId: String) async throws -> CGImage
     {
-        // Re-resolve shareable content and the target window on every attempt.
         // ScreenCaptureKit can transiently return an invalid filter or leak its
         // internal continuation when a window is in a fluid state (just
-        // minimised, off-screen, moving displays). The modern image-window path
-        // already wraps `SCScreenshotManager.captureImage` in `RetryHandler`
-        // (ScreenCaptureKitOperator+Window.swift:197); mirror that here so the
-        // `see` command no longer times out on the first transient failure.
+        // minimised, off-screen, moving displays). The modern image-window
+        // path already wraps `SCScreenshotManager.captureImage` in
+        // `RetryHandler` (ScreenCaptureKitOperator+Window.swift:197); mirror
+        // that here so the `see` command no longer times out on the first
+        // transient failure. The single-attempt body is extracted to keep
+        // main-actor isolation explicit; each attempt re-resolves shareable
+        // content so a stale window handle cannot survive across retries.
         try await RetryHandler.withRetry(policy: .standard) {
-            let content = try await ScreenCaptureKitCaptureGate.shareableContent(
-                excludingDesktopWindows: false,
-                onScreenWindowsOnly: false)
-            guard let scWindow = content.windows.first(where: { $0.windowID == windowID }) else {
-                throw OperationError.captureFailed(
-                    reason: "Window \(windowID) is not in ScreenCaptureKit shareable content " +
-                        "(it may be minimised, off-screen, or on another Space).")
-            }
-            guard let display = content.displays.first(where: { $0.frame.intersects(scWindow.frame) }) else {
-                throw OperationError.captureFailed(
-                    reason: "Window \(windowID) is not on any available display")
-            }
-
-            let nativeScale = ScreenCaptureScaleResolver.plan(
-                preference: .native,
-                displayID: display.displayID,
-                fallbackPixelWidth: display.width,
-                frameWidth: display.frame.width).nativeScale
-
-            let filter = SCContentFilter(display: display, including: [scWindow])
-            let config = self.makeScreenshotConfiguration()
-            // Display-bound filters expect display-local geometry. This mirrors the reliable modern path and keeps
-            // single-shot captures crisp without relying on the obsolete CoreGraphics window API.
-            config.sourceRect = ScreenCapturePlanner.displayLocalSourceRect(
-                globalRect: scWindow.frame,
-                displayFrame: display.frame)
-            config.width = max(Int(scWindow.frame.width * nativeScale), 1)
-            config.height = max(Int(scWindow.frame.height * nativeScale), 1)
-            config.captureResolution = .best
-            config.ignoreShadowsSingleWindow = true
-            if #available(macOS 14.2, *) {
-                config.includeChildWindows = false
-            }
-
-            self.logger.debug(
-                "Capturing window via display-bound SCScreenshotManager",
-                metadata: [
-                    "windowID": windowID,
-                    "displayID": display.displayID,
-                ],
+            try await self.captureWindowWithScreenshotManagerAttempt(
+                windowID: windowID,
                 correlationId: correlationId)
-
-            return try await ScreenCaptureKitCaptureGate.captureImage(
-                contentFilter: filter,
-                configuration: config)
         }
+    }
+
+    private func captureWindowWithScreenshotManagerAttempt(
+        windowID: CGWindowID,
+        correlationId: String) async throws -> CGImage
+    {
+        let content = try await ScreenCaptureKitCaptureGate.shareableContent(
+            excludingDesktopWindows: false,
+            onScreenWindowsOnly: false)
+        guard let scWindow = content.windows.first(where: { $0.windowID == windowID }) else {
+            throw OperationError.captureFailed(
+                reason: "Window \(windowID) is not in ScreenCaptureKit shareable content " +
+                    "(it may be minimised, off-screen, or on another Space).")
+        }
+        guard let display = content.displays.first(where: { $0.frame.intersects(scWindow.frame) }) else {
+            throw OperationError.captureFailed(
+                reason: "Window \(windowID) is not on any available display")
+        }
+
+        let nativeScale = ScreenCaptureScaleResolver.plan(
+            preference: .native,
+            displayID: display.displayID,
+            fallbackPixelWidth: display.width,
+            frameWidth: display.frame.width).nativeScale
+
+        let filter = SCContentFilter(display: display, including: [scWindow])
+        let config = self.makeScreenshotConfiguration()
+        // Display-bound filters expect display-local geometry. This mirrors the reliable modern path and keeps
+        // single-shot captures crisp without relying on the obsolete CoreGraphics window API.
+        config.sourceRect = ScreenCapturePlanner.displayLocalSourceRect(
+            globalRect: scWindow.frame,
+            displayFrame: display.frame)
+        config.width = max(Int(scWindow.frame.width * nativeScale), 1)
+        config.height = max(Int(scWindow.frame.height * nativeScale), 1)
+        config.captureResolution = .best
+        config.ignoreShadowsSingleWindow = true
+        if #available(macOS 14.2, *) {
+            config.includeChildWindows = false
+        }
+
+        self.logger.debug(
+            "Capturing window via display-bound SCScreenshotManager",
+            metadata: [
+                "windowID": windowID,
+                "displayID": display.displayID,
+            ],
+            correlationId: correlationId)
+
+        return try await ScreenCaptureKitCaptureGate.captureImage(
+            contentFilter: filter,
+            configuration: config)
     }
 
     @MainActor

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Capture/LegacyScreenCaptureOperator+Support.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Capture/LegacyScreenCaptureOperator+Support.swift
@@ -66,50 +66,60 @@ extension LegacyScreenCaptureOperator {
         windowID: CGWindowID,
         correlationId: String) async throws -> CGImage
     {
-        let content = try await ScreenCaptureKitCaptureGate.shareableContent(
-            excludingDesktopWindows: false,
-            onScreenWindowsOnly: false)
-        guard let scWindow = content.windows.first(where: { $0.windowID == windowID }) else {
-            throw OperationError.captureFailed(
-                reason: "Failed to locate window \(windowID) in ScreenCaptureKit shareable content")
+        // Re-resolve shareable content and the target window on every attempt.
+        // ScreenCaptureKit can transiently return an invalid filter or leak its
+        // internal continuation when a window is in a fluid state (just
+        // minimised, off-screen, moving displays). The modern image-window path
+        // already wraps `SCScreenshotManager.captureImage` in `RetryHandler`
+        // (ScreenCaptureKitOperator+Window.swift:197); mirror that here so the
+        // `see` command no longer times out on the first transient failure.
+        try await RetryHandler.withRetry(policy: .standard) {
+            let content = try await ScreenCaptureKitCaptureGate.shareableContent(
+                excludingDesktopWindows: false,
+                onScreenWindowsOnly: false)
+            guard let scWindow = content.windows.first(where: { $0.windowID == windowID }) else {
+                throw OperationError.captureFailed(
+                    reason: "Window \(windowID) is not in ScreenCaptureKit shareable content " +
+                        "(it may be minimised, off-screen, or on another Space).")
+            }
+            guard let display = content.displays.first(where: { $0.frame.intersects(scWindow.frame) }) else {
+                throw OperationError.captureFailed(
+                    reason: "Window \(windowID) is not on any available display")
+            }
+
+            let nativeScale = ScreenCaptureScaleResolver.plan(
+                preference: .native,
+                displayID: display.displayID,
+                fallbackPixelWidth: display.width,
+                frameWidth: display.frame.width).nativeScale
+
+            let filter = SCContentFilter(display: display, including: [scWindow])
+            let config = self.makeScreenshotConfiguration()
+            // Display-bound filters expect display-local geometry. This mirrors the reliable modern path and keeps
+            // single-shot captures crisp without relying on the obsolete CoreGraphics window API.
+            config.sourceRect = ScreenCapturePlanner.displayLocalSourceRect(
+                globalRect: scWindow.frame,
+                displayFrame: display.frame)
+            config.width = max(Int(scWindow.frame.width * nativeScale), 1)
+            config.height = max(Int(scWindow.frame.height * nativeScale), 1)
+            config.captureResolution = .best
+            config.ignoreShadowsSingleWindow = true
+            if #available(macOS 14.2, *) {
+                config.includeChildWindows = false
+            }
+
+            self.logger.debug(
+                "Capturing window via display-bound SCScreenshotManager",
+                metadata: [
+                    "windowID": windowID,
+                    "displayID": display.displayID,
+                ],
+                correlationId: correlationId)
+
+            return try await ScreenCaptureKitCaptureGate.captureImage(
+                contentFilter: filter,
+                configuration: config)
         }
-        guard let display = content.displays.first(where: { $0.frame.intersects(scWindow.frame) }) else {
-            throw OperationError.captureFailed(
-                reason: "Window \(windowID) is not on any available display")
-        }
-
-        let nativeScale = ScreenCaptureScaleResolver.plan(
-            preference: .native,
-            displayID: display.displayID,
-            fallbackPixelWidth: display.width,
-            frameWidth: display.frame.width).nativeScale
-
-        let filter = SCContentFilter(display: display, including: [scWindow])
-        let config = self.makeScreenshotConfiguration()
-        // Display-bound filters expect display-local geometry. This mirrors the reliable modern path and keeps
-        // single-shot captures crisp without relying on the obsolete CoreGraphics window API.
-        config.sourceRect = ScreenCapturePlanner.displayLocalSourceRect(
-            globalRect: scWindow.frame,
-            displayFrame: display.frame)
-        config.width = max(Int(scWindow.frame.width * nativeScale), 1)
-        config.height = max(Int(scWindow.frame.height * nativeScale), 1)
-        config.captureResolution = .best
-        config.ignoreShadowsSingleWindow = true
-        if #available(macOS 14.2, *) {
-            config.includeChildWindows = false
-        }
-
-        self.logger.debug(
-            "Capturing window via display-bound SCScreenshotManager",
-            metadata: [
-                "windowID": windowID,
-                "displayID": display.displayID,
-            ],
-            correlationId: correlationId)
-
-        return try await ScreenCaptureKitCaptureGate.captureImage(
-            contentFilter: filter,
-            configuration: config)
     }
 
     @MainActor


### PR DESCRIPTION
## Summary

Closes #127.

`peekaboo see` in window mode (`--app`, `--window-id`, `--mode frontmost`) consistently timed out after 3 s with `SWIFT TASK CONTINUATION MISUSE` logs from `SCScreenshotManager`, while `peekaboo image --mode window` worked on the same machine.

### Root cause (parity gap)

Both paths build the same `SCContentFilter(display:including:[window])` and call `ScreenCaptureKitCaptureGate.captureImage`. The only material difference:

- **image-window** (`ScreenCaptureKitOperator+Window.swift:197`) wraps the call in `RetryHandler.withRetry(policy: .standard)`.
- **see-window** (`LegacyScreenCaptureOperator+Support.swift::captureWindowWithScreenshotManager`) did **not** retry.

ScreenCaptureKit can transiently leak its internal continuation or return an invalid filter when the target window is briefly in a fluid state (just minimised, off-screen, mid-Space-switch). The existing `ScreenCaptureKitCaptureGate` already absorbs the continuation-leak log line (it has documented this behaviour at the top of the file), but a 3 s timeout still propagates if there is no retry above it. The retry wrapper hides this on the working path; adding it to the legacy path restores parity.

## Changes

`Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Capture/LegacyScreenCaptureOperator+Support.swift`

- Wrap the body of `captureWindowWithScreenshotManager` in `RetryHandler.withRetry(policy: .standard)`, mirroring the modern path.
- Re-fetch `SCShareableContent` and re-resolve the `SCWindow` / `SCDisplay` on every attempt so a stale handle from a prior fetch cannot survive across retries.
- Reword the \"window not in shareable content\" error to point at the most common cause (minimised / off-screen / other Space).

## Risk

Medium — touches the capture hot path. Mitigation: the retry policy and code shape match `ScreenCaptureKitOperator+Window.swift:197` exactly, which is the path the working `image --mode window` already uses.

## Test plan

- [ ] \`pnpm run lint\`
- [ ] \`pnpm run format\`
- [ ] \`PEEKABOO_INCLUDE_AUTOMATION_TESTS=true pnpm run test:safe\`
- [ ] Manual repro from #127 on macOS 26 hardware:
      \`peekaboo see --app Finder --path /tmp/test.png --capture-engine sckit --log-level verbose\`
      should now write a snapshot under \`~/.peekaboo/snapshots/\` and exit 0.
- [ ] Verify \`peekaboo see --mode frontmost\` and \`peekaboo see --window-id <id>\` also succeed.

> **Author verification requested.** I cannot reproduce the original timeout on the development host this PR was prepared on, so the issue author's confirmation that the retry resolves the symptom would be appreciated before merge.