### PR TITLE
fix(agent): align system prompt with real tool schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 - `peekaboo-mcp` now shuts down cleanly during restart backoff and repairs executable permissions without shelling out through an install path.
 - `pnpm run peekaboo:dev` no longer depends on a hardcoded local checkout path.
+- `peekaboo agent` now tells models to use the current tool schema instead of stale tool names and arguments. Thanks @vyctorbrzezowski for #139.
 
 ## [3.2.0] - 2026-05-15
 

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/Agent/Tools/AgentSystemPrompt.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/Agent/Tools/AgentSystemPrompt.swift
@@ -119,10 +119,11 @@ public struct AgentSystemPrompt {
     private static func windowManagementSection() -> String {
         """
         **Window Management Strategy**
-        1. Use the `list` tool with `{ "item_type": "application_windows" }` to see available windows.
+        1. Use the `list` tool with `{ "item_type": "application_windows", "app": "Safari" }` to see available windows.
         2. If the target window is missing, call `list_apps` to check whether the app is running.
         3. Launch applications with the `launch_app` tool: `{ "name": "Safari" }`.
-        4. Use the `list` tool with `{ "item_type": "application_windows" }` again to confirm the window exists.
+        4. Use the `list` tool with `{ "item_type": "application_windows", "app": "Safari" }`
+           again to confirm the window exists.
         5. Capture background apps with `see` using `{ "app_target": "Safari" }`.
         6. Use the `window` tool for focus/move/resize operations, always specifying
            `{ "action": "focus", "app": "Google Chrome" }` (or the relevant action plus identifiers).

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/Agent/Tools/AgentSystemPrompt.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/Agent/Tools/AgentSystemPrompt.swift
@@ -64,11 +64,11 @@ public struct AgentSystemPrompt {
 
         **Task Execution Guidelines**
         - Start with the `see` tool to understand the current UI state (e.g.,
-          `{ "app": "Safari", "json_output": true }`).
+          `{ "app_target": "Safari" }`).
         - First call `see` to get the latest state before other UI actions. Treat element IDs from `see` as valid
           only for the current visible state; after any mutating action, use the action result or fetch fresh state
           to verify the UI changed as expected.
-        - `see` accepts an `app` field to capture and focus background apps—use it instead of CLI syntax.
+        - `see` accepts an `app_target` field to capture and focus background apps—use it instead of CLI syntax.
         - Prefer element-targeted interactions over coordinate clicks when an element ID is available.
         - Prefer `set_value` for form fields when replacing the whole value; use `type` when observable keystrokes,
           autocomplete, IME behavior, or key actions matter.
@@ -108,8 +108,8 @@ public struct AgentSystemPrompt {
         **Communication Style**
         - Announce what you are about to do in one or two sentences.
         - Use casual, friendly language.
-        - Before each tool call, explain *why* you chose that tool and repeat the exact JSON payload you will send
-          (e.g., “Switching to Chrome via `app` = {\"action\":\"switch\",\"to\":\"Google Chrome\"}”).
+        - Before each tool call, explain *why* you chose that tool.
+          Keep user-visible updates short; do not repeat the full JSON payload verbatim.
         - Report whether the tool succeeded right after it returns.
         - Report errors clearly but briefly.
         - Ask for clarification only when truly necessary.
@@ -119,11 +119,11 @@ public struct AgentSystemPrompt {
     private static func windowManagementSection() -> String {
         """
         **Window Management Strategy**
-        1. Use the `list_windows` tool (no arguments needed) to see available windows.
+        1. Use the `list` tool with `{ "item_type": "application_windows" }` to see available windows.
         2. If the target window is missing, call `list_apps` to check whether the app is running.
         3. Launch applications with the `launch_app` tool: `{ "name": "Safari" }`.
-        4. Use `list_windows` again to confirm the window exists.
-        5. Capture background apps with `see` using `{ "app": "Safari", "json_output": true }`.
+        4. Use the `list` tool with `{ "item_type": "application_windows" }` again to confirm the window exists.
+        5. Capture background apps with `see` using `{ "app_target": "Safari" }`.
         6. Use the `window` tool for focus/move/resize operations, always specifying
            `{ "action": "focus", "app": "Google Chrome" }` (or the relevant action plus identifiers).
 
@@ -140,12 +140,12 @@ public struct AgentSystemPrompt {
         """
         **Dialog Interaction**
         1. Capture the dialog with `see` to identify controls.
-        2. Use `dialog_click` for standard buttons.
-        3. Use `dialog_input` for text fields.
+        2. Use the `dialog` tool with action "click" for standard buttons.
+        3. Use the `dialog` tool with action "input" for text fields.
         4. If dialog helpers fail, fall back to precise `click` commands.
 
         **Common Patterns**
-        - Menus → `menu_click` with the full path.
+        - Menus → the `menu` tool with action "click" and the full path.
         - Keyboard shortcuts → `hotkey` with modifiers.
         - Text entry → click the field, then `type`.
         - Scrolling → `scroll` with direction and amount.
@@ -178,7 +178,6 @@ public struct AgentSystemPrompt {
           `app switch --to…`; instead emit JSON like `{ "action": "switch", "to": "Safari" }`.
         - Treat the tool descriptions as the contract. For example, `app` always needs an `action`, and `hotkey`
           always needs `keys`.
-        - The `calculate` tool must include an `expression` (e.g., `{ "expression": "1+1" }`).
         - Double-check that each tool call has the necessary data before executing. If you are unsure what payload a
           tool expects, re-read its description for the JSON example.
         - When interacting with browsers, send pointer tools (move/drag/swipe) with `"profile": "human"` (the same
@@ -197,7 +196,7 @@ public struct AgentSystemPrompt {
         - Reuse successful patterns.
         - Avoid redundant captures if the UI has not changed.
         - Skip `sleep` unless a flow explicitly requires a delay—each agent turn already incurs network/runtime
-          latency, so extra sleeps rarely help. When you need to wait, prefer the `wait` tool or use UI cues (new
+          latency, so extra sleeps rarely help. When you need to wait, prefer the `sleep` tool or use UI cues (new
           elements in `see`, updated window listings) instead of hard-coded pauses.
 
         Remember: you are an automation expert. Be confident, helpful, and focused on

--- a/Core/PeekabooCore/Tests/PeekabooAgentRuntimeTests/AgentSystemPromptTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooAgentRuntimeTests/AgentSystemPromptTests.swift
@@ -54,4 +54,14 @@ struct AgentSystemPromptTests {
         let prompt = AgentSystemPrompt.generate()
         #expect(prompt.contains("`sleep`"), "Prompt should reference the real `sleep` tool for waits.")
     }
+
+    @Test
+    func `generated prompt includes app when listing application windows`() {
+        guard #available(macOS 14.0, *) else { return }
+        let prompt = AgentSystemPrompt.generate()
+        #expect(
+            prompt.contains(#""item_type": "application_windows", "app": "Safari""#),
+            "Prompt should include the required `app` argument when listing application windows."
+        )
+    }
 }

--- a/Core/PeekabooCore/Tests/PeekabooAgentRuntimeTests/AgentSystemPromptTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooAgentRuntimeTests/AgentSystemPromptTests.swift
@@ -22,8 +22,7 @@ struct AgentSystemPromptTests {
         for token in Self.forbiddenTokens {
             #expect(
                 !prompt.contains(token),
-                "Prompt still references stale tool/argument: \(token)"
-            )
+                "Prompt still references stale tool/argument: \(token)")
         }
     }
 
@@ -31,7 +30,9 @@ struct AgentSystemPromptTests {
     func `generated prompt references real see parameter app_target`() {
         guard #available(macOS 14.0, *) else { return }
         let prompt = AgentSystemPrompt.generate()
-        #expect(prompt.contains("app_target"), "Prompt should guide agents to use the real `app_target` parameter for `see`.")
+        #expect(
+            prompt.contains("app_target"),
+            "Prompt should guide agents to use the real `app_target` parameter for `see`.")
     }
 
     @Test
@@ -61,7 +62,6 @@ struct AgentSystemPromptTests {
         let prompt = AgentSystemPrompt.generate()
         #expect(
             prompt.contains(#""item_type": "application_windows", "app": "Safari""#),
-            "Prompt should include the required `app` argument when listing application windows."
-        )
+            "Prompt should include the required `app` argument when listing application windows.")
     }
 }

--- a/Core/PeekabooCore/Tests/PeekabooAgentRuntimeTests/AgentSystemPromptTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooAgentRuntimeTests/AgentSystemPromptTests.swift
@@ -1,0 +1,57 @@
+import Testing
+@testable import PeekabooAgentRuntime
+
+struct AgentSystemPromptTests {
+    /// Forbidden tokens that must not appear in the generated system prompt.
+    /// These correspond to tools or arguments that do not exist in the current
+    /// agent tool schema, so mentioning them would mislead the model.
+    private static let forbiddenTokens = [
+        "`calculate`",
+        "`wait` tool",
+        "`dialog_click`",
+        "`dialog_input`",
+        "`menu_click`",
+        "json_output",
+        "`list_windows`",
+    ]
+
+    @Test
+    func `generated prompt contains no forbidden stale tool references`() {
+        guard #available(macOS 14.0, *) else { return }
+        let prompt = AgentSystemPrompt.generate()
+        for token in Self.forbiddenTokens {
+            #expect(
+                !prompt.contains(token),
+                "Prompt still references stale tool/argument: \(token)"
+            )
+        }
+    }
+
+    @Test
+    func `generated prompt references real see parameter app_target`() {
+        guard #available(macOS 14.0, *) else { return }
+        let prompt = AgentSystemPrompt.generate()
+        #expect(prompt.contains("app_target"), "Prompt should guide agents to use the real `app_target` parameter for `see`.")
+    }
+
+    @Test
+    func `generated prompt references real dialog tool`() {
+        guard #available(macOS 14.0, *) else { return }
+        let prompt = AgentSystemPrompt.generate()
+        #expect(prompt.contains("`dialog` tool"), "Prompt should reference the real `dialog` tool.")
+    }
+
+    @Test
+    func `generated prompt references real menu tool`() {
+        guard #available(macOS 14.0, *) else { return }
+        let prompt = AgentSystemPrompt.generate()
+        #expect(prompt.contains("`menu` tool"), "Prompt should reference the real `menu` tool.")
+    }
+
+    @Test
+    func `generated prompt references real sleep tool`() {
+        guard #available(macOS 14.0, *) else { return }
+        let prompt = AgentSystemPrompt.generate()
+        #expect(prompt.contains("`sleep`"), "Prompt should reference the real `sleep` tool for waits.")
+    }
+}


### PR DESCRIPTION
## Summary
- Align the agent system prompt with the current tool schema for `see`, `list`, `dialog`, `menu`, and `sleep`.
- Remove stale prompt references to nonexistent tools/arguments such as `calculate`, `wait`, `dialog_click`, `dialog_input`, `menu_click`, `list_windows`, and `json_output`.
- Trim the instruction that asked the model to repeat the full JSON payload before every tool call.
- Add regression coverage so stale prompt/tool references do not come back silently.

## Validation
- `swift test --package-path Core/PeekabooCore --filter AgentSystemPrompt`
- `swift test --package-path Core/PeekabooCore --filter AgentTurnBoundary`
- `rg -n '`calculate`|`wait` tool|`dialog_click`|`dialog_input`|`menu_click`|json_output|`list_windows`|repeat the exact JSON payload|exact JSON payload' Core/PeekabooCore/Sources/PeekabooAgentRuntime/Agent/Tools/AgentSystemPrompt.swift` returned no matches\n\n## Visual changes\nNone.