### PR TITLE
fix(agent): align observation guidance with inspect_ui

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - AX element detection now honors traversal budgets and reports truncation when depth, count, or per-node child limits are reached. Thanks @vyctorbrzezowski for #140.
 - `peekaboo agent` and MCP clients now have an `inspect_ui` tool for AX-only UI text/control inspection without capturing screenshots. Thanks @vyctorbrzezowski for #141.
 - Window-mode capture now falls back to desktop-independent ScreenCaptureKit filters when multi-display setups cannot map a window to an enumerated display. Thanks @lonexreb for #147.
+- `peekaboo agent` guidance now routes AX-only observation through `inspect_ui` consistently while keeping screenshot-backed checks on `see`. Thanks @vyctorbrzezowski for #144.
 
 ## [3.2.0] - 2026-05-15
 

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/Agent/Tools/AgentSystemPrompt.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/Agent/Tools/AgentSystemPrompt.swift
@@ -45,14 +45,14 @@ public struct AgentSystemPrompt {
 
         For ANY calculation or math problem:
         1. Use the `app` tool with action "launch" and name "Calculator".
-        2. Use `see` to capture the Calculator interface.
+        2. Use `inspect_ui` to read Calculator controls, or `see` if visual layout is needed.
         3. Use `click` to press the calculator buttons.
         4. Read the result from the display.
 
         Other common tool usage:
-        - Screenshots → always use `see`.
+        - Observation → choose `browser`, `inspect_ui`, or `see` based on the target surface.
         - UI interaction → use `click`, `type`, `scroll`.
-        - Information gathering → use `list`, `analyze`.
+        - Information gathering → use `list`, `inspect_ui`, or `analyze` based on the information source.
 
         NEVER provide calculated results directly—always go through the Calculator app.
 
@@ -63,12 +63,17 @@ public struct AgentSystemPrompt {
         4. **Error Recovery** – Learn from failures and adapt your approach.
 
         **Task Execution Guidelines**
-        - Start with the `see` tool to understand the current UI state (e.g.,
-          `{ "app_target": "Safari" }`).
-        - First call `see` to get the latest state before other UI actions. Treat element IDs from `see` as valid
-          only for the current visible state; after any mutating action, use the action result or fetch fresh state
-          to verify the UI changed as expected.
-        - `see` accepts an `app_target` field to capture and focus background apps—use it instead of CLI syntax.
+        - Before acting on the UI, get fresh state with the observation tool appropriate to the target surface.
+        - Use `browser` for Chrome page content, forms, DOM/a11y snapshots, console, network, page screenshots,
+          and performance traces.
+        - Use `inspect_ui` for native macOS UI text, labels, buttons, text fields, control state, and element IDs
+          when you do not need a visual screenshot.
+        - Use `see` for desktop/app screenshots, visual layout, images, colors, pixels, coordinates, screen-level
+          targets, menu bar targets, or when accessibility text is missing or incomplete.
+        - Treat element IDs from `see` or `inspect_ui` as valid only for the current visible state; after any mutating
+          action, use the action result or fetch fresh state to verify the UI changed as expected.
+        - `see` accepts an `app_target` field to capture and focus background apps; `inspect_ui` accepts the same
+          field for AX-only inspection. Use structured JSON instead of CLI syntax.
         - Prefer element-targeted interactions over coordinate clicks when an element ID is available.
         - Prefer `set_value` for form fields when replacing the whole value; use `type` when observable keystrokes,
           autocomplete, IME behavior, or key actions matter.
@@ -97,9 +102,10 @@ public struct AgentSystemPrompt {
         - End with a final summary.
 
         **Screenshot Requests**
-        1. Immediately call `see` with the appropriate parameters.
-        2. Never claim you cannot capture the screen—the tool gives you access.
-        3. Only fall back to instructions if `see` fails.
+        1. For desktop or native app screenshots, call `see` with the appropriate parameters.
+        2. For Chrome page screenshots, prefer `browser` when Chrome DevTools MCP is available.
+        3. Never claim you cannot capture the screen—the tools give you access.
+        4. Only fall back to instructions if the appropriate observation tool fails.
         """
     }
 
@@ -124,7 +130,8 @@ public struct AgentSystemPrompt {
         3. Launch applications with the `launch_app` tool: `{ "name": "Safari" }`.
         4. Use the `list` tool with `{ "item_type": "application_windows", "app": "Safari" }`
            again to confirm the window exists.
-        5. Capture background apps with `see` using `{ "app_target": "Safari" }`.
+        5. Observe background apps with `inspect_ui` when AX-only text/control state is enough, or `see` when a
+           screenshot is needed, using `{ "app_target": "Safari" }`.
         6. Use the `window` tool for focus/move/resize operations, always specifying
            `{ "action": "focus", "app": "Google Chrome" }` (or the relevant action plus identifiers).
 
@@ -140,7 +147,8 @@ public struct AgentSystemPrompt {
     private static func dialogSection() -> String {
         """
         **Dialog Interaction**
-        1. Capture the dialog with `see` to identify controls.
+        1. Inspect the dialog with `inspect_ui` when text/control state is enough, or `see` when visual layout
+           matters.
         2. Use the `dialog` tool with action "click" for standard buttons.
         3. Use the `dialog` tool with action "input" for text fields.
         4. If dialog helpers fail, fall back to precise `click` commands.
@@ -157,10 +165,10 @@ public struct AgentSystemPrompt {
         """
         **Browser Automation**
         - When the target is Google Chrome and the task concerns page content, forms, DOM/a11y snapshots,
-          console, network, screenshots, or performance, prefer the `browser` tool.
+          console, network, page screenshots, or performance, prefer the `browser` tool.
         - Start with `browser` action `status`. If it is not connected, use `connect` only after the user
           has enabled Chrome remote debugging and accepted Chrome's prompt.
-        - Use native Peekaboo tools (`see`, `click`, `type`, `menu`, `dialog`, `window`) for macOS UI,
+        - Use native Peekaboo tools (`inspect_ui`, `see`, `click`, `type`, `menu`, `dialog`, `window`) for macOS UI,
           browser chrome, permissions, menus, dialogs, and non-browser apps.
         - If `browser` fails or is unavailable, fall back to native Peekaboo screen/AX tools.
         """
@@ -169,7 +177,7 @@ public struct AgentSystemPrompt {
     private static func toolUsageSection() -> String {
         """
         **Error Recovery**
-        - Refresh the view with `see` if an element is missing.
+        - Refresh the view with the appropriate observation tool if an element is missing.
         - Try menu paths or hotkeys when clicks fail.
         - Check for hidden dialogs when a window does not respond.
         - Provide specific error details so the user understands the issue.
@@ -198,7 +206,7 @@ public struct AgentSystemPrompt {
         - Avoid redundant captures if the UI has not changed.
         - Skip `sleep` unless a flow explicitly requires a delay—each agent turn already incurs network/runtime
           latency, so extra sleeps rarely help. When you need to wait, prefer the `sleep` tool or use UI cues (new
-          elements in `see`, updated window listings) instead of hard-coded pauses.
+          elements from `inspect_ui` or `see`, updated window listings) instead of hard-coded pauses.
 
         Remember: you are an automation expert. Be confident, helpful, and focused on
         completing the task.

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/ClickTool.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/ClickTool.swift
@@ -216,7 +216,7 @@ public struct ClickTool: MCPTool {
         ]
         if let invalidatedSnapshotId {
             metaDict["invalidated_snapshot"] = .string(invalidatedSnapshotId)
-            metaDict["requires_fresh_see"] = .bool(true)
+            metaDict["requires_fresh_observation"] = .bool(true)
         }
         if let processId = effectiveTargetProcessIdentifier.map({ Int32($0) }) {
             metaDict["target_pid"] = .double(Double(processId))

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/ClickTool.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/ClickTool.swift
@@ -15,7 +15,7 @@ public struct ClickTool: MCPTool {
     public var description: String {
         """
         Clicks on UI elements or coordinates.
-        Supports element queries, specific IDs from see command, or raw coordinates.
+        Supports element queries, specific IDs from `see` or `inspect_ui`, or raw coordinates.
         Includes smart waiting for elements to become actionable.
         \(PeekabooMCPVersion.banner) using openai/gpt-5.5, anthropic/claude-opus-4-7
         """
@@ -30,7 +30,7 @@ public struct ClickTool: MCPTool {
                     """),
                 "on": SchemaBuilder.string(
                     description: """
-                    Optional. Element ID to click (e.g., B1, T2) from see command output.
+                    Optional. Element ID to click (e.g., B1, T2) from `see` or `inspect_ui` output.
                     """),
                 "coords": SchemaBuilder.string(
                     description: """
@@ -38,7 +38,7 @@ public struct ClickTool: MCPTool {
                     """),
                 "snapshot": SchemaBuilder.string(
                     description: """
-                    Optional. Snapshot ID from see command. Uses latest snapshot if not specified.
+                    Optional. Snapshot ID from `see` or `inspect_ui`. Uses latest snapshot if not specified.
                     """),
                 "wait_for": SchemaBuilder.number(
                     description: """
@@ -252,7 +252,7 @@ public struct ClickTool: MCPTool {
 
     private func requireSnapshot(id: String?) async throws -> UISnapshot {
         guard let snapshot = await self.getSnapshot(id: id) else {
-            throw ClickToolError("No active snapshot. Run 'see' command first to capture UI state.")
+            throw ClickToolError("No active snapshot. Run 'see' or 'inspect_ui' first to capture UI state.")
         }
         return snapshot
     }
@@ -260,7 +260,7 @@ public struct ClickTool: MCPTool {
     private func requireElement(id: String, snapshot: UISnapshot) async throws -> UIElement {
         guard let element = await snapshot.getElement(byId: id) else {
             throw ClickToolError(
-                "Element '\(id)' not found in current snapshot. Run 'see' command to update UI state.")
+                "Element '\(id)' not found in current snapshot. Run 'see' or 'inspect_ui' to update UI state.")
         }
         return element
     }

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/DragTool+Resolution.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/DragTool+Resolution.swift
@@ -13,7 +13,8 @@ extension DragTool {
             return DragPointDescription(point: point, description: "(\(Int(point.x)), \(Int(point.y)))")
         case let .element(query):
             guard let snapshot = await self.getSnapshot(id: snapshotId) else {
-                throw CoordinateParseError(message: "No active snapshot. Run 'see' command first to capture UI state.")
+                throw CoordinateParseError(
+                    message: "No active snapshot. Run 'see' or 'inspect_ui' first to capture UI state.")
             }
             if let element = await snapshot.getElement(byId: query) {
                 return DragPointDescription(

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/DragTool.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/DragTool.swift
@@ -34,7 +34,8 @@ public struct DragTool: MCPTool {
                 "to_app": SchemaBuilder.string(
                     description: "Optional. Target application name when dragging between apps"),
                 "snapshot": SchemaBuilder.string(
-                    description: "Optional. Snapshot ID from see command. Uses latest snapshot if not specified"),
+                    description: "Optional. Snapshot ID from `see` or `inspect_ui`. " +
+                        "Uses latest snapshot if not specified"),
                 "duration": SchemaBuilder.number(
                     description: "Optional. Duration in milliseconds (default: 500)",
                     default: 500),

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/MoveTool+Execution.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/MoveTool+Execution.swift
@@ -30,11 +30,13 @@ extension MoveTool {
             return ResolvedMoveTarget(location: location, description: summary)
         case let .element(elementId):
             guard let snapshot = await self.getSnapshot(id: request.snapshotId) else {
-                throw MoveToolValidationError("No active snapshot. Run 'see' command first to capture UI state.")
+                throw MoveToolValidationError(
+                    "No active snapshot. Run 'see' or 'inspect_ui' first to capture UI state.")
             }
             guard let element = await snapshot.getElement(byId: elementId) else {
                 throw MoveToolValidationError(
-                    "Element '\(elementId)' not found in current snapshot. Run 'see' command to update UI state.")
+                    "Element '\(elementId)' not found in current snapshot. " +
+                        "Run 'see' or 'inspect_ui' to update UI state.")
             }
             let location = CGPoint(x: element.frame.midX, y: element.frame.midY)
             let label = element.title ?? element.label ?? "untitled"

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/MoveTool.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/MoveTool.swift
@@ -29,9 +29,10 @@ public struct MoveTool: MCPTool {
                 "coordinates": SchemaBuilder.string(
                     description: "Optional. Alias for 'to' - coordinates in format 'x,y' (e.g., '100,200')."),
                 "id": SchemaBuilder.string(
-                    description: "Optional. Element ID to move to (from see command output)."),
+                    description: "Optional. Element ID to move to (from `see` or `inspect_ui` output)."),
                 "snapshot": SchemaBuilder.string(
-                    description: "Optional. Snapshot ID from see command. Uses latest snapshot if not specified."),
+                    description: "Optional. Snapshot ID from `see` or `inspect_ui`. " +
+                        "Uses latest snapshot if not specified."),
                 "center": SchemaBuilder.boolean(
                     description: "Optional. Move to center of screen.",
                     default: false),

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/PerformActionTool.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/PerformActionTool.swift
@@ -14,7 +14,7 @@ public struct PerformActionTool: MCPTool {
     public var description: String {
         """
         Invokes a named accessibility action on an element, such as AXPress or AXShowMenu.
-        Use with element IDs from see when a semantic action is available.
+        Use with element IDs from `see` or `inspect_ui` when a semantic action is available.
         \(PeekabooMCPVersion.banner) using openai/gpt-5.5, anthropic/claude-opus-4-7
         """
     }
@@ -23,11 +23,12 @@ public struct PerformActionTool: MCPTool {
         SchemaBuilder.object(
             properties: [
                 "on": SchemaBuilder.string(
-                    description: "Element ID from see output, such as B1, or a query string."),
+                    description: "Element ID from `see` or `inspect_ui` output, such as B1, or a query string."),
                 "action": SchemaBuilder.string(
                     description: "Accessibility action name to invoke, e.g. AXPress, AXShowMenu, AXIncrement."),
                 "snapshot": SchemaBuilder.string(
-                    description: "Optional. Snapshot ID from see command. Uses latest snapshot if not specified."),
+                    description: "Optional. Snapshot ID from `see` or `inspect_ui`. " +
+                        "Uses latest snapshot if not specified."),
             ],
             required: ["on", "action"])
     }
@@ -68,7 +69,8 @@ public struct PerformActionTool: MCPTool {
     private func effectiveSnapshotId(_ requestedSnapshotId: String?) async throws -> String? {
         if let requestedSnapshotId {
             guard let snapshot = await UISnapshotManager.shared.getSnapshot(id: requestedSnapshotId) else {
-                throw PerformActionToolError("Snapshot '\(requestedSnapshotId)' not found. Run 'see' again.")
+                throw PerformActionToolError(
+                    "Snapshot '\(requestedSnapshotId)' not found. Run 'see' or 'inspect_ui' again.")
             }
             return snapshot.id
         }

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/PerformActionTool.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/PerformActionTool.swift
@@ -101,7 +101,7 @@ public struct PerformActionTool: MCPTool {
         }
         if let invalidatedSnapshotId {
             meta["invalidated_snapshot"] = .string(invalidatedSnapshotId)
-            meta["requires_fresh_see"] = .bool(true)
+            meta["requires_fresh_observation"] = .bool(true)
         }
 
         return ToolResponse.text(message, meta: .object(meta))

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/ScrollTool.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/ScrollTool.swift
@@ -144,7 +144,7 @@ public struct ScrollTool: MCPTool {
         var baseMeta: [String: Value] = [:]
         if let invalidatedSnapshotId {
             baseMeta["invalidated_snapshot"] = .string(invalidatedSnapshotId)
-            baseMeta["requires_fresh_see"] = .bool(true)
+            baseMeta["requires_fresh_observation"] = .bool(true)
         }
         let meta = baseMeta.isEmpty ? nil : Value.object(baseMeta)
         return ToolResponse.text(message, meta: ToolEventSummary.merge(summary: summary, into: meta))

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/ScrollTool.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/ScrollTool.swift
@@ -31,10 +31,11 @@ public struct ScrollTool: MCPTool {
                     description: "Scroll direction: up (content moves up), down (content moves down), left, or right.",
                     enum: ["up", "down", "left", "right"]),
                 "on": SchemaBuilder.string(
-                    description: "Optional. Element ID to scroll on (from see command). " +
+                    description: "Optional. Element ID to scroll on (from `see` or `inspect_ui`). " +
                         "If not specified, scrolls at current mouse position."),
                 "snapshot": SchemaBuilder.string(
-                    description: "Optional. Snapshot ID from see command. Uses latest snapshot if not specified."),
+                    description: "Optional. Snapshot ID from `see` or `inspect_ui`. " +
+                        "Uses latest snapshot if not specified."),
                 "amount": SchemaBuilder.number(
                     description: "Optional. Number of scroll ticks/lines. Default: 3.",
                     default: 3),
@@ -160,12 +161,12 @@ public struct ScrollTool: MCPTool {
         }
 
         guard let snapshot = await self.getSnapshot(id: request.snapshotId) else {
-            throw ScrollToolValidationError("No active snapshot. Run 'see' command first to capture UI state.")
+            throw ScrollToolValidationError("No active snapshot. Run 'see' or 'inspect_ui' first to capture UI state.")
         }
 
         guard let element = await snapshot.getElement(byId: elementId) else {
             throw ScrollToolValidationError(
-                "Element '\(elementId)' not found in current snapshot. Run 'see' command to update UI state.")
+                "Element '\(elementId)' not found in current snapshot. Run 'see' or 'inspect_ui' to update UI state.")
         }
 
         let label = element.title ?? element.label ?? "untitled"

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/SetValueTool.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/SetValueTool.swift
@@ -14,7 +14,7 @@ public struct SetValueTool: MCPTool {
     public var description: String {
         """
         Sets an accessibility element value directly without synthesizing keystrokes.
-        Use for forms and controls after see returns an element ID. Requires a settable AX value.
+        Use for forms and controls after `see` or `inspect_ui` returns an element ID. Requires a settable AX value.
         \(PeekabooMCPVersion.banner) using openai/gpt-5.5, anthropic/claude-opus-4-7
         """
     }
@@ -23,7 +23,7 @@ public struct SetValueTool: MCPTool {
         SchemaBuilder.object(
             properties: [
                 "on": SchemaBuilder.string(
-                    description: "Element ID from see output, such as T1, or a query string."),
+                    description: "Element ID from `see` or `inspect_ui` output, such as T1, or a query string."),
                 "value": SchemaBuilder.anyOf(
                     [
                         SchemaBuilder.string(),
@@ -33,7 +33,8 @@ public struct SetValueTool: MCPTool {
                     ],
                     description: "Value to set. Supported types: string, boolean, integer, or number."),
                 "snapshot": SchemaBuilder.string(
-                    description: "Optional. Snapshot ID from see command. Uses latest snapshot if not specified."),
+                    description: "Optional. Snapshot ID from `see` or `inspect_ui`. " +
+                        "Uses latest snapshot if not specified."),
             ],
             required: ["on", "value"])
     }
@@ -74,7 +75,7 @@ public struct SetValueTool: MCPTool {
     private func effectiveSnapshotId(_ requestedSnapshotId: String?) async throws -> String? {
         if let requestedSnapshotId {
             guard let snapshot = await UISnapshotManager.shared.getSnapshot(id: requestedSnapshotId) else {
-                throw SetValueToolError("Snapshot '\(requestedSnapshotId)' not found. Run 'see' again.")
+                throw SetValueToolError("Snapshot '\(requestedSnapshotId)' not found. Run 'see' or 'inspect_ui' again.")
             }
             return snapshot.id
         }

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/SetValueTool.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/SetValueTool.swift
@@ -115,7 +115,7 @@ public struct SetValueTool: MCPTool {
         }
         if let invalidatedSnapshotId {
             meta["invalidated_snapshot"] = .string(invalidatedSnapshotId)
-            meta["requires_fresh_see"] = .bool(true)
+            meta["requires_fresh_observation"] = .bool(true)
         }
 
         return ToolResponse.text(message, meta: .object(meta))

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/TypeTool.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/TypeTool.swift
@@ -146,7 +146,7 @@ public struct TypeTool: MCPTool {
         ]
         if let invalidatedSnapshotId {
             baseMetaDict["invalidated_snapshot"] = .string(invalidatedSnapshotId)
-            baseMetaDict["requires_fresh_see"] = .bool(true)
+            baseMetaDict["requires_fresh_observation"] = .bool(true)
         }
         let baseMeta: Value = .object(baseMetaDict)
         let summary = self.buildEventSummary(

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/TypeTool.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/TypeTool.swift
@@ -28,10 +28,11 @@ public struct TypeTool: MCPTool {
                 "text": SchemaBuilder.string(
                     description: "The text to type. If not specified, can use special key flags instead."),
                 "on": SchemaBuilder.string(
-                    description: "Optional. Element ID to type into (from see command). " +
+                    description: "Optional. Element ID to type into (from `see` or `inspect_ui`). " +
                         "If not specified, types at current focus."),
                 "snapshot": SchemaBuilder.string(
-                    description: "Optional. Snapshot ID from see command. Uses latest snapshot if not specified."),
+                    description: "Optional. Snapshot ID from `see` or `inspect_ui`. " +
+                        "Uses latest snapshot if not specified."),
                 "delay": SchemaBuilder.number(
                     description: "Optional. Delay between keystrokes in milliseconds (linear profile). Default: 5.",
                     default: 5),
@@ -178,12 +179,12 @@ public struct TypeTool: MCPTool {
     private func resolveTargetContext(for request: TypeRequest) async throws -> TargetElementContext? {
         guard let elementId = request.elementId else { return nil }
         guard let snapshot = await self.getSnapshot(id: request.snapshotId) else {
-            throw TypeToolValidationError("No active snapshot. Run 'see' command first to capture UI state.")
+            throw TypeToolValidationError("No active snapshot. Run 'see' or 'inspect_ui' first to capture UI state.")
         }
 
         guard let element = await snapshot.getElement(byId: elementId) else {
             throw TypeToolValidationError(
-                "Element '\(elementId)' not found in current snapshot. Run 'see' command to update UI state.")
+                "Element '\(elementId)' not found in current snapshot. Run 'see' or 'inspect_ui' to update UI state.")
         }
 
         return TargetElementContext(snapshot: snapshot, element: element)

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/ToolRegistry/ToolDefinitions.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/ToolRegistry/ToolDefinitions.swift
@@ -62,7 +62,7 @@ public enum UIAutomationToolDefinitions {
         abstract: "Click on UI elements or coordinates",
         discussion: """
         Clicks on UI elements or coordinates. Supports element queries,
-        specific IDs from see command, or raw coordinates.
+        specific IDs from `see` or `inspect_ui`, or raw coordinates.
         """,
         category: .ui,
         parameters: [
@@ -74,7 +74,7 @@ public enum UIAutomationToolDefinitions {
             ParameterDefinition(
                 name: "on",
                 type: .string,
-                description: "Element ID to click (e.g., B1, T2) from see command output",
+                description: "Element ID to click (e.g., B1, T2) from `see` or `inspect_ui` output",
                 required: false),
             ParameterDefinition(
                 name: "coords",
@@ -94,7 +94,7 @@ public enum UIAutomationToolDefinitions {
             ParameterDefinition(
                 name: "session",
                 type: .string,
-                description: "Session ID from see command",
+                description: "Snapshot/session state identifier from a prior UI observation",
                 required: false),
             ParameterDefinition(
                 name: "waitFor",

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/ToolRegistry/ToolRegistry.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/ToolRegistry/ToolRegistry.swift
@@ -41,13 +41,13 @@ public enum ToolRegistry {
                 "peekaboo see --app Safari --path ~/Shots/safari.png --annotate",
                 "peekaboo see --mode screen --json",
             ],
-            agentGuidance: "Run `see` whenever you need fresh element IDs; the response " +
-                "contains snapshot ids and absolute coordinates."),
+            agentGuidance: "Run `inspect_ui` for AX-only element IDs, or `see` when a screenshot/visual " +
+                "element map is needed; both responses contain snapshot ids."),
         "click": ToolOverride(
             category: .automation,
             abstract: "High-precision UI clicking with fuzzy matching and snapshot-aware targeting.",
             discussion: """
-            Clicks on UI elements or coordinates. Supports IDs from the `see` command,
+            Clicks on UI elements or coordinates. Supports IDs from `see` or `inspect_ui`,
             fuzzy text queries, or raw coordinates.
 
             ELEMENT MATCHING
@@ -60,8 +60,8 @@ public enum ToolRegistry {
             peekaboo click --on B2 --space-switch
 
             TROUBLESHOOTING
-            If the element isn't found, re-run `peekaboo see` to refresh the snapshot,
-            or provide a more precise query (like an ID or coordinates).
+            If the element isn't found, refresh the snapshot with a fresh observation (`peekaboo see`
+            in CLI, or `see`/`inspect_ui` in MCP), or provide a more precise query.
             """,
             examples: [
                 "peekaboo click \"Submit\"",

--- a/Core/PeekabooCore/Tests/PeekabooAgentRuntimeTests/AgentSystemPromptTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooAgentRuntimeTests/AgentSystemPromptTests.swift
@@ -64,4 +64,35 @@ struct AgentSystemPromptTests {
             prompt.contains(#""item_type": "application_windows", "app": "Safari""#),
             "Prompt should include the required `app` argument when listing application windows.")
     }
+
+    @Test
+    func `generated prompt routes observation by target surface`() {
+        guard #available(macOS 14.0, *) else { return }
+        let prompt = AgentSystemPrompt.generate()
+
+        #expect(prompt.contains("observation tool appropriate to the target surface"))
+        #expect(prompt.contains("Use `browser` for Chrome page content"))
+        #expect(prompt.contains("Use `inspect_ui` for native macOS UI text"))
+        #expect(prompt.contains("Use `see` for desktop/app screenshots"))
+    }
+
+    @Test
+    func `generated prompt no longer forces see as the first observation tool`() {
+        guard #available(macOS 14.0, *) else { return }
+        let prompt = AgentSystemPrompt.generate()
+
+        #expect(!prompt.contains("Screenshots → always use `see`"))
+        #expect(!prompt.contains("Start with the `see` tool"))
+        #expect(!prompt.contains("First call `see`"))
+    }
+
+    @Test
+    func `generated prompt preserves see for visual observations`() {
+        guard #available(macOS 14.0, *) else { return }
+        let prompt = AgentSystemPrompt.generate()
+
+        #expect(prompt.contains("visual layout"))
+        #expect(prompt.contains("pixels"))
+        #expect(prompt.contains("accessibility text is missing or incomplete"))
+    }
 }

--- a/Core/PeekabooCore/Tests/PeekabooTests/AgentToolDescriptionTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/AgentToolDescriptionTests.swift
@@ -117,6 +117,35 @@ struct AgentToolDescriptionTests {
 
     @Test
     @MainActor
+    func `Agent interaction tool schemas accept snapshots from see or inspect ui`() throws {
+        let service = try PeekabooAgentService(services: PeekabooServices())
+        let tools = service.createAgentTools()
+        let interactionToolNames = Set(["click", "type", "set_value", "perform_action", "scroll", "drag", "move"])
+        let stalePhrases = [
+            "from see command",
+            "from see output",
+            "Run 'see' command",
+            "Run 'see' again",
+        ]
+
+        for tool in tools where interactionToolNames.contains(tool.name) {
+            let parameterDescriptions = tool.parameters.properties.values.map(\.description)
+            let guidance = ([tool.description] + parameterDescriptions).joined(separator: "\n")
+
+            #expect(
+                guidance.contains("inspect_ui"),
+                "Tool '\(tool.name)' should mention that `inspect_ui` snapshots/IDs are valid.")
+
+            for phrase in stalePhrases {
+                #expect(
+                    !guidance.contains(phrase),
+                    "Tool '\(tool.name)' still implies only `see` can provide snapshots/IDs: \(phrase)")
+            }
+        }
+    }
+
+    @Test
+    @MainActor
     func `Shell tool has quoting examples`() {
         guard let shellTool = makeAgentTools().first(where: { $0.name == "shell" }) else {
             Issue.record("Shell tool not found")

--- a/Core/PeekabooCore/Tests/PeekabooTests/MCP/MCPToolExecutionTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/MCP/MCPToolExecutionTests.swift
@@ -486,6 +486,8 @@ struct MCPToolExecutionTests {
         }
         let invalidated = await UISnapshotManager.shared.getSnapshot(id: snapshotId)
         #expect(invalidated == nil)
+        #expect(MCPResponseMeta.requiresFreshObservation(response))
+        #expect(!MCPResponseMeta.hasRequiresFreshSee(response))
     }
 
     @Test
@@ -518,6 +520,8 @@ struct MCPToolExecutionTests {
         #expect(calls.first?.snapshotId == snapshotId)
         let invalidated = await UISnapshotManager.shared.getSnapshot(id: snapshotId)
         #expect(invalidated == nil)
+        #expect(MCPResponseMeta.requiresFreshObservation(response))
+        #expect(!MCPResponseMeta.hasRequiresFreshSee(response))
     }
 
     @Test
@@ -660,6 +664,8 @@ struct MCPToolExecutionTests {
         let stillLatest = await UISnapshotManager.shared.getSnapshot(id: latestSnapshotId)
         #expect(invalidated == nil)
         #expect(stillLatest != nil)
+        #expect(MCPResponseMeta.requiresFreshObservation(response))
+        #expect(!MCPResponseMeta.hasRequiresFreshSee(response))
     }
 
     @Test
@@ -718,6 +724,8 @@ struct MCPToolExecutionTests {
         #expect(typeSnapshotId == nil)
         let invalidated = await UISnapshotManager.shared.getSnapshot(id: snapshotId)
         #expect(invalidated == nil)
+        #expect(MCPResponseMeta.requiresFreshObservation(response))
+        #expect(!MCPResponseMeta.hasRequiresFreshSee(response))
     }
 
     @Test
@@ -743,6 +751,8 @@ struct MCPToolExecutionTests {
         let stillLatest = await UISnapshotManager.shared.getSnapshot(id: latestSnapshotId)
         #expect(invalidated == nil)
         #expect(stillLatest != nil)
+        #expect(MCPResponseMeta.requiresFreshObservation(response))
+        #expect(!MCPResponseMeta.hasRequiresFreshSee(response))
     }
 
     @Test
@@ -761,6 +771,8 @@ struct MCPToolExecutionTests {
         #expect(requests.first?.snapshotId == nil)
         let invalidated = await UISnapshotManager.shared.getSnapshot(id: snapshotId)
         #expect(invalidated == nil)
+        #expect(MCPResponseMeta.requiresFreshObservation(response))
+        #expect(!MCPResponseMeta.hasRequiresFreshSee(response))
     }
 
     @Test
@@ -786,6 +798,8 @@ struct MCPToolExecutionTests {
         let stillLatest = await UISnapshotManager.shared.getSnapshot(id: latestSnapshotId)
         #expect(invalidated == nil)
         #expect(stillLatest != nil)
+        #expect(MCPResponseMeta.requiresFreshObservation(response))
+        #expect(!MCPResponseMeta.hasRequiresFreshSee(response))
     }
 
     @Test
@@ -898,6 +912,8 @@ struct MCPElementActionToolExecutionTests {
         #expect(call?.snapshotId == snapshotId)
         let invalidated = await UISnapshotManager.shared.getSnapshot(id: snapshotId)
         #expect(invalidated == nil)
+        #expect(MCPResponseMeta.requiresFreshObservation(response))
+        #expect(!MCPResponseMeta.hasRequiresFreshSee(response))
     }
 
     @Test
@@ -918,6 +934,8 @@ struct MCPElementActionToolExecutionTests {
         #expect(call?.snapshotId == snapshotId)
         let invalidated = await UISnapshotManager.shared.getSnapshot(id: snapshotId)
         #expect(invalidated == nil)
+        #expect(MCPResponseMeta.requiresFreshObservation(response))
+        #expect(!MCPResponseMeta.hasRequiresFreshSee(response))
     }
 
     @Test
@@ -944,10 +962,28 @@ struct MCPElementActionToolExecutionTests {
         #expect(call?.snapshotId == snapshotId)
         let invalidated = await UISnapshotManager.shared.getSnapshot(id: snapshotId)
         #expect(invalidated == nil)
+        #expect(MCPResponseMeta.requiresFreshObservation(response))
+        #expect(!MCPResponseMeta.hasRequiresFreshSee(response))
     }
 }
 
 // MARK: - Test Helpers
+
+private enum MCPResponseMeta {
+    static func requiresFreshObservation(_ response: ToolResponse) -> Bool {
+        guard case let .object(meta) = response.meta,
+              case .bool(true)? = meta["requires_fresh_observation"]
+        else {
+            return false
+        }
+        return true
+    }
+
+    static func hasRequiresFreshSee(_ response: ToolResponse) -> Bool {
+        guard case let .object(meta) = response.meta else { return false }
+        return meta["requires_fresh_see"] != nil
+    }
+}
 
 private enum MCPToolTestHelpers {
     static func makeContext(


### PR DESCRIPTION
## Why
After #141, `inspect_ui` can create snapshots and element IDs without capturing screenshots, but parts of the agent prompt and interaction tool guidance still described `see` as the only observation source. That can steer agents toward unnecessary screenshots for AX-only native UI reads.

## Summary
- Route agent observation guidance by surface: Chrome page work -> `browser`, AX-only native UI -> `inspect_ui`, visual/pixel/screen work -> `see`.
- Update interaction tool descriptions and recovery messages so snapshots and element IDs can come from `see` or `inspect_ui`.
- Add regression coverage for prompt routing and agent tool schema guidance.

## Validation
- `pnpm run format`
- `pnpm run lint` (exits 0; existing SwiftLint parameter-count warnings are outside this diff)
- `swift test --package-path Core/PeekabooCore --filter AgentSystemPromptTests`
- `swift test --package-path Core/PeekabooCore --filter AgentToolDescriptionTests`
- `pnpm run test:safe`
- `git diff --check origin/main...HEAD`