### PR TITLE
test(perf): harden local command benchmark helper

### DIFF
--- a/Apps/Playground/scripts/peekaboo-perf.sh
+++ b/Apps/Playground/scripts/peekaboo-perf.sh
@@ -254,6 +254,19 @@ allow_failures = os.environ["PEEKABOO_PERF_ALLOW_FAILURES"] == "1"
 command_args = json.loads(os.environ["PEEKABOO_PERF_COMMAND_ARGS_JSON"])
 
 
+def display_path(path):
+    raw = Path(path)
+    try:
+        return str(raw.resolve().relative_to(Path.cwd().resolve()))
+    except Exception:
+        return str(raw)
+
+
+def display_pattern(phase):
+    root = display_path(log_root)
+    return f"{root}/{timestamp}-{name}-{phase}-*.json"
+
+
 def percentile(sorted_values, pct):
     if not sorted_values:
         return None
@@ -308,9 +321,9 @@ def collect(payloads):
         data = payload.get("data", {}) or {}
         exit_code = int(data.get("exit_code", 0))
         if exit_code != 0:
-            failures.append({"path": path, "exit_code": exit_code, "reason": "exit_code"})
+            failures.append({"path": display_path(path), "exit_code": exit_code, "reason": "exit_code"})
         elif payload.get("success") is False:
-            failures.append({"path": path, "exit_code": exit_code, "reason": "success_false"})
+            failures.append({"path": display_path(path), "exit_code": exit_code, "reason": "success_false"})
 
         exec_time = data.get("execution_time")
         if exec_time is None:
@@ -340,8 +353,8 @@ summary = {
     "command": command_args,
     "run_count": int(os.environ["PEEKABOO_PERF_RUNS"]),
     "warmup_count": int(os.environ["PEEKABOO_PERF_WARMUPS"]),
-    "measured_pattern": f"{log_root}/{timestamp}-{name}-run-*.json",
-    "warmup_pattern": f"{log_root}/{timestamp}-{name}-warmup-*.json",
+    "measured_pattern": display_pattern("run"),
+    "warmup_pattern": display_pattern("warmup"),
     "execution_time": stats(execution_times),
     "wall_time": stats(wall_times),
     "failures": failures,

--- a/Apps/Playground/scripts/peekaboo-perf.sh
+++ b/Apps/Playground/scripts/peekaboo-perf.sh
@@ -305,7 +305,7 @@ def stats(values):
         variance = sum((value - mean) ** 2 for value in values_sorted) / (len(values_sorted) - 1)
         stddev = math.sqrt(variance)
     else:
-        stddev = 0.0
+        stddev = None
     return {
         "n": len(values_sorted),
         "samples_s": values_sorted,
@@ -364,7 +364,6 @@ def collect(payloads):
 
 
 measured_payloads = load_payloads("run")
-warmup_payloads = load_payloads("warmup")
 execution_times, wall_times, failures = collect(measured_payloads)
 
 summary = {

--- a/Apps/Playground/scripts/peekaboo-perf.sh
+++ b/Apps/Playground/scripts/peekaboo-perf.sh
@@ -32,7 +32,7 @@ EOF
 }
 
 is_nonnegative_int() {
-  [[ "$1" =~ ^[0-9]+$ ]]
+  [[ "$1" == "0" || "$1" =~ ^[1-9][0-9]*$ ]]
 }
 
 is_positive_int() {
@@ -256,11 +256,22 @@ timestamp = os.environ["PEEKABOO_PERF_TS"]
 allow_failures = os.environ["PEEKABOO_PERF_ALLOW_FAILURES"] == "1"
 command_args = json.loads(os.environ["PEEKABOO_PERF_COMMAND_ARGS_JSON"])
 
+try:
+    checkout_root = subprocess.check_output(
+        ["git", "rev-parse", "--show-toplevel"],
+        text=True,
+        stderr=subprocess.DEVNULL,
+    ).strip()
+except Exception:
+    checkout_root = str(Path.cwd().resolve())
+
 
 def sanitize_text(value):
     result = str(value)
     cwd = str(Path.cwd().resolve())
     home = os.environ.get("HOME")
+    if checkout_root:
+        result = result.replace(checkout_root, ".")
     if cwd:
         result = result.replace(cwd, ".")
     if home:
@@ -341,10 +352,13 @@ def collect(payloads):
     for path, payload in payloads:
         data = payload.get("data", {}) or {}
         exit_code = int(data.get("exit_code", 0))
+        failed = False
         if exit_code != 0:
             failures.append({"path": display_path(path), "exit_code": exit_code, "reason": "exit_code"})
+            failed = True
         elif payload.get("success") is False:
             failures.append({"path": display_path(path), "exit_code": exit_code, "reason": "success_false"})
+            failed = True
 
         exec_time = data.get("execution_time")
         if exec_time is None:
@@ -355,9 +369,9 @@ def collect(payloads):
             exec_time = data.get("executionTimeSeconds")
 
         wall_time = data.get("wall_time")
-        if isinstance(exec_time, (int, float)):
+        if not failed and isinstance(exec_time, (int, float)):
             execution_times.append(float(exec_time))
-        if isinstance(wall_time, (int, float)):
+        if not failed and isinstance(wall_time, (int, float)):
             wall_times.append(float(wall_time))
 
     return execution_times, wall_times, failures

--- a/Apps/Playground/scripts/peekaboo-perf.sh
+++ b/Apps/Playground/scripts/peekaboo-perf.sh
@@ -254,12 +254,23 @@ allow_failures = os.environ["PEEKABOO_PERF_ALLOW_FAILURES"] == "1"
 command_args = json.loads(os.environ["PEEKABOO_PERF_COMMAND_ARGS_JSON"])
 
 
+def sanitize_text(value):
+    result = str(value)
+    cwd = str(Path.cwd().resolve())
+    home = os.environ.get("HOME")
+    if cwd:
+        result = result.replace(cwd, ".")
+    if home:
+        result = result.replace(home, "~")
+    return result
+
+
 def display_path(path):
     raw = Path(path)
     try:
         return str(raw.resolve().relative_to(Path.cwd().resolve()))
     except Exception:
-        return str(raw)
+        return sanitize_text(raw)
 
 
 def display_pattern(phase):
@@ -350,7 +361,7 @@ summary = {
     "name": name,
     "timestamp": timestamp,
     "binary": os.environ["PEEKABOO_PERF_BIN_NAME"],
-    "command": command_args,
+    "command": [sanitize_text(arg) for arg in command_args],
     "run_count": int(os.environ["PEEKABOO_PERF_RUNS"]),
     "warmup_count": int(os.environ["PEEKABOO_PERF_WARMUPS"]),
     "measured_pattern": display_pattern("run"),
@@ -362,7 +373,6 @@ summary = {
         "platform": platform.platform(),
         "python": platform.python_version(),
         "git_commit": git_value(["rev-parse", "--short", "HEAD"]),
-        "git_branch": git_value(["branch", "--show-current"]),
     },
 }
 

--- a/Apps/Playground/scripts/peekaboo-perf.sh
+++ b/Apps/Playground/scripts/peekaboo-perf.sh
@@ -4,23 +4,36 @@ set -euo pipefail
 
 NAME=""
 RUNS=10
+WARMUPS=0
 LOG_ROOT="${LOG_ROOT:-$PWD/.artifacts/playground-tools}"
 BIN="${PEEKABOO_BIN:-$PWD/peekaboo}"
+ALLOW_FAILURES=0
 
 usage() {
   cat <<'EOF'
-Usage: peekaboo-perf.sh --name <slug> [--runs N] [--log-root DIR] [--bin PATH] -- <peekaboo args...>
+Usage: peekaboo-perf.sh --name <slug> [--runs N] [--warmups N] [--log-root DIR] [--bin PATH] [--allow-failures] -- <peekaboo args...>
 
-Runs a Peekaboo CLI command N times, captures JSON output per run, and writes a summary JSON
-with mean/median/p95/min/max based on `data.execution_time` (falls back to wall time if missing).
+Runs a Peekaboo CLI command repeatedly, captures per-run JSON output, and writes a summary JSON
+with mean/median/p95/min/max based on command execution time when present and wall time otherwise.
+
+The helper is local-only: it writes under .artifacts by default, sends nothing anywhere, and is not a
+telemetry subsystem. Failed measured runs make the helper exit non-zero unless --allow-failures is set.
 
 Examples:
-  ./Apps/Playground/scripts/peekaboo-perf.sh --name see-click-fixture --runs 10 -- \
+  pnpm run benchmark:tools --name see-click-fixture --runs 10 --warmups 1 --bin ./Apps/CLI/.build/debug/peekaboo -- \
     see --app boo.peekaboo.playground.debug --mode window --window-title "Click Fixture" --json-output
 
-  ./Apps/Playground/scripts/peekaboo-perf.sh --name click-single --runs 20 -- \
+  pnpm run benchmark:tools --name click-single --runs 20 --bin ./Apps/CLI/.build/debug/peekaboo -- \
     click "Single Click" --snapshot <id> --app boo.peekaboo.playground.debug --json-output
 EOF
+}
+
+is_nonnegative_int() {
+  [[ "$1" =~ ^[0-9]+$ ]]
+}
+
+is_positive_int() {
+  [[ "$1" =~ ^[1-9][0-9]*$ ]]
 }
 
 while [[ $# -gt 0 ]]; do
@@ -33,6 +46,10 @@ while [[ $# -gt 0 ]]; do
       RUNS="${2:-}"
       shift 2
       ;;
+    --warmups|--warmup)
+      WARMUPS="${2:-}"
+      shift 2
+      ;;
     --log-root)
       LOG_ROOT="${2:-}"
       shift 2
@@ -40,6 +57,10 @@ while [[ $# -gt 0 ]]; do
     --bin)
       BIN="${2:-}"
       shift 2
+      ;;
+    --allow-failures)
+      ALLOW_FAILURES=1
+      shift
       ;;
     -h|--help)
       usage
@@ -63,6 +84,21 @@ if [[ -z "$NAME" ]]; then
   exit 2
 fi
 
+if [[ ! "$NAME" =~ ^[A-Za-z0-9._-]+$ ]]; then
+  echo "--name must contain only letters, numbers, dots, underscores, or hyphens" >&2
+  exit 2
+fi
+
+if ! is_positive_int "$RUNS"; then
+  echo "--runs must be a positive integer" >&2
+  exit 2
+fi
+
+if ! is_nonnegative_int "$WARMUPS"; then
+  echo "--warmups must be a non-negative integer" >&2
+  exit 2
+fi
+
 if [[ $# -eq 0 ]]; then
   echo "Missing peekaboo args after --" >&2
   usage >&2
@@ -77,149 +113,252 @@ fi
 
 mkdir -p "$LOG_ROOT"
 
-TS="$(date +%Y%m%d-%H%M%S)"
-PATTERN="$LOG_ROOT/${TS}-${NAME}-*.json"
+TS="$(date -u +%Y%m%dT%H%M%SZ)"
 SUMMARY="$LOG_ROOT/${TS}-${NAME}-summary.json"
 
-echo "Running $RUNS iterations:"
+COMMAND_ARGS_JSON="$(python3 - "$@" <<'PY'
+import json
+import sys
+
+print(json.dumps(sys.argv[1:]))
+PY
+)"
+
+echo "Running benchmark:"
+echo "- name: $NAME"
+echo "- measured runs: $RUNS"
+echo "- warmups: $WARMUPS"
 echo "- bin: $BIN"
 echo "- out: $LOG_ROOT"
 echo "- cmd: $*"
 
-for i in $(seq 1 "$RUNS"); do
-  OUT="$LOG_ROOT/${TS}-${NAME}-${i}.json"
-  START="$(python3 - <<'PY'
+now_seconds() {
+  python3 - <<'PY'
 import time
+
 print(time.time())
 PY
-)"
+}
 
-  set +e
-  "$BIN" "$@" >"$OUT"
-  EXIT_CODE="$?"
-  set -e
+write_payload() {
+  local out="$1"
+  local phase="$2"
+  local iteration="$3"
+  local wall="$4"
+  local exit_code="$5"
 
-  END="$(python3 - <<'PY'
-import time
-print(time.time())
-PY
-)"
-
-  WALL="$(python3 - <<PY
-start=float("$START")
-end=float("$END")
-print(end-start)
-PY
-)"
-
-  if [[ "$EXIT_CODE" -ne 0 ]]; then
-    echo "Run $i failed (exit=$EXIT_CODE): $OUT" >&2
-  fi
-
-  python3 - <<PY
+  PEEKABOO_PERF_OUT="$out" \
+  PEEKABOO_PERF_PHASE="$phase" \
+  PEEKABOO_PERF_ITERATION="$iteration" \
+  PEEKABOO_PERF_WALL="$wall" \
+  PEEKABOO_PERF_EXIT="$exit_code" \
+    python3 - <<'PY'
 import json
+import os
 from pathlib import Path
 
-path = Path("$OUT")
-raw = path.read_text()
+path = Path(os.environ["PEEKABOO_PERF_OUT"])
+raw = path.read_text(errors="replace")
 try:
-  data = json.loads(raw)
+    payload = json.loads(raw)
 except Exception:
-  data = {"success": False, "data": {}, "raw_output": raw}
-if not isinstance(data, dict):
-  data = {"success": False, "data": {}, "raw_output": raw}
-if "data" not in data or not isinstance(data.get("data"), dict):
-  data["data"] = {}
-data["data"]["wall_time"] = float("$WALL")
-data["data"]["exit_code"] = int("$EXIT_CODE")
-path.write_text(json.dumps(data, indent=2, sort_keys=True) + "\n")
-PY
+    payload = {"success": False, "data": {}, "raw_output": raw}
 
-  echo "- $i/$RUNS -> $OUT (wall=${WALL}s, exit=$EXIT_CODE)"
+if not isinstance(payload, dict):
+    payload = {"success": False, "data": {}, "raw_output": raw}
+
+data = payload.get("data")
+if not isinstance(data, dict):
+    data = {}
+    payload["data"] = data
+
+data["wall_time"] = float(os.environ["PEEKABOO_PERF_WALL"])
+data["exit_code"] = int(os.environ["PEEKABOO_PERF_EXIT"])
+data["benchmark"] = {
+    "phase": os.environ["PEEKABOO_PERF_PHASE"],
+    "iteration": int(os.environ["PEEKABOO_PERF_ITERATION"]),
+}
+
+path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n")
+PY
+}
+
+run_one() {
+  local phase="$1"
+  local iteration="$2"
+  shift 2
+  local out="$LOG_ROOT/${TS}-${NAME}-${phase}-${iteration}.json"
+
+  local start
+  local end
+  local wall
+  local exit_code
+
+  start="$(now_seconds)"
+  set +e
+  "$BIN" "$@" >"$out"
+  exit_code="$?"
+  set -e
+  end="$(now_seconds)"
+
+  wall="$(python3 - <<PY
+start = float("$start")
+end = float("$end")
+print(end - start)
+PY
+)"
+
+  write_payload "$out" "$phase" "$iteration" "$wall" "$exit_code"
+
+  if [[ "$exit_code" -ne 0 ]]; then
+    echo "- $phase $iteration failed (exit=$exit_code): $out" >&2
+  else
+    echo "- $phase $iteration -> $out (wall=${wall}s)"
+  fi
+}
+
+if (( WARMUPS > 0 )); then
+  for i in $(seq 1 "$WARMUPS"); do
+    run_one "warmup" "$i" "$@"
+  done
+fi
+
+for i in $(seq 1 "$RUNS"); do
+  run_one "run" "$i" "$@"
 done
 
-export PEEKABOO_PERF_COMMAND="$BIN $*"
-
-python3 - <<PY
+PEEKABOO_PERF_LOG_ROOT="$LOG_ROOT" \
+PEEKABOO_PERF_SUMMARY="$SUMMARY" \
+PEEKABOO_PERF_NAME="$NAME" \
+PEEKABOO_PERF_TS="$TS" \
+PEEKABOO_PERF_RUNS="$RUNS" \
+PEEKABOO_PERF_WARMUPS="$WARMUPS" \
+PEEKABOO_PERF_ALLOW_FAILURES="$ALLOW_FAILURES" \
+PEEKABOO_PERF_BIN_NAME="$(basename "$BIN")" \
+PEEKABOO_PERF_COMMAND_ARGS_JSON="$COMMAND_ARGS_JSON" \
+  python3 - <<'PY'
 import glob
 import json
 import math
 import os
+import platform
+import subprocess
+import sys
 from pathlib import Path
 
-paths = [p for p in sorted(glob.glob("$PATTERN")) if not p.endswith("-summary.json")]
-summary_path = Path("$SUMMARY")
-command_str = os.environ.get("PEEKABOO_PERF_COMMAND", "")
+log_root = os.environ["PEEKABOO_PERF_LOG_ROOT"]
+summary_path = Path(os.environ["PEEKABOO_PERF_SUMMARY"])
+name = os.environ["PEEKABOO_PERF_NAME"]
+timestamp = os.environ["PEEKABOO_PERF_TS"]
+allow_failures = os.environ["PEEKABOO_PERF_ALLOW_FAILURES"] == "1"
+command_args = json.loads(os.environ["PEEKABOO_PERF_COMMAND_ARGS_JSON"])
+
 
 def percentile(sorted_values, pct):
-  if not sorted_values:
-    return None
-  if len(sorted_values) == 1:
-    return sorted_values[0]
-  k = (len(sorted_values) - 1) * pct
-  f = math.floor(k)
-  c = math.ceil(k)
-  if f == c:
-    return sorted_values[int(k)]
-  d0 = sorted_values[int(f)] * (c - k)
-  d1 = sorted_values[int(c)] * (k - f)
-  return d0 + d1
+    if not sorted_values:
+        return None
+    if len(sorted_values) == 1:
+        return sorted_values[0]
+    k = (len(sorted_values) - 1) * pct
+    floor_index = math.floor(k)
+    ceil_index = math.ceil(k)
+    if floor_index == ceil_index:
+        return sorted_values[int(k)]
+    low = sorted_values[floor_index] * (ceil_index - k)
+    high = sorted_values[ceil_index] * (k - floor_index)
+    return low + high
 
-execution_times = []
-wall_times = []
-failures = []
 
-for p in paths:
-  raw = Path(p).read_text()
-  payload = json.loads(raw)
-  data = payload.get("data", {}) or {}
-  exit_code = int(data.get("exit_code", 0))
-  if exit_code != 0:
-    failures.append({"path": p, "exit_code": exit_code})
-  exec_t = data.get("execution_time")
-  if exec_t is None:
-    exec_t = data.get("executionTime")
-  if exec_t is None:
-    exec_t = data.get("execution_time_s")
-  if exec_t is None:
-    exec_t = data.get("executionTimeSeconds")
-  wall_t = data.get("wall_time")
-  if isinstance(exec_t, (int, float)):
-    execution_times.append(float(exec_t))
-  if isinstance(wall_t, (int, float)):
-    wall_times.append(float(wall_t))
+def stats(values):
+    values_sorted = sorted(values)
+    if not values_sorted:
+        return None
+    return {
+        "n": len(values_sorted),
+        "samples_s": values_sorted,
+        "mean_s": sum(values_sorted) / len(values_sorted),
+        "median_s": percentile(values_sorted, 0.50),
+        "p95_s": percentile(values_sorted, 0.95),
+        "min_s": values_sorted[0],
+        "max_s": values_sorted[-1],
+    }
 
-execution_times_sorted = sorted(execution_times)
-wall_times_sorted = sorted(wall_times)
 
-def stats(values_sorted):
-  if not values_sorted:
-    return None
-  n = len(values_sorted)
-  mean = sum(values_sorted) / n
-  median = percentile(values_sorted, 0.50)
-  p95 = percentile(values_sorted, 0.95)
-  return {
-    "n": n,
-    "samples_s": values_sorted,
-    "mean_s": mean,
-    "median_s": median,
-    "p95_s": p95,
-    "min_s": values_sorted[0],
-    "max_s": values_sorted[-1],
-  }
+def git_value(args):
+    try:
+        return subprocess.check_output(["git", *args], text=True, stderr=subprocess.DEVNULL).strip()
+    except Exception:
+        return None
+
+
+def load_payloads(phase):
+    paths = sorted(glob.glob(f"{log_root}/{timestamp}-{name}-{phase}-*.json"))
+    payloads = []
+    for path in paths:
+        payload = json.loads(Path(path).read_text())
+        payloads.append((path, payload))
+    return payloads
+
+
+def collect(payloads):
+    execution_times = []
+    wall_times = []
+    failures = []
+    for path, payload in payloads:
+        data = payload.get("data", {}) or {}
+        exit_code = int(data.get("exit_code", 0))
+        if exit_code != 0:
+            failures.append({"path": path, "exit_code": exit_code, "reason": "exit_code"})
+        elif payload.get("success") is False:
+            failures.append({"path": path, "exit_code": exit_code, "reason": "success_false"})
+
+        exec_time = data.get("execution_time")
+        if exec_time is None:
+            exec_time = data.get("executionTime")
+        if exec_time is None:
+            exec_time = data.get("execution_time_s")
+        if exec_time is None:
+            exec_time = data.get("executionTimeSeconds")
+
+        wall_time = data.get("wall_time")
+        if isinstance(exec_time, (int, float)):
+            execution_times.append(float(exec_time))
+        if isinstance(wall_time, (int, float)):
+            wall_times.append(float(wall_time))
+
+    return execution_times, wall_times, failures
+
+
+measured_payloads = load_payloads("run")
+warmup_payloads = load_payloads("warmup")
+execution_times, wall_times, failures = collect(measured_payloads)
 
 summary = {
-  "pattern": "$PATTERN",
-  "command": command_str,
-  "timestamp": "$TS",
-  "execution_time": stats(execution_times_sorted),
-  "wall_time": stats(wall_times_sorted),
-  "failures": failures,
+    "name": name,
+    "timestamp": timestamp,
+    "binary": os.environ["PEEKABOO_PERF_BIN_NAME"],
+    "command": command_args,
+    "run_count": int(os.environ["PEEKABOO_PERF_RUNS"]),
+    "warmup_count": int(os.environ["PEEKABOO_PERF_WARMUPS"]),
+    "measured_pattern": f"{log_root}/{timestamp}-{name}-run-*.json",
+    "warmup_pattern": f"{log_root}/{timestamp}-{name}-warmup-*.json",
+    "execution_time": stats(execution_times),
+    "wall_time": stats(wall_times),
+    "failures": failures,
+    "environment": {
+        "platform": platform.platform(),
+        "python": platform.python_version(),
+        "git_commit": git_value(["rev-parse", "--short", "HEAD"]),
+        "git_branch": git_value(["branch", "--show-current"]),
+    },
 }
 
 summary_path.write_text(json.dumps(summary, indent=2, sort_keys=True) + "\n")
+
 print(str(summary_path))
+if failures and not allow_failures:
+    print(f"Benchmark failed: {len(failures)} measured run(s) exited non-zero", file=sys.stderr)
+    sys.exit(1)
 PY
 
 echo "Summary: $SUMMARY"

--- a/Apps/Playground/scripts/peekaboo-perf.sh
+++ b/Apps/Playground/scripts/peekaboo-perf.sh
@@ -2,6 +2,9 @@
 
 set -euo pipefail
 
+# Local benchmarking harness for source checkouts. This is not telemetry and is not intended
+# for CI pass/fail gates; treat the numbers as local evidence for before/after comparisons.
+
 NAME=""
 RUNS=10
 WARMUPS=0
@@ -13,8 +16,8 @@ usage() {
   cat <<'EOF'
 Usage: peekaboo-perf.sh --name <slug> [--runs N] [--warmups N] [--log-root DIR] [--bin PATH] [--allow-failures] -- <peekaboo args...>
 
-Runs a Peekaboo CLI command repeatedly, captures per-run JSON output, and writes a summary JSON
-with mean/median/p95/min/max based on command execution time when present and wall time otherwise.
+Runs a Peekaboo CLI command repeatedly, captures per-run JSON output, and writes a summary JSON with
+mean/stddev/median/p95/min/max based on command execution time when present and wall time otherwise.
 
 The helper is local-only: it writes under .artifacts by default, sends nothing anywhere, and is not a
 telemetry subsystem. Failed measured runs make the helper exit non-zero unless --allow-failures is set.
@@ -297,10 +300,17 @@ def stats(values):
     values_sorted = sorted(values)
     if not values_sorted:
         return None
+    mean = sum(values_sorted) / len(values_sorted)
+    if len(values_sorted) > 1:
+        variance = sum((value - mean) ** 2 for value in values_sorted) / (len(values_sorted) - 1)
+        stddev = math.sqrt(variance)
+    else:
+        stddev = 0.0
     return {
         "n": len(values_sorted),
         "samples_s": values_sorted,
-        "mean_s": sum(values_sorted) / len(values_sorted),
+        "mean_s": mean,
+        "stddev_s": stddev,
         "median_s": percentile(values_sorted, 0.50),
         "p95_s": percentile(values_sorted, 0.95),
         "min_s": values_sorted[0],

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,6 @@
 
 ## [3.2.1] - Unreleased
 
-### Added
-- Added a local `pnpm run benchmark:tools` helper for repeatable command timing summaries without persistent telemetry. Thanks @vyctorbrzezowski.
-
 ### Fixed
 - `peekaboo-mcp` now shuts down cleanly during restart backoff and repairs executable permissions without shelling out through an install path.
 - `pnpm run peekaboo:dev` no longer depends on a hardcoded local checkout path.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [3.2.1] - Unreleased
 
+### Added
+- Added a local `pnpm run benchmark:tools` helper for repeatable command timing summaries without persistent telemetry. Thanks @vyctorbrzezowski.
+
 ### Fixed
 - `peekaboo-mcp` now shuts down cleanly during restart backoff and repairs executable permissions without shelling out through an install path.
 - `pnpm run peekaboo:dev` no longer depends on a hardcoded local checkout path.

--- a/docs/testing/benchmarks.md
+++ b/docs/testing/benchmarks.md
@@ -77,6 +77,8 @@ pnpm run benchmark:tools \
 - `warmup` runs are saved but excluded from the reported statistics.
 - `failures` lists measured runs with non-zero exit codes.
 - The helper exits non-zero when measured runs fail unless you pass `--allow-failures`.
+- The summary includes the command arguments after replacing the current checkout path with `.` and `$HOME` with
+  `~`; avoid benchmarking commands with secrets or sensitive local paths if you plan to share the artifacts.
 
 Use p95 for regressions and PR evidence. Avoid hard thresholds in unit tests; command latency depends on host load,
 permissions, active windows, display count, and whether the daemon/Bridge path is warm.

--- a/docs/testing/benchmarks.md
+++ b/docs/testing/benchmarks.md
@@ -80,7 +80,8 @@ pnpm run benchmark:tools \
 
 - `wall_time` measures total process/runtime time from the helper's perspective.
 - `execution_time` uses the command's own JSON timing field when the command exposes one.
-- Summaries include `mean_s`, `stddev_s`, `median_s`, `p95_s`, `min_s`, and `max_s`.
+- Summaries include `mean_s`, `stddev_s`, `median_s`, `p95_s`, `min_s`, and `max_s`; `stddev_s` is `null` for
+  a single measured sample.
 - `warmup` runs are saved and printed but excluded from reported statistics and failure counts. Measured runs determine
   the helper's exit status.
 - The default is 10 measured runs and 0 warmups to preserve the older helper behavior. Use 1-3 warmups when

--- a/docs/testing/benchmarks.md
+++ b/docs/testing/benchmarks.md
@@ -14,6 +14,9 @@ This is not telemetry. It does not install a background collector, write a globa
 over the network. It runs a command N times and writes JSON artifacts under `.artifacts/` so you can inspect or
 share the specific run when needed.
 
+Do not use this helper as a CI pass/fail gate. Use it for local before/after evidence and attach the summary only
+when the numbers materially support a performance change.
+
 ## Quick start
 
 Build a debug CLI once:
@@ -74,11 +77,18 @@ pnpm run benchmark:tools \
 
 - `wall_time` measures total process/runtime time from the helper's perspective.
 - `execution_time` uses the command's own JSON timing field when the command exposes one.
+- Summaries include `mean_s`, `stddev_s`, `median_s`, `p95_s`, `min_s`, and `max_s`.
 - `warmup` runs are saved but excluded from the reported statistics.
+- The default is 10 measured runs and 0 warmups to preserve the older helper behavior. Use 1-3 warmups when
+  collecting PR evidence for a code path that benefits from daemon, filesystem, or process warmup.
 - `failures` lists measured runs with non-zero exit codes.
 - The helper exits non-zero when measured runs fail unless you pass `--allow-failures`.
 - The summary includes the command arguments after replacing the current checkout path with `.` and `$HOME` with
-  `~`; avoid benchmarking commands with secrets or sensitive local paths if you plan to share the artifacts.
+  `~`; per-run payloads still contain the raw command output, so avoid benchmarking commands with secrets or
+  sensitive local paths if you plan to share the artifacts.
 
 Use p95 for regressions and PR evidence. Avoid hard thresholds in unit tests; command latency depends on host load,
 permissions, active windows, display count, and whether the daemon/Bridge path is warm.
+
+For cleaner macOS measurements, keep the machine awake (`caffeinate` is useful for longer runs), close heavy apps,
+avoid Low Power Mode, and treat thermal throttling or Spotlight/indexing activity as reasons to rerun the sample.

--- a/docs/testing/benchmarks.md
+++ b/docs/testing/benchmarks.md
@@ -19,12 +19,15 @@ when the numbers materially support a performance change.
 
 ## Quick start
 
-Build a debug CLI once:
+Build a CLI once:
 
 ```bash
 pnpm run build:cli
 BIN="$(swift build --package-path Apps/CLI --show-bin-path)/peekaboo"
 ```
+
+Use the same binary for before/after comparisons. Debug and release builds are not comparable; use
+`pnpm run build:cli:release` and the release `peekaboo` path when you need release-build evidence.
 
 Run a UI-free smoke benchmark:
 
@@ -78,7 +81,8 @@ pnpm run benchmark:tools \
 - `wall_time` measures total process/runtime time from the helper's perspective.
 - `execution_time` uses the command's own JSON timing field when the command exposes one.
 - Summaries include `mean_s`, `stddev_s`, `median_s`, `p95_s`, `min_s`, and `max_s`.
-- `warmup` runs are saved but excluded from the reported statistics.
+- `warmup` runs are saved and printed but excluded from reported statistics and failure counts. Measured runs determine
+  the helper's exit status.
 - The default is 10 measured runs and 0 warmups to preserve the older helper behavior. Use 1-3 warmups when
   collecting PR evidence for a code path that benefits from daemon, filesystem, or process warmup.
 - `failures` lists measured runs with non-zero exit codes.

--- a/docs/testing/benchmarks.md
+++ b/docs/testing/benchmarks.md
@@ -1,0 +1,82 @@
+---
+summary: 'Run local Peekaboo command microbenchmarks without persistent telemetry.'
+read_when:
+  - 'measuring local command latency before or after a performance change'
+  - 'preparing benchmark evidence for a Peekaboo PR'
+---
+
+# Local command benchmarks
+
+Peekaboo keeps performance evidence local and explicit. Use the benchmark helper when you need repeatable
+numbers for a command, especially after changing capture, observation, targeting, or input paths.
+
+This is not telemetry. It does not install a background collector, write a global database, or send anything
+over the network. It runs a command N times and writes JSON artifacts under `.artifacts/` so you can inspect or
+share the specific run when needed.
+
+## Quick start
+
+Build a debug CLI once:
+
+```bash
+pnpm run build:cli
+BIN="$(swift build --package-path Apps/CLI --show-bin-path)/peekaboo"
+```
+
+Run a UI-free smoke benchmark:
+
+```bash
+pnpm run benchmark:tools \
+  --name tools-json \
+  --runs 5 \
+  --warmups 1 \
+  --bin "$BIN" \
+  -- tools --json-output
+```
+
+The summary path is printed at the end:
+
+```text
+.artifacts/playground-tools/20260517T021530Z-tools-json-summary.json
+```
+
+## Playground fixture benchmarks
+
+For UI commands, use the Playground fixture windows so each run targets the same app/window shape.
+
+1. Build and open the Playground app.
+2. Open the relevant fixture window from the Playground `Fixtures` menu.
+3. Run the benchmark against the fixture title or a snapshot captured from that fixture.
+
+Example `see` benchmark:
+
+```bash
+pnpm run benchmark:tools \
+  --name see-click-fixture \
+  --runs 10 \
+  --warmups 1 \
+  --bin "$BIN" \
+  -- see --app boo.peekaboo.playground.debug --mode window --window-title "Click Fixture" --json-output
+```
+
+Example `menu` benchmark:
+
+```bash
+pnpm run benchmark:tools \
+  --name menu-list-all-playground \
+  --runs 5 \
+  --warmups 1 \
+  --bin "$BIN" \
+  -- menu list-all --app boo.peekaboo.playground.debug --json-output
+```
+
+## How to read the summary
+
+- `wall_time` measures total process/runtime time from the helper's perspective.
+- `execution_time` uses the command's own JSON timing field when the command exposes one.
+- `warmup` runs are saved but excluded from the reported statistics.
+- `failures` lists measured runs with non-zero exit codes.
+- The helper exits non-zero when measured runs fail unless you pass `--allow-failures`.
+
+Use p95 for regressions and PR evidence. Avoid hard thresholds in unit tests; command latency depends on host load,
+permissions, active windows, display count, and whether the daemon/Bridge path is warm.

--- a/docs/testing/tools.md
+++ b/docs/testing/tools.md
@@ -47,11 +47,12 @@ read_when:
 
 ## Performance Checks
 - Capture performance summaries whenever a tool feels “slow” (or after fixing perf regressions) so we have a hard baseline.
-- Use `Apps/Playground/scripts/peekaboo-perf.sh` to run a command repeatedly and write a `*-summary.json` alongside the per-run JSON payloads (it reads `data.execution_time` or `data.executionTime` when available):
+- Use `pnpm run benchmark:tools` to run a command repeatedly and write a `*-summary.json` alongside the per-run JSON payloads. The helper reads command timing fields such as `data.execution_time` or `data.executionTime` when available, falls back to wall time, and exits non-zero if a measured run fails:
   ```bash
-  ./Apps/Playground/scripts/peekaboo-perf.sh --name see-click-fixture --runs 10 -- \
+  pnpm run benchmark:tools --name see-click-fixture --runs 10 --warmups 1 -- \
     see --app boo.peekaboo.playground.debug --mode window --window-title "Click Fixture" --json-output
   ```
+- See [benchmarks.md](benchmarks.md) for the full local benchmarking workflow.
 - Current reference baseline (2025-12-17, Click Fixture): `see` p95 ≈ 0.97s, `click` p95 ≈ 0.18s (`.artifacts/playground-tools/20251217-174822-perf-see-click-clickfixture-summary.json`).
 - Additional baselines (2025-12-17):
   - Scroll Fixture (`scroll --on vertical-scroll`, 15 runs): wall p95 ≈ 0.30s, exec p95 ≈ 0.12s (`.artifacts/playground-tools/20251217-224849-scroll-vertical-scroll-fixture-summary.json`).

--- a/package.json
+++ b/package.json
@@ -40,6 +40,8 @@
     "docs:list": "node scripts/docs-list.mjs",
     "docs:site": "node scripts/build-docs-site.mjs",
     "lint:docs": "node scripts/docs-lint.mjs",
+    "benchmark:tools": "Apps/Playground/scripts/peekaboo-perf.sh",
+    "test:benchmark-tools": "scripts/test-peekaboo-perf.sh",
     "polter": "FORCE_COLOR=1 CLICOLOR_FORCE=1 NODE_PATH=../poltergeist/node_modules script -q /dev/null node ../poltergeist/dist/polter.js",
     "polter:dev": "FORCE_COLOR=1 CLICOLOR_FORCE=1 NODE_PATH=../poltergeist/node_modules pnpm --dir ../poltergeist exec tsx ../poltergeist/src/polter.ts",
     "peekaboo": "FORCE_COLOR=1 CLICOLOR_FORCE=1 NODE_PATH=../poltergeist/node_modules script -q /dev/null ./scripts/poltergeist-wrapper.sh peekaboo",

--- a/scripts/test-peekaboo-perf.sh
+++ b/scripts/test-peekaboo-perf.sh
@@ -26,7 +26,7 @@ chmod +x "$FAKE_BIN"
   --warmups 1 \
   --log-root "$TMP_DIR/smoke" \
   --bin "$FAKE_BIN" \
-  -- ok --json-output >/tmp/peekaboo-perf-smoke.log
+  -- ok "$ROOT/private-fixture.json" --json-output >/tmp/peekaboo-perf-smoke.log
 
 SMOKE_SUMMARY="$(find "$TMP_DIR/smoke" -name '*-smoke-summary.json' -print -quit)"
 python3 - "$SMOKE_SUMMARY" <<'PY'
@@ -41,7 +41,8 @@ assert summary["execution_time"]["n"] == 3
 assert summary["wall_time"]["n"] == 3
 assert summary["failures"] == []
 assert summary["binary"] == "fake-peekaboo"
-assert summary["command"] == ["ok", "--json-output"]
+assert summary["command"] == ["ok", "./private-fixture.json", "--json-output"]
+assert "git_branch" not in summary["environment"]
 PY
 
 set +e

--- a/scripts/test-peekaboo-perf.sh
+++ b/scripts/test-peekaboo-perf.sh
@@ -16,6 +16,11 @@ if [[ "${1:-}" == "fail" ]]; then
   exit 7
 fi
 
+if [[ "${1:-}" == "softfail" ]]; then
+  echo '{"success":false,"data":{"execution_time":0.03}}'
+  exit 0
+fi
+
 echo '{"success":true,"data":{"execution_time":0.01}}'
 EOF
 chmod +x "$FAKE_BIN"
@@ -97,6 +102,22 @@ if [[ "$FAILING_STATUS" -eq 0 ]]; then
   exit 1
 fi
 
+set +e
+"$ROOT/Apps/Playground/scripts/peekaboo-perf.sh" \
+  --name bad-warmup \
+  --runs 1 \
+  --warmups 08 \
+  --log-root "$TMP_DIR/bad-warmup" \
+  --bin "$FAKE_BIN" \
+  -- ok >/tmp/peekaboo-perf-bad-warmup.log 2>&1
+BAD_WARMUP_STATUS="$?"
+set -e
+
+if [[ "$BAD_WARMUP_STATUS" -eq 0 ]]; then
+  echo "Expected leading-zero warmup count to fail validation" >&2
+  exit 1
+fi
+
 "$ROOT/Apps/Playground/scripts/peekaboo-perf.sh" \
   --name allowed \
   --runs 1 \
@@ -114,6 +135,29 @@ summary = json.load(open(sys.argv[1]))
 assert len(summary["failures"]) == 1
 assert summary["failures"][0]["exit_code"] == 7
 assert summary["failures"][0]["reason"] == "exit_code"
+assert summary["execution_time"] is None
+assert summary["wall_time"] is None
+PY
+
+"$ROOT/Apps/Playground/scripts/peekaboo-perf.sh" \
+  --name softfail \
+  --runs 1 \
+  --allow-failures \
+  --log-root "$TMP_DIR/softfail" \
+  --bin "$FAKE_BIN" \
+  -- softfail >/tmp/peekaboo-perf-softfail.log
+
+SOFTFAIL_SUMMARY="$(find "$TMP_DIR/softfail" -name '*-softfail-summary.json' -print -quit)"
+python3 - "$SOFTFAIL_SUMMARY" <<'PY'
+import json
+import sys
+
+summary = json.load(open(sys.argv[1]))
+assert len(summary["failures"]) == 1
+assert summary["failures"][0]["exit_code"] == 0
+assert summary["failures"][0]["reason"] == "success_false"
+assert summary["execution_time"] is None
+assert summary["wall_time"] is None
 PY
 
 echo "test-peekaboo-perf: ok"

--- a/scripts/test-peekaboo-perf.sh
+++ b/scripts/test-peekaboo-perf.sh
@@ -76,6 +76,10 @@ assert summary["command"][0:3] == ["ok", "arg with spaces", "semi;colon"]
 assert summary["command"][-1] == "--json-output"
 assert any("$(touch " in arg for arg in summary["command"])
 assert any("`touch " in arg for arg in summary["command"])
+assert summary["execution_time"]["n"] == 1
+assert summary["execution_time"]["stddev_s"] is None
+assert summary["wall_time"]["n"] == 1
+assert summary["wall_time"]["stddev_s"] is None
 PY
 
 set +e

--- a/scripts/test-peekaboo-perf.sh
+++ b/scripts/test-peekaboo-perf.sh
@@ -47,6 +47,37 @@ assert summary["command"] == ["ok", "./private-fixture.json", "--json-output"]
 assert "git_branch" not in summary["environment"]
 PY
 
+PWNED_SUBSHELL="$TMP_DIR/pwned-subshell"
+PWNED_BACKTICK="$TMP_DIR/pwned-backtick"
+"$ROOT/Apps/Playground/scripts/peekaboo-perf.sh" \
+  --name shell-safe \
+  --runs 1 \
+  --log-root "$TMP_DIR/shell-safe" \
+  --bin "$FAKE_BIN" \
+  -- ok \
+  "arg with spaces" \
+  "semi;colon" \
+  "\$(touch $PWNED_SUBSHELL)" \
+  "\`touch $PWNED_BACKTICK\`" \
+  --json-output >/tmp/peekaboo-perf-shell-safe.log
+
+if [[ -e "$PWNED_SUBSHELL" || -e "$PWNED_BACKTICK" ]]; then
+  echo "Benchmark helper executed shell metacharacters from command arguments" >&2
+  exit 1
+fi
+
+SHELL_SAFE_SUMMARY="$(find "$TMP_DIR/shell-safe" -name '*-shell-safe-summary.json' -print -quit)"
+python3 - "$SHELL_SAFE_SUMMARY" <<'PY'
+import json
+import sys
+
+summary = json.load(open(sys.argv[1]))
+assert summary["command"][0:3] == ["ok", "arg with spaces", "semi;colon"]
+assert summary["command"][-1] == "--json-output"
+assert any("$(touch " in arg for arg in summary["command"])
+assert any("`touch " in arg for arg in summary["command"])
+PY
+
 set +e
 "$ROOT/Apps/Playground/scripts/peekaboo-perf.sh" \
   --name failing \

--- a/scripts/test-peekaboo-perf.sh
+++ b/scripts/test-peekaboo-perf.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+FAKE_BIN="$TMP_DIR/fake-peekaboo"
+cat >"$FAKE_BIN" <<'EOF'
+#!/bin/bash
+set -euo pipefail
+
+if [[ "${1:-}" == "fail" ]]; then
+  echo '{"success":false,"data":{"execution_time":0.02}}'
+  exit 7
+fi
+
+echo '{"success":true,"data":{"execution_time":0.01}}'
+EOF
+chmod +x "$FAKE_BIN"
+
+"$ROOT/Apps/Playground/scripts/peekaboo-perf.sh" \
+  --name smoke \
+  --runs 3 \
+  --warmups 1 \
+  --log-root "$TMP_DIR/smoke" \
+  --bin "$FAKE_BIN" \
+  -- ok --json-output >/tmp/peekaboo-perf-smoke.log
+
+SMOKE_SUMMARY="$(find "$TMP_DIR/smoke" -name '*-smoke-summary.json' -print -quit)"
+python3 - "$SMOKE_SUMMARY" <<'PY'
+import json
+import sys
+
+summary = json.load(open(sys.argv[1]))
+assert summary["name"] == "smoke"
+assert summary["run_count"] == 3
+assert summary["warmup_count"] == 1
+assert summary["execution_time"]["n"] == 3
+assert summary["wall_time"]["n"] == 3
+assert summary["failures"] == []
+assert summary["binary"] == "fake-peekaboo"
+assert summary["command"] == ["ok", "--json-output"]
+PY
+
+set +e
+"$ROOT/Apps/Playground/scripts/peekaboo-perf.sh" \
+  --name failing \
+  --runs 1 \
+  --log-root "$TMP_DIR/failing" \
+  --bin "$FAKE_BIN" \
+  -- fail >/tmp/peekaboo-perf-failing.log 2>&1
+FAILING_STATUS="$?"
+set -e
+
+if [[ "$FAILING_STATUS" -eq 0 ]]; then
+  echo "Expected failing benchmark to exit non-zero" >&2
+  exit 1
+fi
+
+"$ROOT/Apps/Playground/scripts/peekaboo-perf.sh" \
+  --name allowed \
+  --runs 1 \
+  --allow-failures \
+  --log-root "$TMP_DIR/allowed" \
+  --bin "$FAKE_BIN" \
+  -- fail >/tmp/peekaboo-perf-allowed.log
+
+ALLOWED_SUMMARY="$(find "$TMP_DIR/allowed" -name '*-allowed-summary.json' -print -quit)"
+python3 - "$ALLOWED_SUMMARY" <<'PY'
+import json
+import sys
+
+summary = json.load(open(sys.argv[1]))
+assert len(summary["failures"]) == 1
+assert summary["failures"][0]["exit_code"] == 7
+assert summary["failures"][0]["reason"] == "exit_code"
+PY
+
+echo "test-peekaboo-perf: ok"

--- a/scripts/test-peekaboo-perf.sh
+++ b/scripts/test-peekaboo-perf.sh
@@ -39,6 +39,8 @@ assert summary["run_count"] == 3
 assert summary["warmup_count"] == 1
 assert summary["execution_time"]["n"] == 3
 assert summary["wall_time"]["n"] == 3
+assert "stddev_s" in summary["execution_time"]
+assert "stddev_s" in summary["wall_time"]
 assert summary["failures"] == []
 assert summary["binary"] == "fake-peekaboo"
 assert summary["command"] == ["ok", "./private-fixture.json", "--json-output"]


### PR DESCRIPTION
## Why

Peekaboo already had a local Playground perf helper and documented performance baselines, but there was no easy, documented way for contributors to run repeatable command-level measurements before proposing performance changes. That made local evidence for performance work harder to collect consistently without adding persistent telemetry.

This PR hardens that existing local helper rather than introducing a benchmark platform. The goal is a small, explicit way to time the same Peekaboo command across multiple runs, separate warmups from measured samples, and produce a shareable summary when investigating command-level regressions or improvements.

## Summary

- Harden `Apps/Playground/scripts/peekaboo-perf.sh` with warmups, argument validation, failure-aware exit behavior, portable summary paths, and local command/environment metadata.
- Expose the existing local helper as `pnpm run benchmark:tools` so contributors can find it without knowing the Playground script path.
- Add `scripts/test-peekaboo-perf.sh` with a fake binary to cover argument handling, failure behavior, summary shape, path sanitization, shell-safe metacharacter arguments, and `stddev_s` reporting.
- Add `docs/testing/benchmarks.md` for local-only usage, macOS measurement hygiene, debug-vs-release caveats, warmup semantics, summary interpretation, and artifact-sharing limits.

This stays intentionally local-only: no daemon, background collector, global metrics store, network upload, or CI performance threshold. Per-run payloads still contain raw command output; the docs call out that contributors should not share artifacts from commands containing secrets or sensitive local paths.

## Validation

- `pnpm run docs:list`
- `pnpm run lint:docs`
- `bash -n Apps/Playground/scripts/peekaboo-perf.sh scripts/test-peekaboo-perf.sh`
- `pnpm run test:benchmark-tools`
- `pnpm run benchmark:tools --help`
- `pnpm run build:cli`
- `pnpm run benchmark:tools --name tools-json-smoke --runs 2 --warmups 1 --bin "$BIN" -- tools --json-output`
- `pnpm run benchmark:tools --name tools-json-smoke-hardened --runs 1 --warmups 1 --bin "$BIN" -- tools --json-output`
- `pnpm run benchmark:tools --name tools-json-smoke-final2 --runs 2 --warmups 1 --bin "$BIN" -- tools --json-output`
- `git diff --check upstream/main...HEAD`

The real CLI smoke wrote its summary under `.artifacts/playground-tools/`; the final summary includes `stddev_s`, portable artifact patterns, sanitized command metadata, and no failures.