### PR TITLE
docs: prefer ${VAR} over {env:VAR} for custom provider apiKey

### DIFF
--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Core/ConfigCommand+Providers.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Core/ConfigCommand+Providers.swift
@@ -51,7 +51,7 @@ extension ConfigCommand {
               --type openai \\
               --name "OpenRouter" \\
               --base-url "https://openrouter.ai/api/v1" \\
-              --api-key "{env:OPENROUTER_API_KEY}" \\
+              --api-key "${OPENROUTER_API_KEY}" \\
               --description "Access to 300+ models via OpenRouter"
 
             # Add local Ollama with authentication
@@ -66,7 +66,7 @@ extension ConfigCommand {
               --type openai \\
               --name "Groq" \\
               --base-url "https://api.groq.com/openai/v1" \\
-              --api-key "{env:GROQ_API_KEY}"
+              --api-key "${GROQ_API_KEY}"
             """
         )
 
@@ -82,7 +82,7 @@ extension ConfigCommand {
         @Option(name: .long, help: "Base URL for the API endpoint")
         var baseUrl: String
 
-        @Option(name: .long, help: "API key or credential reference (e.g., {env:API_KEY})")
+        @Option(name: .long, help: "API key or credential reference (e.g., ${API_KEY})")
         var apiKey: String
 
         @Option(name: .long, help: "Optional description of the provider")

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Core/ConfigCommand+Providers.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Core/ConfigCommand+Providers.swift
@@ -51,7 +51,7 @@ extension ConfigCommand {
               --type openai \\
               --name "OpenRouter" \\
               --base-url "https://openrouter.ai/api/v1" \\
-              --api-key "${OPENROUTER_API_KEY}" \\
+              --api-key '${OPENROUTER_API_KEY}' \\
               --description "Access to 300+ models via OpenRouter"
 
             # Add local Ollama with authentication
@@ -66,7 +66,7 @@ extension ConfigCommand {
               --type openai \\
               --name "Groq" \\
               --base-url "https://api.groq.com/openai/v1" \\
-              --api-key "${GROQ_API_KEY}"
+              --api-key '${GROQ_API_KEY}'
             """
         )
 

--- a/Apps/Mac/Peekaboo/Features/Settings/AddCustomProviderView.swift
+++ b/Apps/Mac/Peekaboo/Features/Settings/AddCustomProviderView.swift
@@ -455,9 +455,9 @@ private struct ProviderConfigurationStepView: View {
                         SecureFormField(
                             title: "API Key",
                             binding: self.$apiKey,
-                            placeholder: "sk-... or {env:API_KEY}")
+                            placeholder: "sk-... or ${API_KEY}")
                         {
-                            Text("Your API key or environment variable reference")
+                            Text("Your API key or environment variable reference (use ${VAR})")
                                 .foregroundColor(.secondary)
                         }
                     }

--- a/Apps/Mac/Peekaboo/Features/Settings/CustomProviderView.swift
+++ b/Apps/Mac/Peekaboo/Features/Settings/CustomProviderView.swift
@@ -307,7 +307,7 @@ struct EditCustomProviderView: View {
                     HStack {
                         Text("API Key")
                             .frame(width: 100, alignment: .trailing)
-                        TextField("{env:OPENROUTER_API_KEY}", text: self.$apiKey)
+                        TextField("${OPENROUTER_API_KEY}", text: self.$apiKey)
                             .textFieldStyle(.roundedBorder)
                     }
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - `peekaboo agent` and MCP clients now have an `inspect_ui` tool for AX-only UI text/control inspection without capturing screenshots. Thanks @vyctorbrzezowski for #141.
 - Window-mode capture now falls back to desktop-independent ScreenCaptureKit filters when multi-display setups cannot map a window to an enumerated display. Thanks @lonexreb for #147.
 - `peekaboo agent` guidance now routes AX-only observation through `inspect_ui` consistently while keeping screenshot-backed checks on `see`. Thanks @vyctorbrzezowski for #144.
+- Custom provider docs, CLI help, and macOS settings now prefer `${VAR}` API key references and shell examples that preserve them literally. Thanks @scotthuang for #142.
 
 ## [3.2.0] - 2026-05-15
 

--- a/Core/PeekabooCore/Sources/PeekabooAutomation/Configuration/Configuration.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAutomation/Configuration/Configuration.swift
@@ -320,7 +320,9 @@ public struct Configuration: Codable {
     /// including API endpoint, authentication, and request customization.
     public struct ProviderOptions: Codable {
         public let baseURL: String
-        public let apiKey: String // Environment variable reference like {env:API_KEY}
+        // Literal API key or env-var reference, e.g. "${API_KEY}".
+        // Legacy "{env:API_KEY}" form is honored only by the config CLI (see docs/provider.md).
+        public let apiKey: String
         public let headers: [String: String]?
         public let timeout: TimeInterval?
         public let retryAttempts: Int?

--- a/Core/PeekabooCore/Sources/PeekabooAutomation/Configuration/Configuration.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAutomation/Configuration/Configuration.swift
@@ -321,7 +321,7 @@ public struct Configuration: Codable {
     public struct ProviderOptions: Codable {
         public let baseURL: String
         // Literal API key or env-var reference, e.g. "${API_KEY}".
-        // Legacy "{env:API_KEY}" form is honored only by the config CLI (see docs/provider.md).
+        // Legacy "{env:API_KEY}" references remain supported for compatibility.
         public let apiKey: String
         public let headers: [String: String]?
         public let timeout: TimeInterval?

--- a/Core/PeekabooCore/Sources/PeekabooAutomation/Configuration/ConfigurationManager+CustomProviders.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAutomation/Configuration/ConfigurationManager+CustomProviders.swift
@@ -36,7 +36,7 @@ extension ConfigurationManager {
             return (false, "Provider '\(id)' not found")
         }
 
-        guard let apiKey = resolveCredential(provider.options.apiKey) else {
+        guard let apiKey = self.resolveCredentialReference(provider.options.apiKey) else {
             return (false, "API key not found or invalid: \(provider.options.apiKey)")
         }
 
@@ -57,7 +57,7 @@ extension ConfigurationManager {
             return ([], "Provider '\(id)' not found")
         }
 
-        guard let apiKey = resolveCredential(provider.options.apiKey) else {
+        guard let apiKey = self.resolveCredentialReference(provider.options.apiKey) else {
             return ([], "API key not found: \(provider.options.apiKey)")
         }
 
@@ -74,18 +74,29 @@ extension ConfigurationManager {
         }
     }
 
-    private func resolveCredential(_ reference: String) -> String? {
-        guard reference.hasPrefix("{env:"), reference.hasSuffix("}") else {
+    public func resolveCredentialReference(_ reference: String) -> String? {
+        guard let varName = Self.credentialReferenceName(reference) else {
             return reference
         }
 
-        let varName = String(reference.dropFirst(5).dropLast(1))
         if let envValue = self.environmentValue(for: varName) {
             return envValue
         }
-        if let credValue = credentials[varName] {
+        if let credValue = self.credentialValue(for: varName) {
             return credValue
         }
+        return nil
+    }
+
+    static func credentialReferenceName(_ reference: String) -> String? {
+        if reference.hasPrefix("{env:"), reference.hasSuffix("}") {
+            return String(reference.dropFirst(5).dropLast(1))
+        }
+
+        if reference.hasPrefix("${"), reference.hasSuffix("}") {
+            return String(reference.dropFirst(2).dropLast(1))
+        }
+
         return nil
     }
 

--- a/Core/PeekabooCore/Sources/PeekabooAutomation/Configuration/ConfigurationManager+Parsing.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAutomation/Configuration/ConfigurationManager+Parsing.swift
@@ -15,7 +15,7 @@ extension ConfigurationManager {
             let data = try Data(contentsOf: URL(fileURLWithPath: configPath))
             let jsonString = String(data: data, encoding: .utf8) ?? ""
             let cleanedJSON = self.stripJSONComments(from: jsonString)
-            expandedJSON = self.expandEnvironmentVariables(in: cleanedJSON)
+            expandedJSON = self.expandEnvironmentVariables(in: cleanedJSON, preservingKeys: ["apiKey"])
 
             if let expandedData = expandedJSON.data(using: .utf8) {
                 let config = try JSONCoding.decoder.decode(Configuration.self, from: expandedData)
@@ -39,6 +39,11 @@ extension ConfigurationManager {
 
     /// Expand environment variables in the format `${VAR_NAME}`.
     public func expandEnvironmentVariables(in text: String) -> String {
+        self.expandEnvironmentVariables(in: text, preservingKeys: [])
+    }
+
+    /// Expand environment variables in the format `${VAR_NAME}` except in selected JSON string properties.
+    func expandEnvironmentVariables(in text: String, preservingKeys: Set<String>) -> String {
         let pattern = #"\$\{([A-Za-z_][A-Za-z0-9_]*)\}"#
 
         do {
@@ -48,6 +53,12 @@ extension ConfigurationManager {
 
             // Reverse replacement keeps each regex match range valid against the original string.
             for match in regex.matches(in: text, options: [], range: range).reversed() {
+                if let propertyName = self.jsonStringPropertyName(containing: match, in: text),
+                   preservingKeys.contains(propertyName)
+                {
+                    continue
+                }
+
                 let varNameRange = match.range(at: 1)
                 if let swiftRange = Range(varNameRange, in: text) {
                     let varName = String(text[swiftRange])
@@ -63,6 +74,25 @@ extension ConfigurationManager {
         } catch {
             return text
         }
+    }
+
+    private func jsonStringPropertyName(containing match: NSTextCheckingResult, in text: String) -> String? {
+        guard let matchRange = Range(match.range, in: text) else { return nil }
+        let prefix = String(text[..<matchRange.lowerBound])
+        let pattern = #""((?:[^"\\]|\\.)*)"\s*:\s*"((?:[^"\\]|\\.)*)$"#
+
+        guard let regex = try? NSRegularExpression(pattern: pattern, options: [.dotMatchesLineSeparators]) else {
+            return nil
+        }
+
+        let range = NSRange(location: 0, length: prefix.utf16.count)
+        guard let match = regex.matches(in: prefix, options: [], range: range).last,
+              let keyRange = Range(match.range(at: 1), in: prefix)
+        else {
+            return nil
+        }
+
+        return String(prefix[keyRange])
     }
 
     func environmentValue(for key: String) -> String? {

--- a/Core/PeekabooCore/Sources/PeekabooAutomation/Services/AI/PeekabooAIService.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAutomation/Services/AI/PeekabooAIService.swift
@@ -72,7 +72,12 @@ private final class PeekabooCustomProviderModel: ModelProvider, @unchecked Senda
     }
 
     private func openAICompatibleProvider() throws -> OpenAICompatibleProvider {
-        try OpenAICompatibleProvider(
+        guard let apiKey, !apiKey.isEmpty else {
+            throw TachikomaError.authenticationFailed(
+                "API key reference for custom provider '\(self.providerID)' could not be resolved")
+        }
+
+        return try OpenAICompatibleProvider(
             modelId: self.resolvedModelID,
             baseURL: self.baseURL ?? "",
             configuration: self.compatibleConfiguration(),
@@ -80,7 +85,12 @@ private final class PeekabooCustomProviderModel: ModelProvider, @unchecked Senda
     }
 
     private func anthropicCompatibleProvider() throws -> AnthropicCompatibleProvider {
-        try AnthropicCompatibleProvider(
+        guard let apiKey, !apiKey.isEmpty else {
+            throw TachikomaError.authenticationFailed(
+                "API key reference for custom provider '\(self.providerID)' could not be resolved")
+        }
+
+        return try AnthropicCompatibleProvider(
             modelId: self.resolvedModelID,
             baseURL: self.baseURL ?? "",
             configuration: self.compatibleConfiguration(),
@@ -416,7 +426,7 @@ public final class PeekabooAIService {
         }
     }
 
-    private func tachikomaConfiguration(for model: LanguageModel) -> TachikomaConfiguration {
+    func tachikomaConfiguration(for model: LanguageModel) -> TachikomaConfiguration {
         guard case let .custom(provider) = model,
               let peekabooProvider = provider as? PeekabooCustomProviderModel
         else {
@@ -424,6 +434,14 @@ public final class PeekabooAIService {
         }
 
         let configuration = TachikomaConfiguration(loadFromEnvironment: true)
+        configuration.setProviderFactoryOverride { selectedModel, baseConfiguration in
+            if case let .custom(selectedProvider) = selectedModel,
+               selectedProvider.modelId == peekabooProvider.modelId
+            {
+                return peekabooProvider
+            }
+            return try ProviderFactory.createProvider(for: selectedModel, configuration: baseConfiguration)
+        }
         guard let apiKey = peekabooProvider.apiKey, !apiKey.isEmpty else {
             return configuration
         }
@@ -455,28 +473,14 @@ public final class PeekabooAIService {
         case .anthropic: .anthropic
         }
 
-        CustomProviderRegistry.shared.loadFromProfile()
-
         return PeekabooCustomProviderModel(
             providerID: providerID,
             resolvedModelID: resolvedModelID,
             kind: kind,
             baseURL: provider.options.baseURL,
-            apiKey: self.resolveCredential(provider.options.apiKey, configuration: configuration),
+            apiKey: configuration.resolveCredentialReference(provider.options.apiKey),
             additionalHeaders: provider.options.headers ?? [:],
             supportsVision: model?.supportsVision ?? true)
-    }
-
-    private static func resolveCredential(_ reference: String, configuration: ConfigurationManager) -> String? {
-        guard reference.hasPrefix("{env:"), reference.hasSuffix("}") else {
-            return reference
-        }
-
-        let variableName = String(reference.dropFirst(5).dropLast(1))
-        if let environmentValue = ProcessInfo.processInfo.environment[variableName] {
-            return environmentValue
-        }
-        return configuration.credentialValue(for: variableName)
     }
 
     nonisolated static func normalizeCoordinateTextIfNeeded(

--- a/Core/PeekabooCore/Tests/PeekabooTests/ConfigurationEnvironmentTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/ConfigurationEnvironmentTests.swift
@@ -6,6 +6,7 @@ import Testing
 @testable import PeekabooCore
 @testable import PeekabooVisualizer
 
+@Suite(.serialized)
 struct ConfigurationManagerEnvironmentTests {
     private let manager = ConfigurationManager.shared
 
@@ -104,6 +105,60 @@ struct ConfigurationManagerEnvironmentTests {
             #expect(self.manager.getSelectedProvider() == "google")
         }
     }
+
+    @Test
+    func `custom provider apiKey env references stay literal when config is saved`() throws {
+        let key = "PEEKABOO_CUSTOM_PROVIDER_KEY"
+        setenv(key, "secret-that-must-not-be-written", 1)
+        defer { unsetenv(key) }
+
+        try withIsolatedConfigurationEnvironment { configDir in
+            let configPath = configDir.appendingPathComponent("config.json")
+            let configJSON = """
+            {
+              "customProviders": {
+                "openrouter": {
+                  "name": "OpenRouter",
+                  "type": "openai",
+                  "options": {
+                    "baseURL": "https://openrouter.ai/api/v1",
+                    "apiKey": "${\(key)}"
+                  },
+                  "enabled": true
+                }
+              }
+            }
+            """
+            try configJSON.write(to: configPath, atomically: true, encoding: .utf8)
+
+            self.manager.resetForTesting()
+            let config = self.manager.loadConfiguration()
+            #expect(config?.customProviders?["openrouter"]?.options.apiKey == "${\(key)}")
+
+            let provider = Configuration.CustomProvider(
+                name: "Other",
+                type: .openai,
+                options: .init(baseURL: "https://api.example.com/v1", apiKey: "literal-key"))
+            try self.manager.addCustomProvider(provider, id: "other")
+
+            let saved = try String(contentsOf: configPath, encoding: .utf8)
+            #expect(saved.contains("${\(key)}"))
+            #expect(!saved.contains("secret-that-must-not-be-written"))
+        }
+    }
+
+    @Test
+    func `credential references resolve shell style and legacy env forms`() throws {
+        try withIsolatedConfigurationEnvironment { _ in
+            unsetenv("PEEKABOO_STORED_PROVIDER_KEY")
+            self.manager.resetForTesting()
+            try self.manager.saveCredentials(["PEEKABOO_STORED_PROVIDER_KEY": "stored-secret"])
+
+            #expect(self.manager.resolveCredentialReference("${PEEKABOO_STORED_PROVIDER_KEY}") == "stored-secret")
+            #expect(self.manager.resolveCredentialReference("{env:PEEKABOO_STORED_PROVIDER_KEY}") == "stored-secret")
+            #expect(self.manager.resolveCredentialReference("literal-secret") == "literal-secret")
+        }
+    }
 }
 
 private func withIsolatedConfigurationEnvironment(_ body: (URL) throws -> Void) throws {
@@ -113,7 +168,9 @@ private func withIsolatedConfigurationEnvironment(_ body: (URL) throws -> Void) 
     try fileManager.createDirectory(at: configDir, withIntermediateDirectories: true)
 
     let previousConfigDir = getenv("PEEKABOO_CONFIG_DIR").map { String(cString: $0) }
+    let previousDisableMigration = getenv("PEEKABOO_CONFIG_DISABLE_MIGRATION").map { String(cString: $0) }
     setenv("PEEKABOO_CONFIG_DIR", configDir.path, 1)
+    setenv("PEEKABOO_CONFIG_DISABLE_MIGRATION", "1", 1)
     ConfigurationManager.shared.resetForTesting()
 
     defer {
@@ -121,6 +178,11 @@ private func withIsolatedConfigurationEnvironment(_ body: (URL) throws -> Void) 
             setenv("PEEKABOO_CONFIG_DIR", previousConfigDir, 1)
         } else {
             unsetenv("PEEKABOO_CONFIG_DIR")
+        }
+        if let previousDisableMigration {
+            setenv("PEEKABOO_CONFIG_DISABLE_MIGRATION", previousDisableMigration, 1)
+        } else {
+            unsetenv("PEEKABOO_CONFIG_DISABLE_MIGRATION")
         }
         ConfigurationManager.shared.resetForTesting()
         try? fileManager.removeItem(at: configDir)

--- a/Core/PeekabooCore/Tests/PeekabooTests/PeekabooAIServiceProviderTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/PeekabooAIServiceProviderTests.swift
@@ -53,6 +53,114 @@ struct PeekabooAIServiceProviderTests {
 
     @Test
     @MainActor
+    func `Custom provider generation uses resolved Peekaboo provider credentials`() throws {
+        try self.withIsolatedEnvironment(
+            ["PEEKABOO_CUSTOM_PROVIDER_KEY": "resolved-secret"],
+            configurationJSON: """
+            {
+              "aiProviders": { "providers": "local-proxy/mini" },
+              "customProviders": {
+                "local-proxy": {
+                  "name": "Local Proxy",
+                  "type": "openai",
+                  "enabled": true,
+                  "options": {
+                    "baseURL": "http://localhost:8317/v1",
+                    "apiKey": "${PEEKABOO_CUSTOM_PROVIDER_KEY}"
+                  },
+                  "models": {
+                    "mini": {
+                      "name": "gpt-5.4-mini",
+                      "supportsVision": true
+                    }
+                  }
+                }
+              }
+            }
+            """) {
+                let tempHome = FileManager.default.temporaryDirectory
+                    .appendingPathComponent("peekaboo-home-\(UUID().uuidString)", isDirectory: true)
+                let profileDir = tempHome.appendingPathComponent(".peekaboo", isDirectory: true)
+                try FileManager.default.createDirectory(at: profileDir, withIntermediateDirectories: true)
+                try """
+                {
+                  "customProviders": {
+                    "local-proxy": {
+                      "type": "openai",
+                      "options": {
+                        "baseURL": "http://localhost:8317/v1",
+                        "apiKey": "${PEEKABOO_CUSTOM_PROVIDER_KEY}"
+                      }
+                    }
+                  }
+                }
+                """.write(to: profileDir.appendingPathComponent("config.json"), atomically: true, encoding: .utf8)
+
+                let previousHome = getenv("HOME").map { String(cString: $0) }
+                setenv("HOME", tempHome.path, 1)
+                CustomProviderRegistry.shared.loadFromProfile()
+                defer {
+                    try? "{}".write(
+                        to: profileDir.appendingPathComponent("config.json"),
+                        atomically: true,
+                        encoding: .utf8)
+                    CustomProviderRegistry.shared.loadFromProfile()
+                    if let previousHome {
+                        setenv("HOME", previousHome, 1)
+                    } else {
+                        unsetenv("HOME")
+                    }
+                    try? FileManager.default.removeItem(at: tempHome)
+                }
+
+                let service = PeekabooAIService()
+                let model = try #require(service.availableModels().first)
+                let provider = try service.tachikomaConfiguration(for: model).makeProvider(for: model)
+
+                #expect(String(describing: type(of: provider)).contains("PeekabooCustomProviderModel"))
+                #expect(Mirror(reflecting: provider).descendant("apiKey") as? String == "resolved-secret")
+            }
+    }
+
+    @Test
+    @MainActor
+    func `Custom provider unresolved references do not fall back to generic compatible keys`() async throws {
+        try await self.withIsolatedEnvironment(
+            ["API_KEY": "wrong-generic-key"],
+            configurationJSON: """
+            {
+              "aiProviders": { "providers": "local-proxy/mini" },
+              "customProviders": {
+                "local-proxy": {
+                  "name": "Local Proxy",
+                  "type": "openai",
+                  "enabled": true,
+                  "options": {
+                    "baseURL": "http://127.0.0.1:9/v1",
+                    "apiKey": "${PEEKABOO_MISSING_PROVIDER_KEY}"
+                  },
+                  "models": {
+                    "mini": {
+                      "name": "gpt-5.4-mini",
+                      "supportsVision": true
+                    }
+                  }
+                }
+              }
+            }
+            """) {
+                let service = PeekabooAIService()
+                let model = try #require(service.availableModels().first)
+                let provider = try service.tachikomaConfiguration(for: model).makeProvider(for: model)
+
+                await #expect(throws: TachikomaError.self) {
+                    _ = try await provider.generateText(request: ProviderRequest(messages: [.user("hello")]))
+                }
+            }
+    }
+
+    @Test
+    @MainActor
     func `Falls back to Gemini when only Gemini key is present`() throws {
         try self.withIsolatedEnvironment(["GEMINI_API_KEY": "key"]) {
             let service = PeekabooAIService()
@@ -279,6 +387,9 @@ struct PeekabooAIServiceProviderTests {
             "GEMINI_API_KEY",
             "GOOGLE_API_KEY",
             "MINIMAX_API_KEY",
+            "API_KEY",
+            "PEEKABOO_CUSTOM_PROVIDER_KEY",
+            "PEEKABOO_MISSING_PROVIDER_KEY",
             "PEEKABOO_OLLAMA_BASE_URL",
             "OLLAMA_BASE_URL",
         ]
@@ -338,6 +449,9 @@ struct PeekabooAIServiceProviderTests {
             "GEMINI_API_KEY",
             "GOOGLE_API_KEY",
             "MINIMAX_API_KEY",
+            "API_KEY",
+            "PEEKABOO_CUSTOM_PROVIDER_KEY",
+            "PEEKABOO_MISSING_PROVIDER_KEY",
             "PEEKABOO_OLLAMA_BASE_URL",
             "OLLAMA_BASE_URL",
         ]

--- a/docs/commands/config.md
+++ b/docs/commands/config.md
@@ -45,7 +45,7 @@ peekaboo config add-provider openrouter \
   --type openai \
   --name "OpenRouter" \
   --base-url https://openrouter.ai/api/v1 \
-  --api-key "{env:OPENROUTER_API_KEY}" --force
+  --api-key "${OPENROUTER_API_KEY}" --force
 peekaboo config test-provider --provider-id openrouter
 
 # Add and validate keys (stores even if validation fails; warns on failure)

--- a/docs/commands/config.md
+++ b/docs/commands/config.md
@@ -45,7 +45,7 @@ peekaboo config add-provider openrouter \
   --type openai \
   --name "OpenRouter" \
   --base-url https://openrouter.ai/api/v1 \
-  --api-key "${OPENROUTER_API_KEY}" --force
+  --api-key '${OPENROUTER_API_KEY}' --force
 peekaboo config test-provider --provider-id openrouter
 
 # Add and validate keys (stores even if validation fails; warns on failure)

--- a/docs/provider.md
+++ b/docs/provider.md
@@ -54,7 +54,7 @@ Custom providers are configured in `~/.peekaboo/config.json`:
       "type": "openai",
       "options": {
         "baseURL": "https://openrouter.ai/api/v1",
-        "apiKey": "{env:OPENROUTER_API_KEY}",
+        "apiKey": "${OPENROUTER_API_KEY}",
         "headers": {
           "HTTP-Referer": "https://peekaboo.app",
           "X-Title": "Peekaboo"
@@ -89,6 +89,7 @@ Custom providers are configured in `~/.peekaboo/config.json`:
 - Peekaboo never copies environment values into files automatically. Env vars are read live and shown as `ready (env)` in `config show/init`.
 - Credentials you add manually are stored in `~/.peekaboo/credentials` with `chmod 600`.
 - OAuth (OpenAI/Codex, Anthropic Max) stores refresh/access tokens + expiry in the credentials file; no API key is written.
+- In `customProviders[*].options.apiKey`, prefer the shell-style `${VAR}` form for env-var references — it is expanded by the runtime that talks to the model. The legacy `{env:VAR}` form is only honored by the `config` CLI.
 
 ```bash
 # Set API key (stored after validation)
@@ -257,7 +258,7 @@ Define available models with capabilities:
 ```json
 "options": {
   "baseURL": "https://api.provider.com/v1",
-  "apiKey": "{env:API_KEY}",
+  "apiKey": "${API_KEY}",
   "timeout": 30,
   "retryAttempts": 3,
   "headers": {},
@@ -306,7 +307,7 @@ peekaboo config validate
 
 - API keys are stored separately in `~/.peekaboo/credentials` (chmod 600)
 - Never commit API keys to configuration files
-- Use environment variable references: `{env:API_KEY}`
+- Use environment variable references: `${API_KEY}`
 - Rotate API keys regularly
 - Use least-privilege API keys when available
 

--- a/docs/provider.md
+++ b/docs/provider.md
@@ -89,7 +89,7 @@ Custom providers are configured in `~/.peekaboo/config.json`:
 - Peekaboo never copies environment values into files automatically. Env vars are read live and shown as `ready (env)` in `config show/init`.
 - Credentials you add manually are stored in `~/.peekaboo/credentials` with `chmod 600`.
 - OAuth (OpenAI/Codex, Anthropic Max) stores refresh/access tokens + expiry in the credentials file; no API key is written.
-- In `customProviders[*].options.apiKey`, prefer the shell-style `${VAR}` form for env-var references — it is expanded by the runtime that talks to the model. The legacy `{env:VAR}` form is only honored by the `config` CLI.
+- In `customProviders[*].options.apiKey`, prefer the shell-style `${VAR}` form for env-var references — it is expanded by the runtime that talks to the model. When passing this through a shell command, quote it as `'${VAR}'` so the literal reference is saved. The legacy `{env:VAR}` form is only honored by the `config` CLI.
 
 ```bash
 # Set API key (stored after validation)
@@ -307,7 +307,7 @@ peekaboo config validate
 
 - API keys are stored separately in `~/.peekaboo/credentials` (chmod 600)
 - Never commit API keys to configuration files
-- Use environment variable references: `${API_KEY}`
+- Use environment variable references: `${API_KEY}` in JSON, or `'${API_KEY}'` in shell commands
 - Rotate API keys regularly
 - Use least-privilege API keys when available
 

--- a/docs/provider.md
+++ b/docs/provider.md
@@ -89,7 +89,7 @@ Custom providers are configured in `~/.peekaboo/config.json`:
 - Peekaboo never copies environment values into files automatically. Env vars are read live and shown as `ready (env)` in `config show/init`.
 - Credentials you add manually are stored in `~/.peekaboo/credentials` with `chmod 600`.
 - OAuth (OpenAI/Codex, Anthropic Max) stores refresh/access tokens + expiry in the credentials file; no API key is written.
-- In `customProviders[*].options.apiKey`, prefer the shell-style `${VAR}` form for env-var references — it is expanded by the runtime that talks to the model. When passing this through a shell command, quote it as `'${VAR}'` so the literal reference is saved. The legacy `{env:VAR}` form is only honored by the `config` CLI.
+- In `customProviders[*].options.apiKey`, prefer the shell-style `${VAR}` form for env-var references — it is resolved by the runtime that talks to the model. When passing this through a shell command, quote it as `'${VAR}'` so the literal reference is saved. The legacy `{env:VAR}` form remains supported for compatibility.
 
 ```bash
 # Set API key (stored after validation)


### PR DESCRIPTION
## Why

The custom-provider docs and UI hints currently mix two different env-var
reference syntaxes for `customProviders[*].options.apiKey`:

- `${VAR}` — shell-style, expanded by the Tachikoma custom-provider
  loader before the JSON is parsed. Honored everywhere, including the
  agent / vision runtime (`peekaboo agent`, `peekaboo image --analyze`,
  `peekaboo see`).
- `{env:VAR}` — Peekaboo-specific, expanded by `ConfigurationManager`'s
  `resolveCredential`. Honored only by the `peekaboo config` subcommands
  (`show`, `test-provider`, `models`, etc.) that go through that path.

Today the published examples in `docs/provider.md`, `docs/commands/config.md`,
the Mac settings placeholders, the `add-provider --help` text, and the
inline source comment on `ProviderOptions.apiKey` all use `{env:VAR}`.
Users following those examples end up with the literal string
`{env:MY_KEY}` being forwarded to the upstream provider as the API key,
which surfaces as a confusing "API key format is incorrect" / 401 error
that's hard to attribute to a docs problem.

`docs/commands/config.md` also already states that the loader
"interpolates `${VAR}` placeholders", which directly contradicts its own
example a few lines below.

## What this PR changes

Docs and surface-level strings only. **No runtime behavior change.**

- `docs/provider.md` — JSON examples and the security checklist switch
  to `${VAR}`. A one-line note in *Environment Variables vs Credentials*
  documents which form is honored where.
- `docs/commands/config.md` — example `--api-key "{env:...}"` →
  `"${...}"`, removing the internal contradiction.
- `Apps/CLI/.../ConfigCommand+Providers.swift` — `add-provider --help`
  examples and the `--api-key` flag help text.
- `Apps/Mac/.../AddCustomProviderView.swift`,
  `Apps/Mac/.../CustomProviderView.swift` — settings placeholders.
- `Core/.../Configuration.swift` — single-line comment on `apiKey`
  mentions both forms and points back to `docs/provider.md`.

## What this PR does not change

- `ConfigurationManager.resolveCredential` and `PeekabooAIService.resolveCredential`
  still recognize `{env:VAR}` for back-compat.
- The unit / integration tests that exercise the `{env:VAR}` parser are
  intentionally untouched (they're testing that parser, not user-facing
  guidance).
- No submodule pointers moved.

## Verification

- `swift build --package-path Apps/CLI` — clean build (debug, arm64).
- End-to-end smoke test against ByteDance Volcengine Ark (OpenAI-compat
  endpoint, `doubao-seed-2.0-pro`):

  ```jsonc
  // ~/.peekaboo/config.json
  "customProviders": {
    "volcengine": {
      "type": "openai",
      "enabled": true,
      "options": {
        "baseURL": "https://ark.cn-beijing.volces.com/api/plan/v3",
        "apiKey": "${ARK_API_KEY}"
      },
      "models": {
        "doubao-seed-2.0-pro": { "name": "doubao-seed-2.0-pro", "supportsVision": true }
      }
    }
  }
