### PR TITLE
fix(detection): honor AX traversal budgets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - `peekaboo-mcp` now shuts down cleanly during restart backoff and repairs executable permissions without shelling out through an install path.
 - `pnpm run peekaboo:dev` no longer depends on a hardcoded local checkout path.
 - `peekaboo agent` now tells models to use the current tool schema instead of stale tool names and arguments. Thanks @vyctorbrzezowski for #139.
+- AX element detection now honors traversal budgets and reports truncation when depth, count, or per-node child limits are reached. Thanks @vyctorbrzezowski for #140.
 
 ## [3.2.0] - 2026-05-15
 

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Core/Protocols/ElementDetectionModels.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Core/Protocols/ElementDetectionModels.swift
@@ -148,6 +148,9 @@ public nonisolated struct WindowContext: Sendable, Codable {
     /// Whether element detection should attempt to focus embedded web content when inputs are missing
     public let shouldFocusWebContent: Bool?
 
+    /// Optional traversal budget to constrain AX tree collection
+    public let traversalBudget: AXTraversalBudget?
+
     public init(
         applicationName: String? = nil,
         applicationBundleId: String? = nil,
@@ -155,7 +158,8 @@ public nonisolated struct WindowContext: Sendable, Codable {
         windowTitle: String? = nil,
         windowID: Int? = nil,
         windowBounds: CGRect? = nil,
-        shouldFocusWebContent: Bool? = nil)
+        shouldFocusWebContent: Bool? = nil,
+        traversalBudget: AXTraversalBudget? = nil)
     {
         self.applicationName = applicationName
         self.applicationBundleId = applicationBundleId
@@ -164,6 +168,7 @@ public nonisolated struct WindowContext: Sendable, Codable {
         self.windowID = windowID
         self.windowBounds = windowBounds
         self.shouldFocusWebContent = shouldFocusWebContent
+        self.traversalBudget = traversalBudget
     }
 }
 
@@ -187,13 +192,17 @@ public struct DetectionMetadata: Sendable, Codable {
     /// Whether a dialog was captured instead of a regular window
     public let isDialog: Bool
 
+    /// Truncation metadata if traversal budgets were reached
+    public let truncationInfo: DetectionTruncationInfo?
+
     public init(
         detectionTime: TimeInterval,
         elementCount: Int,
         method: String,
         warnings: [String] = [],
         windowContext: WindowContext? = nil,
-        isDialog: Bool = false)
+        isDialog: Bool = false,
+        truncationInfo: DetectionTruncationInfo? = nil)
     {
         self.detectionTime = detectionTime
         self.elementCount = elementCount
@@ -201,5 +210,6 @@ public struct DetectionMetadata: Sendable, Codable {
         self.warnings = warnings
         self.windowContext = windowContext
         self.isDialog = isDialog
+        self.truncationInfo = truncationInfo
     }
 }

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Core/Protocols/ElementDetectionModels.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Core/Protocols/ElementDetectionModels.swift
@@ -159,7 +159,7 @@ public nonisolated struct WindowContext: Sendable, Codable {
         windowID: Int? = nil,
         windowBounds: CGRect? = nil,
         shouldFocusWebContent: Bool? = nil,
-        traversalBudget: AXTraversalBudget? = nil)
+        traversalBudget: AXTraversalBudget?)
     {
         self.applicationName = applicationName
         self.applicationBundleId = applicationBundleId
@@ -169,6 +169,26 @@ public nonisolated struct WindowContext: Sendable, Codable {
         self.windowBounds = windowBounds
         self.shouldFocusWebContent = shouldFocusWebContent
         self.traversalBudget = traversalBudget
+    }
+
+    public init(
+        applicationName: String? = nil,
+        applicationBundleId: String? = nil,
+        applicationProcessId: Int32? = nil,
+        windowTitle: String? = nil,
+        windowID: Int? = nil,
+        windowBounds: CGRect? = nil,
+        shouldFocusWebContent: Bool? = nil)
+    {
+        self.init(
+            applicationName: applicationName,
+            applicationBundleId: applicationBundleId,
+            applicationProcessId: applicationProcessId,
+            windowTitle: windowTitle,
+            windowID: windowID,
+            windowBounds: windowBounds,
+            shouldFocusWebContent: shouldFocusWebContent,
+            traversalBudget: nil)
     }
 }
 
@@ -202,7 +222,7 @@ public struct DetectionMetadata: Sendable, Codable {
         warnings: [String] = [],
         windowContext: WindowContext? = nil,
         isDialog: Bool = false,
-        truncationInfo: DetectionTruncationInfo? = nil)
+        truncationInfo: DetectionTruncationInfo?)
     {
         self.detectionTime = detectionTime
         self.elementCount = elementCount
@@ -211,5 +231,23 @@ public struct DetectionMetadata: Sendable, Codable {
         self.windowContext = windowContext
         self.isDialog = isDialog
         self.truncationInfo = truncationInfo
+    }
+
+    public init(
+        detectionTime: TimeInterval,
+        elementCount: Int,
+        method: String,
+        warnings: [String] = [],
+        windowContext: WindowContext? = nil,
+        isDialog: Bool = false)
+    {
+        self.init(
+            detectionTime: detectionTime,
+            elementCount: elementCount,
+            method: method,
+            warnings: warnings,
+            windowContext: windowContext,
+            isDialog: isDialog,
+            truncationInfo: nil)
     }
 }

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Observation/DesktopObservationRequestModels.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Observation/DesktopObservationRequestModels.swift
@@ -56,6 +56,19 @@ public struct DetectionTruncationInfo: Sendable, Codable, Equatable {
     }
 }
 
+extension DetectionTruncationInfo {
+    static func merge(
+        _ lhs: DetectionTruncationInfo?,
+        _ rhs: DetectionTruncationInfo?) -> DetectionTruncationInfo?
+    {
+        guard lhs != nil || rhs != nil else { return nil }
+        return DetectionTruncationInfo(
+            maxDepthReached: lhs?.maxDepthReached == true || rhs?.maxDepthReached == true,
+            maxElementCountReached: lhs?.maxElementCountReached == true || rhs?.maxElementCountReached == true,
+            maxChildrenPerNodeReached: lhs?.maxChildrenPerNodeReached == true || rhs?.maxChildrenPerNodeReached == true)
+    }
+}
+
 public struct DesktopDetectionOptions: Sendable, Codable, Equatable {
     public var mode: DetectionMode
     public var allowWebFocusFallback: Bool
@@ -75,6 +88,24 @@ public struct DesktopDetectionOptions: Sendable, Codable, Equatable {
         self.includeMenuBarElements = includeMenuBarElements
         self.preferOCR = preferOCR
         self.traversalBudget = traversalBudget
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case mode
+        case allowWebFocusFallback
+        case includeMenuBarElements
+        case preferOCR
+        case traversalBudget
+    }
+
+    public init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.mode = try container.decode(DetectionMode.self, forKey: .mode)
+        self.allowWebFocusFallback = try container.decode(Bool.self, forKey: .allowWebFocusFallback)
+        self.includeMenuBarElements = try container.decode(Bool.self, forKey: .includeMenuBarElements)
+        self.preferOCR = try container.decode(Bool.self, forKey: .preferOCR)
+        self.traversalBudget = try container.decodeIfPresent(AXTraversalBudget.self, forKey: .traversalBudget)
+            ?? AXTraversalBudget()
     }
 }
 

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Observation/DesktopObservationRequestModels.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Observation/DesktopObservationRequestModels.swift
@@ -40,6 +40,22 @@ public struct AXTraversalBudget: Sendable, Codable, Equatable {
     }
 }
 
+public struct DetectionTruncationInfo: Sendable, Codable, Equatable {
+    public let maxDepthReached: Bool
+    public let maxElementCountReached: Bool
+    public let maxChildrenPerNodeReached: Bool
+
+    public init(
+        maxDepthReached: Bool = false,
+        maxElementCountReached: Bool = false,
+        maxChildrenPerNodeReached: Bool = false)
+    {
+        self.maxDepthReached = maxDepthReached
+        self.maxElementCountReached = maxElementCountReached
+        self.maxChildrenPerNodeReached = maxChildrenPerNodeReached
+    }
+}
+
 public struct DesktopDetectionOptions: Sendable, Codable, Equatable {
     public var mode: DetectionMode
     public var allowWebFocusFallback: Bool

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Observation/DesktopObservationService+Detection.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Observation/DesktopObservationService+Detection.swift
@@ -21,7 +21,8 @@ extension DesktopObservationService {
             windowTitle: context?.windowTitle,
             windowID: context?.windowID,
             windowBounds: context?.windowBounds,
-            shouldFocusWebContent: request.detection.allowWebFocusFallback)
+            shouldFocusWebContent: request.detection.allowWebFocusFallback,
+            traversalBudget: request.detection.traversalBudget)
 
         return try await tracer.span("detection.ax") {
             try await self.detectElements(

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Observation/ObservationOCRService.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Observation/ObservationOCRService.swift
@@ -148,7 +148,8 @@ public enum ObservationOCRMapper {
                 method: method,
                 warnings: metadata.warnings,
                 windowContext: metadata.windowContext,
-                isDialog: metadata.isDialog))
+                isDialog: metadata.isDialog,
+                truncationInfo: metadata.truncationInfo))
     }
 
     public static func detectionResult(

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/AXTreeCollector.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/AXTreeCollector.swift
@@ -324,7 +324,7 @@ struct AXTreeCollector {
 }
 
 extension AXTraversalBudget {
-    fileprivate var normalizedForTraversal: AXTraversalBudget {
+    var normalizedForTraversal: AXTraversalBudget {
         AXTraversalBudget(
             maxDepth: max(0, self.maxDepth),
             maxElementCount: max(0, self.maxElementCount),

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/AXTreeCollector.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/AXTreeCollector.swift
@@ -9,18 +9,38 @@ struct AXTreeCollector {
     struct Result {
         let elements: [DetectedElement]
         let elementIdMap: [String: DetectedElement]
+        let truncationInfo: DetectionTruncationInfo?
     }
 
     private struct TraversalState {
         var elements: [DetectedElement]
         var elementIdMap: [String: DetectedElement]
         var visitedElements: Set<Element>
+        var truncationFlags: TruncationFlags
 
         @MainActor
         init() {
             self.elements = []
             self.elementIdMap = [:]
             self.visitedElements = Set<Element>()
+            self.truncationFlags = TruncationFlags()
+        }
+    }
+
+    private struct TruncationFlags {
+        var maxDepthReached = false
+        var maxElementCountReached = false
+        var maxChildrenPerNodeReached = false
+
+        var isEmpty: Bool {
+            !self.maxDepthReached && !self.maxElementCountReached && !self.maxChildrenPerNodeReached
+        }
+
+        func toInfo() -> DetectionTruncationInfo {
+            DetectionTruncationInfo(
+                maxDepthReached: self.maxDepthReached,
+                maxElementCountReached: self.maxElementCountReached,
+                maxChildrenPerNodeReached: self.maxChildrenPerNodeReached)
         }
     }
 
@@ -41,8 +61,9 @@ struct AXTreeCollector {
 
     private let logger = Logger(subsystem: "boo.peekaboo.core", category: "AXTreeCollector")
 
-    func collect(window: Element, deadline: Date) -> Result {
+    func collect(window: Element, deadline: Date, budget: AXTraversalBudget? = nil) -> Result {
         var state = TraversalState()
+        let resolvedBudget = (budget ?? AXTraversalBudget()).normalizedForTraversal
 
         // Traverse only the captured window. Walking the app root also visits sibling windows,
         // which makes `see --app` slower and returns elements outside the screenshot.
@@ -50,21 +71,35 @@ struct AXTreeCollector {
             window,
             depth: 0,
             deadline: deadline,
+            budget: resolvedBudget,
             state: &state)
 
-        return Result(elements: state.elements, elementIdMap: state.elementIdMap)
+        let truncationInfo: DetectionTruncationInfo? = state.truncationFlags.isEmpty
+            ? nil
+            : state.truncationFlags.toInfo()
+        return Result(
+            elements: state.elements,
+            elementIdMap: state.elementIdMap,
+            truncationInfo: truncationInfo)
     }
 
     private func processElement(
         _ element: Element,
         depth: Int,
         deadline: Date,
+        budget: AXTraversalBudget,
         state: inout TraversalState)
     {
-        guard depth < AXTraversalPolicy.maxTraversalDepth else { return }
+        guard depth < budget.maxDepth else {
+            state.truncationFlags.maxDepthReached = true
+            return
+        }
         guard !Task.isCancelled else { return }
         guard Date() < deadline else { return }
-        guard state.elements.count < AXTraversalPolicy.maxElementCount else { return }
+        guard state.elements.count < budget.maxElementCount else {
+            state.truncationFlags.maxElementCountReached = true
+            return
+        }
         guard state.visitedElements.insert(element).inserted else { return }
         guard let descriptor = AXDescriptorReader.describe(element) else { return }
 
@@ -106,6 +141,7 @@ struct AXTreeCollector {
             of: element,
             depth: depth + 1,
             deadline: deadline,
+            budget: budget,
             state: &state)
     }
 
@@ -113,17 +149,25 @@ struct AXTreeCollector {
         of element: Element,
         depth: Int,
         deadline: Date,
+        budget: AXTraversalBudget,
         state: inout TraversalState)
     {
         guard !Task.isCancelled else { return }
         guard let children = element.children() else { return }
-        let limitedChildren = children.prefix(AXTraversalPolicy.maxChildrenPerNode)
+        if children.count > budget.maxChildrenPerNode {
+            state.truncationFlags.maxChildrenPerNodeReached = true
+        }
+        let limitedChildren = children.prefix(budget.maxChildrenPerNode)
         for child in limitedChildren {
-            guard state.elements.count < AXTraversalPolicy.maxElementCount else { break }
+            guard state.elements.count < budget.maxElementCount else {
+                state.truncationFlags.maxElementCountReached = true
+                break
+            }
             self.processElement(
                 child,
                 depth: depth,
                 deadline: deadline,
+                budget: budget,
                 state: &state)
         }
     }
@@ -276,5 +320,14 @@ struct AXTreeCollector {
         }
 
         return nil
+    }
+}
+
+private extension AXTraversalBudget {
+    var normalizedForTraversal: AXTraversalBudget {
+        AXTraversalBudget(
+            maxDepth: max(0, self.maxDepth),
+            maxElementCount: max(0, self.maxElementCount),
+            maxChildrenPerNode: max(0, self.maxChildrenPerNode))
     }
 }

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/AXTreeCollector.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/AXTreeCollector.swift
@@ -323,8 +323,8 @@ struct AXTreeCollector {
     }
 }
 
-private extension AXTraversalBudget {
-    var normalizedForTraversal: AXTraversalBudget {
+extension AXTraversalBudget {
+    fileprivate var normalizedForTraversal: AXTraversalBudget {
         AXTraversalBudget(
             maxDepth: max(0, self.maxDepth),
             maxElementCount: max(0, self.maxElementCount),

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/ElementDetectionCache.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/ElementDetectionCache.swift
@@ -19,9 +19,19 @@ import PeekabooFoundation
         }
     }
 
+    public struct CachedElements: Sendable {
+        public let elements: [DetectedElement]
+        public let truncationInfo: DetectionTruncationInfo?
+
+        public init(elements: [DetectedElement], truncationInfo: DetectionTruncationInfo? = nil) {
+            self.elements = elements
+            self.truncationInfo = truncationInfo
+        }
+    }
+
     private struct Entry {
         let cachedAt: Date
-        let elements: [DetectedElement]
+        let result: CachedElements
     }
 
     private let ttl: TimeInterval
@@ -39,18 +49,24 @@ import PeekabooFoundation
     }
 
     public func elements(for key: Key) -> [DetectedElement]? {
+        self.result(for: key)?.elements
+    }
+
+    public func result(for key: Key) -> CachedElements? {
         guard let entry = self.entries[key] else { return nil }
 
         if self.now().timeIntervalSince(entry.cachedAt) <= self.ttl {
-            return entry.elements
+            return entry.result
         }
 
         self.entries.removeValue(forKey: key)
         return nil
     }
 
-    public func store(_ elements: [DetectedElement], for key: Key) {
-        self.entries[key] = Entry(cachedAt: self.now(), elements: elements)
+    public func store(_ elements: [DetectedElement], truncationInfo: DetectionTruncationInfo? = nil, for key: Key) {
+        self.entries[key] = Entry(
+            cachedAt: self.now(),
+            result: CachedElements(elements: elements, truncationInfo: truncationInfo))
     }
 
     public func removeAll() {

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/ElementDetectionResultBuilder.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/ElementDetectionResultBuilder.swift
@@ -10,9 +10,24 @@ import PeekabooFoundation
         usedCache: Bool,
         windowContext: WindowContext?,
         isDialog: Bool,
-        detectionTime: TimeInterval = 0.0) -> ElementDetectionResult
+        detectionTime: TimeInterval = 0.0,
+        truncationInfo: DetectionTruncationInfo? = nil) -> ElementDetectionResult
     {
-        ElementDetectionResult(
+        var warnings: [String] = []
+        if usedCache {
+            warnings.append("ax_cache_hit")
+        }
+        if truncationInfo?.maxDepthReached == true {
+            warnings.append("ax_truncated_depth")
+        }
+        if truncationInfo?.maxElementCountReached == true {
+            warnings.append("ax_truncated_count")
+        }
+        if truncationInfo?.maxChildrenPerNodeReached == true {
+            warnings.append("ax_truncated_children")
+        }
+
+        return ElementDetectionResult(
             snapshotId: snapshotId,
             screenshotPath: screenshotPath,
             elements: self.group(elements),
@@ -20,9 +35,10 @@ import PeekabooFoundation
                 detectionTime: detectionTime,
                 elementCount: elements.count,
                 method: usedCache ? "AXorcist (cached)" : "AXorcist",
-                warnings: usedCache ? ["ax_cache_hit"] : [],
+                warnings: warnings,
                 windowContext: windowContext,
-                isDialog: isDialog))
+                isDialog: isDialog,
+                truncationInfo: truncationInfo))
     }
 
     public static func group(_ elements: [DetectedElement]) -> DetectedElements {

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/ElementDetectionService.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/ElementDetectionService.swift
@@ -77,29 +77,42 @@ public final class ElementDetectionService {
             windowTitle: windowName,
             windowID: resolvedWindowID,
             windowBounds: windowContext?.windowBounds,
-            shouldFocusWebContent: windowContext?.shouldFocusWebContent)
+            shouldFocusWebContent: windowContext?.shouldFocusWebContent,
+            traversalBudget: windowContext?.traversalBudget)
 
         var elementIdMap: [String: DetectedElement] = [:]
         let allowWebFocus = windowContext?.shouldFocusWebContent ?? true
+        let budget = windowContext?.traversalBudget
+        let usesDefaultBudget = (budget ?? AXTraversalBudget()) == AXTraversalBudget()
         let detectedElements: [DetectedElement]
         let usedCache: Bool
-        let cacheKey = self.axTreeCache.key(
-            windowID: resolvedWindowID,
-            processID: targetApp.processIdentifier,
-            allowWebFocus: allowWebFocus)
-        if let cacheKey, let cached = self.axTreeCache.elements(for: cacheKey) {
+        let truncationInfo: DetectionTruncationInfo?
+        let cacheKey = usesDefaultBudget
+            ? self.axTreeCache.key(
+                windowID: resolvedWindowID,
+                processID: targetApp.processIdentifier,
+                allowWebFocus: allowWebFocus)
+            : nil
+        if let cacheKey, let cached = self.axTreeCache.result(for: cacheKey) {
             self.logger.debug("Using cached AX tree for window \(cacheKey.windowID)")
-            detectedElements = cached
+            detectedElements = cached.elements
             usedCache = true
+            truncationInfo = cached.truncationInfo
         } else {
-            detectedElements = try await self.collectElementsWithTimeout(
+            let collection = try await self.collectElementsWithTimeout(
                 window: windowResolution.window,
                 appElement: windowResolution.appElement,
                 appIsActive: targetApp.isActive,
                 allowWebFocus: allowWebFocus,
+                budget: budget,
                 elementIdMap: &elementIdMap)
+            detectedElements = collection.elements
+            truncationInfo = collection.truncationInfo
             if let cacheKey {
-                self.axTreeCache.store(detectedElements, for: cacheKey)
+                self.axTreeCache.store(
+                    detectedElements,
+                    truncationInfo: collection.truncationInfo,
+                    for: cacheKey)
             }
             usedCache = false
         }
@@ -113,7 +126,8 @@ public final class ElementDetectionService {
             elements: detectedElements,
             usedCache: usedCache,
             windowContext: resolvedWindowContext,
-            isDialog: windowResolution.isDialog)
+            isDialog: windowResolution.isDialog,
+            truncationInfo: truncationInfo)
     }
 }
 
@@ -123,10 +137,13 @@ extension ElementDetectionService {
         appElement: Element,
         appIsActive: Bool,
         allowWebFocus: Bool,
+        budget: AXTraversalBudget?,
         elementIdMap: inout [String: DetectedElement],
-        timeoutSeconds: Double = 20.0) async throws -> [DetectedElement]
+        timeoutSeconds: Double = 20.0) async throws -> (
+            elements: [DetectedElement],
+            truncationInfo: DetectionTruncationInfo?)
     {
-        let (elements, map) = try await ElementDetectionTimeoutRunner.run(seconds: timeoutSeconds) {
+        let (elements, map, truncationInfo) = try await ElementDetectionTimeoutRunner.run(seconds: timeoutSeconds) {
             let deadline = Date().addingTimeInterval(timeoutSeconds)
             var localMap: [String: DetectedElement] = [:]
             let request = ElementCollectionRequest(
@@ -134,32 +151,43 @@ extension ElementDetectionService {
                 appElement: appElement,
                 appIsActive: appIsActive,
                 allowWebFocus: allowWebFocus,
-                deadline: deadline)
-            let elements = await self.collectElements(
+                deadline: deadline,
+                budget: budget)
+            let collection = await self.collectElements(
                 request,
                 elementIdMap: &localMap)
-            return (elements, localMap)
+            return (collection.elements, localMap, collection.truncationInfo)
         }
         elementIdMap = map
-        return elements
+        return (elements, truncationInfo)
     }
 }
 
 extension ElementDetectionService {
+    private struct ElementCollection {
+        let elements: [DetectedElement]
+        let truncationInfo: DetectionTruncationInfo?
+    }
+
     private func collectElements(
         _ request: ElementCollectionRequest,
-        elementIdMap: inout [String: DetectedElement]) async -> [DetectedElement]
+        elementIdMap: inout [String: DetectedElement]) async -> ElementCollection
     {
         var detectedElements: [DetectedElement] = []
         var attempt = 0
+        var truncationInfo: DetectionTruncationInfo?
 
         repeat {
             elementIdMap.removeAll(keepingCapacity: true)
             detectedElements.removeAll(keepingCapacity: true)
 
-            let collection = self.axTreeCollector.collect(window: request.window, deadline: request.deadline)
+            let collection = self.axTreeCollector.collect(
+                window: request.window,
+                deadline: request.deadline,
+                budget: request.budget)
             detectedElements = collection.elements
             elementIdMap = collection.elementIdMap
+            truncationInfo = collection.truncationInfo
 
             if request.appIsActive, let menuBar = request.appElement.menuBar() {
                 self.menuBarElementCollector.appendMenuBar(
@@ -186,7 +214,9 @@ extension ElementDetectionService {
             try? await Task.sleep(nanoseconds: 150_000_000)
         } while true
 
-        return detectedElements
+        return ElementCollection(
+            elements: detectedElements,
+            truncationInfo: truncationInfo)
     }
 }
 
@@ -196,4 +226,5 @@ private struct ElementCollectionRequest {
     let appIsActive: Bool
     let allowWebFocus: Bool
     let deadline: Date
+    let budget: AXTraversalBudget?
 }

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/ElementDetectionService.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/ElementDetectionService.swift
@@ -140,8 +140,8 @@ extension ElementDetectionService {
         budget: AXTraversalBudget?,
         elementIdMap: inout [String: DetectedElement],
         timeoutSeconds: Double = 20.0) async throws -> (
-            elements: [DetectedElement],
-            truncationInfo: DetectionTruncationInfo?)
+        elements: [DetectedElement],
+        truncationInfo: DetectionTruncationInfo?)
     {
         let (elements, map, truncationInfo) = try await ElementDetectionTimeoutRunner.run(seconds: timeoutSeconds) {
             let deadline = Date().addingTimeInterval(timeoutSeconds)

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/ElementDetectionService.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/ElementDetectionService.swift
@@ -190,10 +190,12 @@ extension ElementDetectionService {
             truncationInfo = collection.truncationInfo
 
             if request.appIsActive, let menuBar = request.appElement.menuBar() {
-                self.menuBarElementCollector.appendMenuBar(
+                let menuBarTruncation = self.menuBarElementCollector.appendMenuBar(
                     menuBar,
                     elements: &detectedElements,
-                    elementIdMap: &elementIdMap)
+                    elementIdMap: &elementIdMap,
+                    budget: request.budget)
+                truncationInfo = DetectionTruncationInfo.merge(truncationInfo, menuBarTruncation)
             }
 
             let hasTextField = detectedElements.contains(where: { $0.type == .textField })

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/MenuBarElementCollector.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/MenuBarElementCollector.swift
@@ -8,11 +8,28 @@ struct MenuBarElementCollector {
     func appendMenuBar(
         _ menuBar: Element,
         elements: inout [DetectedElement],
-        elementIdMap: inout [String: DetectedElement])
+        elementIdMap: inout [String: DetectedElement],
+        budget: AXTraversalBudget? = nil) -> DetectionTruncationInfo?
     {
-        guard let menus = menuBar.children() else { return }
+        let resolvedBudget = (budget ?? AXTraversalBudget()).normalizedForTraversal
+        var truncationInfo: DetectionTruncationInfo?
+        guard let menus = menuBar.children() else { return nil }
+        if menus.count > resolvedBudget.maxChildrenPerNode {
+            truncationInfo = DetectionTruncationInfo.merge(
+                truncationInfo,
+                DetectionTruncationInfo(maxChildrenPerNodeReached: true))
+        }
 
-        for menu in menus {
+        for menu in menus.prefix(resolvedBudget.maxChildrenPerNode) {
+            guard self.canAppendElement(
+                depth: 0,
+                elementCount: elements.count,
+                budget: resolvedBudget,
+                truncationInfo: &truncationInfo)
+            else {
+                break
+            }
+
             let menuId = "menu_\(elements.count)"
             let menuElement = DetectedElement(
                 id: menuId,
@@ -28,17 +45,49 @@ struct MenuBarElementCollector {
             elementIdMap[menuId] = menuElement
 
             if let menuItems = menu.children() {
-                self.appendMenuItems(menuItems, elements: &elements, elementIdMap: &elementIdMap)
+                self.appendMenuItems(
+                    menuItems,
+                    depth: 1,
+                    elements: &elements,
+                    elementIdMap: &elementIdMap,
+                    budget: resolvedBudget,
+                    truncationInfo: &truncationInfo)
             }
         }
+        return truncationInfo
     }
 
     private func appendMenuItems(
         _ items: [Element],
+        depth: Int,
         elements: inout [DetectedElement],
-        elementIdMap: inout [String: DetectedElement])
+        elementIdMap: inout [String: DetectedElement],
+        budget: AXTraversalBudget,
+        truncationInfo: inout DetectionTruncationInfo?)
     {
-        for item in items {
+        guard depth < budget.maxDepth else {
+            truncationInfo = DetectionTruncationInfo.merge(
+                truncationInfo,
+                DetectionTruncationInfo(maxDepthReached: true))
+            return
+        }
+
+        if items.count > budget.maxChildrenPerNode {
+            truncationInfo = DetectionTruncationInfo.merge(
+                truncationInfo,
+                DetectionTruncationInfo(maxChildrenPerNodeReached: true))
+        }
+
+        for item in items.prefix(budget.maxChildrenPerNode) {
+            guard self.canAppendElement(
+                depth: depth,
+                elementCount: elements.count,
+                budget: budget,
+                truncationInfo: &truncationInfo)
+            else {
+                break
+            }
+
             let itemId = "menuitem_\(elements.count)"
             let menuItemElement = DetectedElement(
                 id: itemId,
@@ -54,9 +103,38 @@ struct MenuBarElementCollector {
             elementIdMap[itemId] = menuItemElement
 
             if let submenu = item.children(), !submenu.isEmpty {
-                self.appendMenuItems(submenu, elements: &elements, elementIdMap: &elementIdMap)
+                self.appendMenuItems(
+                    submenu,
+                    depth: depth + 1,
+                    elements: &elements,
+                    elementIdMap: &elementIdMap,
+                    budget: budget,
+                    truncationInfo: &truncationInfo)
             }
         }
+    }
+
+    private func canAppendElement(
+        depth: Int,
+        elementCount: Int,
+        budget: AXTraversalBudget,
+        truncationInfo: inout DetectionTruncationInfo?) -> Bool
+    {
+        guard depth < budget.maxDepth else {
+            truncationInfo = DetectionTruncationInfo.merge(
+                truncationInfo,
+                DetectionTruncationInfo(maxDepthReached: true))
+            return false
+        }
+
+        guard elementCount < budget.maxElementCount else {
+            truncationInfo = DetectionTruncationInfo.merge(
+                truncationInfo,
+                DetectionTruncationInfo(maxElementCountReached: true))
+            return false
+        }
+
+        return true
     }
 
     private func menuItemAttributes(_ item: Element) -> [String: String] {

--- a/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/AXTreeCollectorBudgetTests.swift
+++ b/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/AXTreeCollectorBudgetTests.swift
@@ -1,0 +1,115 @@
+import Foundation
+import XCTest
+@testable import PeekabooAutomationKit
+@preconcurrency import AXorcist
+
+@MainActor
+final class AXTreeCollectorBudgetTests: XCTestCase {
+    private func frontmostWindowElement() -> Element? {
+        guard let appAX = AXUIElement.frontmostApplication() else {
+            return nil
+        }
+        let appElement = Element(appAX)
+        return appElement.windows()?.first
+    }
+
+    func testDefaultBudgetCollectsMultipleElementsWhenWindowExposesChildren() throws {
+        guard let window = self.frontmostWindowElement() else {
+            throw XCTSkip("No frontmost window available for AX testing")
+        }
+
+        let collector = AXTreeCollector()
+        let result = collector.collect(window: window, deadline: Date().addingTimeInterval(5.0))
+
+        guard result.elements.count > 1 else {
+            throw XCTSkip("Frontmost window does not expose child AX elements")
+        }
+        guard result.truncationInfo == nil else {
+            throw XCTSkip("Frontmost window exceeds the default AX traversal budget")
+        }
+
+        XCTAssertNil(result.truncationInfo, "Default budget should not trigger truncation on a small AX tree")
+    }
+
+    func testMaxDepthOneStopsAtRoot() throws {
+        guard let window = self.frontmostWindowElement() else {
+            throw XCTSkip("No frontmost window available for AX testing")
+        }
+
+        let collector = AXTreeCollector()
+        let defaultResult = collector.collect(window: window, deadline: Date().addingTimeInterval(5.0))
+        guard defaultResult.elements.count > 1 else {
+            throw XCTSkip("Frontmost window does not expose child AX elements")
+        }
+
+        let budget = AXTraversalBudget(maxDepth: 1, maxElementCount: 400, maxChildrenPerNode: 50)
+        let result = collector.collect(
+            window: window,
+            deadline: Date().addingTimeInterval(5.0),
+            budget: budget)
+
+        XCTAssertEqual(result.elements.count, 1, "Depth 1 should only collect the root window")
+        XCTAssertTrue(result.truncationInfo?.maxDepthReached == true, "Should flag maxDepthReached")
+    }
+
+    func testMaxElementCountStopsEarly() throws {
+        guard let window = self.frontmostWindowElement() else {
+            throw XCTSkip("No frontmost window available for AX testing")
+        }
+
+        let collector = AXTreeCollector()
+        let defaultResult = collector.collect(window: window, deadline: Date().addingTimeInterval(5.0))
+        guard defaultResult.elements.count > 2 else {
+            throw XCTSkip("Frontmost window does not expose enough AX elements")
+        }
+
+        let budget = AXTraversalBudget(maxDepth: 12, maxElementCount: 2, maxChildrenPerNode: 50)
+        let result = collector.collect(
+            window: window,
+            deadline: Date().addingTimeInterval(5.0),
+            budget: budget)
+
+        XCTAssertLessThanOrEqual(result.elements.count, 2, "Budget of 2 elements should collect at most 2")
+        XCTAssertTrue(result.truncationInfo?.maxElementCountReached == true, "Should flag maxElementCountReached")
+    }
+
+    func testMaxChildrenPerNodeLimitsTraversal() throws {
+        guard let window = self.frontmostWindowElement() else {
+            throw XCTSkip("No frontmost window available for AX testing")
+        }
+
+        let collector = AXTreeCollector()
+        let defaultResult = collector.collect(window: window, deadline: Date().addingTimeInterval(5.0))
+        guard defaultResult.elements.count > 1 else {
+            throw XCTSkip("Frontmost window does not expose child AX elements")
+        }
+
+        let collector2 = AXTreeCollector()
+        let budget = AXTraversalBudget(maxDepth: 12, maxElementCount: 400, maxChildrenPerNode: 0)
+        let limitedResult = collector2.collect(
+            window: window,
+            deadline: Date().addingTimeInterval(5.0),
+            budget: budget)
+
+        XCTAssertEqual(limitedResult.elements.count, 1, "Children budget 0 should only collect the root")
+        XCTAssertTrue(
+            limitedResult.truncationInfo?.maxChildrenPerNodeReached == true,
+            "Should flag maxChildrenPerNodeReached")
+    }
+
+    func testNegativeBudgetValuesAreClampedBeforeTraversal() throws {
+        guard let window = self.frontmostWindowElement() else {
+            throw XCTSkip("No frontmost window available for AX testing")
+        }
+
+        let collector = AXTreeCollector()
+        let budget = AXTraversalBudget(maxDepth: -1, maxElementCount: -1, maxChildrenPerNode: -1)
+        let result = collector.collect(
+            window: window,
+            deadline: Date().addingTimeInterval(5.0),
+            budget: budget)
+
+        XCTAssertTrue(result.elements.isEmpty, "Negative depth/count budgets should clamp to zero")
+        XCTAssertTrue(result.truncationInfo?.maxDepthReached == true, "Should flag maxDepthReached")
+    }
+}

--- a/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/AXTreeCollectorBudgetTests.swift
+++ b/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/AXTreeCollectorBudgetTests.swift
@@ -1,4 +1,5 @@
 @preconcurrency import AXorcist
+import CoreGraphics
 import Foundation
 import XCTest
 @testable import PeekabooAutomationKit
@@ -111,5 +112,52 @@ final class AXTreeCollectorBudgetTests: XCTestCase {
 
         XCTAssertTrue(result.elements.isEmpty, "Negative depth/count budgets should clamp to zero")
         XCTAssertTrue(result.truncationInfo?.maxDepthReached == true, "Should flag maxDepthReached")
+    }
+
+    func testDesktopDetectionOptionsDecodesOldPayloadWithoutTraversalBudget() throws {
+        let options = DesktopDetectionOptions(
+            mode: .accessibility,
+            allowWebFocusFallback: false,
+            includeMenuBarElements: true,
+            preferOCR: false)
+        let encoded = try JSONEncoder().encode(options)
+        var object = try XCTUnwrap(JSONSerialization.jsonObject(with: encoded) as? [String: Any])
+        object.removeValue(forKey: "traversalBudget")
+        let oldPayload = try JSONSerialization.data(withJSONObject: object)
+
+        let decoded = try JSONDecoder().decode(DesktopDetectionOptions.self, from: oldPayload)
+
+        XCTAssertEqual(decoded.traversalBudget, AXTraversalBudget())
+        XCTAssertEqual(decoded.allowWebFocusFallback, false)
+    }
+
+    func testOCRMergePreservesTruncationMetadata() {
+        let truncationInfo = DetectionTruncationInfo(maxElementCountReached: true)
+        let detection = ElementDetectionResult(
+            snapshotId: "snapshot",
+            screenshotPath: "",
+            elements: DetectedElements(buttons: [
+                DetectedElement(
+                    id: "elem_1",
+                    type: .button,
+                    label: "OK",
+                    bounds: CGRect(x: 1, y: 1, width: 10, height: 10)),
+            ]),
+            metadata: DetectionMetadata(
+                detectionTime: 0,
+                elementCount: 1,
+                method: "AXorcist",
+                warnings: ["ax_truncated_count"],
+                truncationInfo: truncationInfo))
+        let ocrElement = DetectedElement(
+            id: "ocr_1",
+            type: .staticText,
+            label: "OCR",
+            bounds: CGRect(x: 2, y: 2, width: 10, height: 10))
+
+        let merged = ObservationOCRMapper.merge(ocrElements: [ocrElement], into: detection)
+
+        XCTAssertEqual(merged.metadata.truncationInfo, truncationInfo)
+        XCTAssertTrue(merged.metadata.warnings.contains("ax_truncated_count"))
     }
 }

--- a/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/AXTreeCollectorBudgetTests.swift
+++ b/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/AXTreeCollectorBudgetTests.swift
@@ -1,7 +1,7 @@
+@preconcurrency import AXorcist
 import Foundation
 import XCTest
 @testable import PeekabooAutomationKit
-@preconcurrency import AXorcist
 
 @MainActor
 final class AXTreeCollectorBudgetTests: XCTestCase {

--- a/Core/PeekabooCore/Tests/PeekabooTests/ElementDetectionServiceTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/ElementDetectionServiceTests.swift
@@ -342,6 +342,18 @@ struct ElementDetectionCacheTests {
     }
 
     @Test
+    func `Cache preserves truncation metadata`() {
+        let cache = ElementDetectionCache()
+        let key = ElementDetectionCache.Key(windowID: 7, processID: pid_t(42), allowWebFocus: true)
+        let truncationInfo = DetectionTruncationInfo(maxElementCountReached: true)
+
+        cache.store([Self.element(id: "elem_1")], truncationInfo: truncationInfo, for: key)
+
+        #expect(cache.result(for: key)?.elements.map(\.id) == ["elem_1"])
+        #expect(cache.result(for: key)?.truncationInfo == truncationInfo)
+    }
+
+    @Test
     func `Cache expires stale elements`() {
         var now = Date(timeIntervalSince1970: 1000)
         let cache = ElementDetectionCache(ttl: 1.0) { now }


### PR DESCRIPTION
## Summary

- Thread `DesktopDetectionOptions.traversalBudget` into AX tree collection instead of always using the default traversal limits.
- Return truncation metadata and warnings when depth, element count, or children-per-node limits are reached.
- Keep default-budget cache hits useful by storing truncation metadata with cached AX results, while bypassing the cache for custom budgets.
- Clamp negative budget values before traversal so request-provided budgets cannot reach `prefix(_:)` with invalid counts.

## Validation

- `swift test --package-path Core/PeekabooAutomationKit --filter AXTreeCollectorBudgetTests`
- `swift test --package-path Core/PeekabooCore --filter ElementDetectionCacheTests`
- `swift test --package-path Core/PeekabooCore --filter ElementDetectionServiceTests`
- `swift test --package-path Core/PeekabooAutomationKit --filter Observation`
- `swift test --package-path Apps/CLI --filter SeeCommand`
- `pnpm run build:cli`
- `pnpm run test:safe`
