### PR TITLE
Add PeekabooX to community projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ Set providers via `PEEKABOO_AI_PROVIDERS` or `peekaboo config add`.
 ## Community
 
 - [PeekabooWin](https://github.com/FelixKruger/PeekabooWin) — Windows-first rewrite of the Peekaboo automation loop (JavaScript + PowerShell) by [@FelixKruger](https://github.com/FelixKruger)
+- [PeekabooX](https://github.com/nordbyte/PeekabooX) — Linux-first rewrite of the Peekaboo automation loop (Rust + Python) by [@nordbyte](https://github.com/nordbyte)
 
 ## Development basics
 - Requirements: macOS 15+, Xcode 16+/Swift 6.2. Node 22+ only if you run the pnpm docs/build helper scripts (core CLI/app/MCP are Swift-only).


### PR DESCRIPTION
Hi Peter / devs — I built a Linux version of Peekaboo's automation loop using Rust and Python.

It covers the same core workflow on Linux: capture, semantic desktop inspection, safe input automation, workflow execution, plugins, and bridge into AI tooling through an MCP server and CLI.

Repo: https://github.com/nordbyte/PeekabooX

Peekaboo is credited in the PeekabooX README as the macOS automation project whose README layout is mirrored. PeekabooX is an independent Linux-native implementation — no code was ported from your Swift project.

This PR just adds a one-line link under the existing "Community" section. Happy to adjust the placement or wording if you'd prefer it somewhere else.
