### PR TITLE
fix(capture): fall back to desktop-independent window filter on multi-display Macs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - `peekaboo agent` now tells models to use the current tool schema instead of stale tool names and arguments. Thanks @vyctorbrzezowski for #139.
 - AX element detection now honors traversal budgets and reports truncation when depth, count, or per-node child limits are reached. Thanks @vyctorbrzezowski for #140.
 - `peekaboo agent` and MCP clients now have an `inspect_ui` tool for AX-only UI text/control inspection without capturing screenshots. Thanks @vyctorbrzezowski for #141.
+- Window-mode capture now falls back to desktop-independent ScreenCaptureKit filters when multi-display setups cannot map a window to an enumerated display. Thanks @lonexreb for #147.
 
 ## [3.2.0] - 2026-05-15
 

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Capture/LegacyScreenCaptureOperator+Support.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Capture/LegacyScreenCaptureOperator+Support.swift
@@ -97,10 +97,10 @@ extension LegacyScreenCaptureOperator {
         case .noDisplays:
             throw OperationError.captureFailed(
                 reason: "No displays available for window \(windowID) capture")
-        case .mapped(let index):
+        case let .mapped(index):
             mappedDisplay = content.displays[index]
             scaleSourceDisplay = content.displays[index]
-        case .unmapped(let fallbackIndex):
+        case let .unmapped(fallbackIndex):
             mappedDisplay = nil
             scaleSourceDisplay = content.displays[fallbackIndex]
             self.logger.warning(
@@ -120,8 +120,6 @@ extension LegacyScreenCaptureOperator {
             frameWidth: scaleSourceDisplay.frame.width).nativeScale
 
         let config = self.makeScreenshotConfiguration()
-        config.width = max(Int(scWindow.frame.width * nativeScale), 1)
-        config.height = max(Int(scWindow.frame.height * nativeScale), 1)
         config.captureResolution = .best
         config.ignoreShadowsSingleWindow = true
         if #available(macOS 14.2, *) {
@@ -129,8 +127,10 @@ extension LegacyScreenCaptureOperator {
         }
 
         let filter: SCContentFilter
+        let pixelSize: (width: Int, height: Int)
         if let display = mappedDisplay {
             filter = SCContentFilter(display: display, including: [scWindow])
+            pixelSize = ScreenCapturePlanner.capturePixelSize(for: scWindow.frame, scale: nativeScale)
             // Display-bound filters expect display-local geometry. This mirrors the reliable modern path and keeps
             // single-shot captures crisp without relying on the obsolete CoreGraphics window API.
             config.sourceRect = ScreenCapturePlanner.displayLocalSourceRect(
@@ -145,11 +145,19 @@ extension LegacyScreenCaptureOperator {
                 correlationId: correlationId)
         } else {
             filter = SCContentFilter(desktopIndependentWindow: scWindow)
+            let filterScale = CGFloat(filter.pointPixelScale)
+            let outputScale = filterScale.isFinite && filterScale > 0 ? filterScale : nativeScale
+            pixelSize = ScreenCapturePlanner.capturePixelSize(
+                for: filter.contentRect,
+                fallbackFrame: scWindow.frame,
+                scale: outputScale)
             self.logger.debug(
                 "Capturing window via desktop-independent SCScreenshotManager filter",
                 metadata: ["windowID": windowID],
                 correlationId: correlationId)
         }
+        config.width = pixelSize.width
+        config.height = pixelSize.height
 
         return try await ScreenCaptureKitCaptureGate.captureImage(
             contentFilter: filter,

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Capture/LegacyScreenCaptureOperator+Support.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Capture/LegacyScreenCaptureOperator+Support.swift
@@ -85,24 +85,41 @@ extension LegacyScreenCaptureOperator {
                 reason: "Window \(windowID) is not in ScreenCaptureKit shareable content " +
                     "(it may be minimized, off-screen, or on another Space)")
         }
-        guard let display = content.displays.first(where: { $0.frame.intersects(scWindow.frame) }) else {
+
+        let displayFrames = content.displays.map(\.frame)
+        let match = ScreenCapturePlanner.matchDisplay(
+            windowFrame: scWindow.frame,
+            displayFrames: displayFrames)
+
+        let mappedDisplay: SCDisplay?
+        let scaleSourceDisplay: SCDisplay
+        switch match {
+        case .noDisplays:
             throw OperationError.captureFailed(
-                reason: "Window \(windowID) is not on any available display")
+                reason: "No displays available for window \(windowID) capture")
+        case .mapped(let index):
+            mappedDisplay = content.displays[index]
+            scaleSourceDisplay = content.displays[index]
+        case .unmapped(let fallbackIndex):
+            mappedDisplay = nil
+            scaleSourceDisplay = content.displays[fallbackIndex]
+            self.logger.warning(
+                "Window does not map to any enumerated display; using desktop-independent capture filter",
+                metadata: [
+                    "windowID": windowID,
+                    "windowFrame": "\(scWindow.frame)",
+                    "displayCount": content.displays.count,
+                ],
+                correlationId: correlationId)
         }
 
         let nativeScale = ScreenCaptureScaleResolver.plan(
             preference: .native,
-            displayID: display.displayID,
-            fallbackPixelWidth: display.width,
-            frameWidth: display.frame.width).nativeScale
+            displayID: scaleSourceDisplay.displayID,
+            fallbackPixelWidth: scaleSourceDisplay.width,
+            frameWidth: scaleSourceDisplay.frame.width).nativeScale
 
-        let filter = SCContentFilter(display: display, including: [scWindow])
         let config = self.makeScreenshotConfiguration()
-        // Display-bound filters expect display-local geometry. This mirrors the reliable modern path and keeps
-        // single-shot captures crisp without relying on the obsolete CoreGraphics window API.
-        config.sourceRect = ScreenCapturePlanner.displayLocalSourceRect(
-            globalRect: scWindow.frame,
-            displayFrame: display.frame)
         config.width = max(Int(scWindow.frame.width * nativeScale), 1)
         config.height = max(Int(scWindow.frame.height * nativeScale), 1)
         config.captureResolution = .best
@@ -111,13 +128,28 @@ extension LegacyScreenCaptureOperator {
             config.includeChildWindows = false
         }
 
-        self.logger.debug(
-            "Capturing window via display-bound SCScreenshotManager",
-            metadata: [
-                "windowID": windowID,
-                "displayID": display.displayID,
-            ],
-            correlationId: correlationId)
+        let filter: SCContentFilter
+        if let display = mappedDisplay {
+            filter = SCContentFilter(display: display, including: [scWindow])
+            // Display-bound filters expect display-local geometry. This mirrors the reliable modern path and keeps
+            // single-shot captures crisp without relying on the obsolete CoreGraphics window API.
+            config.sourceRect = ScreenCapturePlanner.displayLocalSourceRect(
+                globalRect: scWindow.frame,
+                displayFrame: display.frame)
+            self.logger.debug(
+                "Capturing window via display-bound SCScreenshotManager",
+                metadata: [
+                    "windowID": windowID,
+                    "displayID": display.displayID,
+                ],
+                correlationId: correlationId)
+        } else {
+            filter = SCContentFilter(desktopIndependentWindow: scWindow)
+            self.logger.debug(
+                "Capturing window via desktop-independent SCScreenshotManager filter",
+                metadata: ["windowID": windowID],
+                correlationId: correlationId)
+        }
 
         return try await ScreenCaptureKitCaptureGate.captureImage(
             contentFilter: filter,

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Capture/ScreenCaptureKitOperator+Support.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Capture/ScreenCaptureKitOperator+Support.swift
@@ -62,6 +62,36 @@ extension ScreenCaptureKitOperator {
     }
 
     func display(for window: SCWindow, displays: [SCDisplay]) -> SCDisplay? {
-        displays.first(where: { $0.frame.intersects(window.frame) })
+        let match = ScreenCapturePlanner.matchDisplay(
+            windowFrame: window.frame,
+            displayFrames: displays.map(\.frame))
+        switch match {
+        case .mapped(let index):
+            return displays[index]
+        case .unmapped, .noDisplays:
+            return nil
+        }
+    }
+
+    /// Resolve a display for window capture, returning both the chosen display and whether the
+    /// window cleanly maps to that display. When the window does not map to any enumerated
+    /// display (multi-display setups with partial enumeration, dormant displays, degenerate
+    /// window frames), callers should construct a desktop-independent capture filter rather than
+    /// throwing — the returned display is still useful for scale and metadata purposes.
+    func resolveDisplayForWindow(
+        _ window: SCWindow,
+        displays: [SCDisplay]) -> (display: SCDisplay, isMapped: Bool)?
+    {
+        let match = ScreenCapturePlanner.matchDisplay(
+            windowFrame: window.frame,
+            displayFrames: displays.map(\.frame))
+        switch match {
+        case .mapped(let index):
+            return (displays[index], true)
+        case .unmapped(let fallbackIndex):
+            return (displays[fallbackIndex], false)
+        case .noDisplays:
+            return nil
+        }
     }
 }

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Capture/ScreenCaptureKitOperator+Support.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Capture/ScreenCaptureKitOperator+Support.swift
@@ -66,7 +66,7 @@ extension ScreenCaptureKitOperator {
             windowFrame: window.frame,
             displayFrames: displays.map(\.frame))
         switch match {
-        case .mapped(let index):
+        case let .mapped(index):
             return displays[index]
         case .unmapped, .noDisplays:
             return nil
@@ -86,9 +86,9 @@ extension ScreenCaptureKitOperator {
             windowFrame: window.frame,
             displayFrames: displays.map(\.frame))
         switch match {
-        case .mapped(let index):
+        case let .mapped(index):
             return (displays[index], true)
-        case .unmapped(let fallbackIndex):
+        case let .unmapped(fallbackIndex):
             return (displays[fallbackIndex], false)
         case .noDisplays:
             return nil

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Capture/ScreenCaptureKitOperator+Window.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Capture/ScreenCaptureKitOperator+Window.swift
@@ -245,18 +245,16 @@ extension ScreenCaptureKitOperator {
         useDisplayBoundFilter: Bool = true) async throws -> CGImage
     {
         let scaleValue = scale == .native ? targetScale : 1.0
-        let width = Int(window.frame.width * scaleValue)
-        let height = Int(window.frame.height * scaleValue)
 
         let config = SCStreamConfiguration()
-        config.width = width
-        config.height = height
         config.captureResolution = .best
         config.showsCursor = false
 
         let filter: SCContentFilter
+        let pixelSize: (width: Int, height: Int)
         if useDisplayBoundFilter {
             filter = SCContentFilter(display: display, including: [window])
+            pixelSize = ScreenCapturePlanner.capturePixelSize(for: window.frame, scale: scaleValue)
             // `window.frame` is global desktop coordinates; display-bound filters require display-local `sourceRect`.
             config.sourceRect = ScreenCapturePlanner.displayLocalSourceRect(
                 globalRect: window.frame,
@@ -266,7 +264,15 @@ extension ScreenCaptureKitOperator {
             // display, so no `sourceRect` is needed. This rescues capture on multi-display Macs where
             // `SCShareableContent.displays` enumeration misses the display the window actually lives on.
             filter = SCContentFilter(desktopIndependentWindow: window)
+            let filterScale = CGFloat(filter.pointPixelScale)
+            let outputScale = scale == .native && filterScale.isFinite && filterScale > 0 ? filterScale : scaleValue
+            pixelSize = ScreenCapturePlanner.capturePixelSize(
+                for: filter.contentRect,
+                fallbackFrame: window.frame,
+                scale: outputScale)
         }
+        config.width = pixelSize.width
+        config.height = pixelSize.height
 
         return try await ScreenCaptureKitCaptureGate.captureImage(
             contentFilter: filter,

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Capture/ScreenCaptureKitOperator+Window.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Capture/ScreenCaptureKitOperator+Window.swift
@@ -59,15 +59,27 @@ extension ScreenCaptureKitOperator {
             ],
             correlationId: correlationId)
 
-        guard let targetDisplay = self.display(for: targetWindow, displays: content.displays) else {
-            throw OperationError.captureFailed(reason: "Window is not on any available display")
+        guard let resolution = self.resolveDisplayForWindow(targetWindow, displays: content.displays) else {
+            throw OperationError.captureFailed(reason: "No displays available for window capture")
+        }
+        let targetDisplay = resolution.display
+        if !resolution.isMapped {
+            self.logger.warning(
+                "Window does not map to any enumerated display; using desktop-independent capture filter",
+                metadata: [
+                    "windowID": targetWindow.windowID,
+                    "windowFrame": "\(targetWindow.frame)",
+                    "displayCount": content.displays.count,
+                ],
+                correlationId: correlationId)
         }
         let scalePlan = self.scalePlan(for: targetDisplay, preference: scale)
         let image = try await self.captureWindowImage(
             targetWindow,
             scale: scale,
             scalePlan: scalePlan,
-            display: targetDisplay)
+            display: targetDisplay,
+            useDisplayBoundFilter: resolution.isMapped)
         let imageData = try image.pngData()
 
         self.logger.debug(
@@ -128,15 +140,27 @@ extension ScreenCaptureKitOperator {
             ],
             correlationId: correlationId)
 
-        guard let targetDisplay = self.display(for: targetWindow, displays: content.displays) else {
-            throw OperationError.captureFailed(reason: "Window is not on any available display")
+        guard let resolution = self.resolveDisplayForWindow(targetWindow, displays: content.displays) else {
+            throw OperationError.captureFailed(reason: "No displays available for window capture")
+        }
+        let targetDisplay = resolution.display
+        if !resolution.isMapped {
+            self.logger.warning(
+                "Window does not map to any enumerated display; using desktop-independent capture filter",
+                metadata: [
+                    "windowID": targetWindow.windowID,
+                    "windowFrame": "\(targetWindow.frame)",
+                    "displayCount": content.displays.count,
+                ],
+                correlationId: correlationId)
         }
         let scalePlan = self.scalePlan(for: targetDisplay, preference: scale)
         let image = try await self.captureWindowImage(
             targetWindow,
             scale: scale,
             scalePlan: scalePlan,
-            display: targetDisplay)
+            display: targetDisplay,
+            useDisplayBoundFilter: resolution.isMapped)
         let imageData = try image.pngData()
 
         await self.emitVisualizer(mode: visualizerMode, rect: targetWindow.frame)
@@ -192,39 +216,57 @@ extension ScreenCaptureKitOperator {
         _ window: SCWindow,
         scale: CaptureScalePreference,
         scalePlan: ScreenCaptureScaleResolver.Plan,
-        display: SCDisplay) async throws -> CGImage
+        display: SCDisplay,
+        useDisplayBoundFilter: Bool = true) async throws -> CGImage
     {
         try await RetryHandler.withRetry(policy: .standard) {
             try await self.createScreenshot(
                 of: window,
                 scale: scale,
                 targetScale: scalePlan.nativeScale,
-                display: display)
+                display: display,
+                useDisplayBoundFilter: useDisplayBoundFilter)
         }
     }
 
-    /// Capture a window screenshot using display-based capture.
-    /// `SCContentFilter(display:including:)` stays reliable for GPU-rendered windows such as iOS Simulator.
+    /// Capture a window screenshot.
+    ///
+    /// When `useDisplayBoundFilter` is `true` (the default), uses `SCContentFilter(display:including:)`
+    /// which stays reliable for GPU-rendered windows such as the iOS Simulator. When `false`, falls
+    /// back to `SCContentFilter(desktopIndependentWindow:)` — the ScreenCaptureKit API designed to
+    /// capture a window without needing to identify which display it lives on. The fallback path is
+    /// used when display resolution failed (multi-display setups with partial enumeration), keeping
+    /// the iOS Simulator behavior intact for the common case.
     func createScreenshot(
         of window: SCWindow,
         scale: CaptureScalePreference,
         targetScale: CGFloat,
-        display: SCDisplay) async throws -> CGImage
+        display: SCDisplay,
+        useDisplayBoundFilter: Bool = true) async throws -> CGImage
     {
         let scaleValue = scale == .native ? targetScale : 1.0
         let width = Int(window.frame.width * scaleValue)
         let height = Int(window.frame.height * scaleValue)
 
-        let filter = SCContentFilter(display: display, including: [window])
         let config = SCStreamConfiguration()
-        // `window.frame` is global desktop coordinates; display-bound filters require display-local `sourceRect`.
-        config.sourceRect = ScreenCapturePlanner.displayLocalSourceRect(
-            globalRect: window.frame,
-            displayFrame: display.frame)
         config.width = width
         config.height = height
         config.captureResolution = .best
         config.showsCursor = false
+
+        let filter: SCContentFilter
+        if useDisplayBoundFilter {
+            filter = SCContentFilter(display: display, including: [window])
+            // `window.frame` is global desktop coordinates; display-bound filters require display-local `sourceRect`.
+            config.sourceRect = ScreenCapturePlanner.displayLocalSourceRect(
+                globalRect: window.frame,
+                displayFrame: display.frame)
+        } else {
+            // `desktopIndependentWindow` captures the window's full content without referencing any
+            // display, so no `sourceRect` is needed. This rescues capture on multi-display Macs where
+            // `SCShareableContent.displays` enumeration misses the display the window actually lives on.
+            filter = SCContentFilter(desktopIndependentWindow: window)
+        }
 
         return try await ScreenCaptureKitCaptureGate.captureImage(
             contentFilter: filter,

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Capture/ScreenCapturePlanner.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Capture/ScreenCapturePlanner.swift
@@ -20,6 +20,71 @@ import Foundation
         globalRect.offsetBy(dx: -displayFrame.origin.x, dy: -displayFrame.origin.y)
     }
 
+    /// Result of attempting to map a window to an available display.
+    public enum WindowDisplayMatch: Equatable, Sendable {
+        /// The window cleanly maps to the display at the given index. Capture can use a
+        /// `SCContentFilter(display:including:)` filter with a display-local source rect.
+        case mapped(displayIndex: Int)
+        /// No display contains or overlaps the window's geometry, but at least one display exists.
+        /// Callers should use a display-independent filter (`SCContentFilter(desktopIndependentWindow:)`).
+        /// `fallbackDisplayIndex` is a best-effort display to read scale and metadata from.
+        case unmapped(fallbackDisplayIndex: Int)
+        /// No displays were enumerated at all. Capture cannot proceed.
+        case noDisplays
+    }
+
+    /// Map a window's global desktop rectangle to one of the supplied display rectangles.
+    ///
+    /// Strategy, in order:
+    /// 1. Display containing the window's geometric center.
+    /// 2. Display with the largest intersection area with the window.
+    /// 3. If the window is degenerate (null / zero size) or sits entirely outside every display,
+    ///    return `.unmapped` so the caller can fall back to a desktop-independent capture filter.
+    ///    The chosen fallback prefers the display whose origin is `(0, 0)` (typically the primary)
+    ///    and otherwise the first enumerated display.
+    ///
+    /// The current `frame.intersects(window.frame)` check used by the live capture path is
+    /// insufficient under three real-world conditions reported by users:
+    /// - The window has a degenerate frame (e.g. `.zero`) on certain multi-display setups,
+    ///   which makes `CGRectIntersectsRect` return false for every display.
+    /// - `SCShareableContent.displays` enumeration is incomplete (e.g. dormant secondary displays,
+    ///   permission scoping, virtual / DisplayLink adapters) so the display the window actually
+    ///   lives on is absent from the list.
+    /// - The window straddles two displays and a deterministic primary choice is desirable.
+    public static func matchDisplay(
+        windowFrame: CGRect,
+        displayFrames: [CGRect]) -> WindowDisplayMatch
+    {
+        guard !displayFrames.isEmpty else { return .noDisplays }
+
+        let windowIsUsable = !windowFrame.isNull && !windowFrame.isEmpty
+
+        if windowIsUsable {
+            let center = CGPoint(x: windowFrame.midX, y: windowFrame.midY)
+            if let centerIndex = displayFrames.firstIndex(where: { $0.contains(center) }) {
+                return .mapped(displayIndex: centerIndex)
+            }
+
+            var bestIndex: Int?
+            var bestArea: CGFloat = 0
+            for (index, frame) in displayFrames.enumerated() {
+                let intersection = frame.intersection(windowFrame)
+                guard !intersection.isNull, !intersection.isEmpty else { continue }
+                let area = intersection.width * intersection.height
+                if area > bestArea {
+                    bestArea = area
+                    bestIndex = index
+                }
+            }
+            if let bestIndex {
+                return .mapped(displayIndex: bestIndex)
+            }
+        }
+
+        let fallback = displayFrames.firstIndex(where: { $0.origin == .zero }) ?? 0
+        return .unmapped(fallbackDisplayIndex: fallback)
+    }
+
     public static func frameSourcePolicy(
         for mode: CaptureMode,
         windowID: CGWindowID?) -> FrameSourcePolicy

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Capture/ScreenCapturePlanner.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Capture/ScreenCapturePlanner.swift
@@ -20,6 +20,37 @@ import Foundation
         globalRect.offsetBy(dx: -displayFrame.origin.x, dy: -displayFrame.origin.y)
     }
 
+    public static func capturePixelSize(
+        for frame: CGRect,
+        fallbackFrame: CGRect? = nil,
+        scale: CGFloat) -> (width: Int, height: Int)
+    {
+        let sourceFrame = self.captureSizeSourceFrame(frame, fallbackFrame: fallbackFrame)
+        return (
+            width: self.capturePixelDimension(sourceFrame.width, scale: scale),
+            height: self.capturePixelDimension(sourceFrame.height, scale: scale))
+    }
+
+    private static func captureSizeSourceFrame(_ frame: CGRect, fallbackFrame: CGRect?) -> CGRect {
+        if self.isUsableCaptureSizeFrame(frame) {
+            return frame
+        }
+        if let fallbackFrame, self.isUsableCaptureSizeFrame(fallbackFrame) {
+            return fallbackFrame
+        }
+        return .zero
+    }
+
+    private static func isUsableCaptureSizeFrame(_ frame: CGRect) -> Bool {
+        !frame.isNull && !frame.isEmpty && frame.width.isFinite && frame.height.isFinite
+    }
+
+    private static func capturePixelDimension(_ logicalLength: CGFloat, scale: CGFloat) -> Int {
+        let scaledLength = logicalLength * scale
+        guard scaledLength.isFinite, scaledLength > 0 else { return 1 }
+        return max(Int(scaledLength), 1)
+    }
+
     /// Result of attempting to map a window to an available display.
     public enum WindowDisplayMatch: Equatable, Sendable {
         /// The window cleanly maps to the display at the given index. Capture can use a

--- a/Core/PeekabooCore/Tests/PeekabooTests/ScreenCapturePlannerMatchDisplayTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/ScreenCapturePlannerMatchDisplayTests.swift
@@ -1,0 +1,280 @@
+import CoreGraphics
+import Foundation
+import Testing
+@_spi(Testing) import PeekabooAutomationKit
+
+/// Regression coverage for `ScreenCapturePlanner.matchDisplay` — the helper that maps a window's
+/// global desktop rectangle to one of the enumerated displays. Introduced to resolve issue #143,
+/// where window-mode capture failed on a multi-display Mac Mini even though `peekaboo window list`
+/// reported the same window as on-screen. The previous code used `SCDisplay.frame.intersects(window.frame)`
+/// directly and threw on `nil`, which left no recovery path for degenerate window frames or partial
+/// display enumeration. The new helper degrades gracefully to a desktop-independent capture filter.
+@Suite
+struct ScreenCapturePlannerMatchDisplayTests {
+    // MARK: - Single-display happy paths
+
+    @Test("window inside the only display maps to index 0")
+    func windowInsideOnlyDisplay() {
+        let displays = [CGRect(x: 0, y: 0, width: 1920, height: 1080)]
+        let window = CGRect(x: 0, y: 30, width: 1920, height: 960)
+
+        let match = ScreenCapturePlanner.matchDisplay(
+            windowFrame: window,
+            displayFrames: displays)
+
+        #expect(match == .mapped(displayIndex: 0))
+    }
+
+    @Test("window matching the reporter's exact bounds maps to the primary display")
+    func windowMatchingReporterBounds() {
+        // From issue #143: Telegram window reported at (0, 30, 1920, 960) on a Mac Mini.
+        // The current `.intersects` test would also succeed for this geometry against the
+        // primary display, but we lock the behavior in so any future refactor that drops
+        // primary-display matching gets caught.
+        let displays = [
+            CGRect(x: 0, y: 0, width: 1920, height: 1080),
+            CGRect(x: 1920, y: 0, width: 1920, height: 1080),
+            CGRect(x: 0, y: -1080, width: 1920, height: 1080),
+        ]
+        let window = CGRect(x: 0, y: 30, width: 1920, height: 960)
+
+        let match = ScreenCapturePlanner.matchDisplay(
+            windowFrame: window,
+            displayFrames: displays)
+
+        #expect(match == .mapped(displayIndex: 0))
+    }
+
+    // MARK: - Multi-display geometries
+
+    @Test("window centered on the secondary right-hand display maps to index 1")
+    func windowOnSecondaryRightDisplay() {
+        let displays = [
+            CGRect(x: 0, y: 0, width: 1920, height: 1080),
+            CGRect(x: 1920, y: 0, width: 2560, height: 1440),
+        ]
+        let window = CGRect(x: 2500, y: 200, width: 1200, height: 800)
+
+        let match = ScreenCapturePlanner.matchDisplay(
+            windowFrame: window,
+            displayFrames: displays)
+
+        #expect(match == .mapped(displayIndex: 1))
+    }
+
+    @Test("window on a display stacked above the primary (negative Y origin) maps correctly")
+    func windowOnDisplayAbovePrimary() {
+        let displays = [
+            CGRect(x: 0, y: 0, width: 1920, height: 1080),
+            CGRect(x: 0, y: -1080, width: 1920, height: 1080),
+        ]
+        let window = CGRect(x: 200, y: -500, width: 600, height: 400)
+
+        let match = ScreenCapturePlanner.matchDisplay(
+            windowFrame: window,
+            displayFrames: displays)
+
+        #expect(match == .mapped(displayIndex: 1))
+    }
+
+    @Test("window on a display to the left of primary (negative X origin) maps correctly")
+    func windowOnDisplayLeftOfPrimary() {
+        let displays = [
+            CGRect(x: 0, y: 0, width: 1920, height: 1080),
+            CGRect(x: -3008, y: 0, width: 3008, height: 1692),
+        ]
+        let window = CGRect(x: -2000, y: 100, width: 800, height: 600)
+
+        let match = ScreenCapturePlanner.matchDisplay(
+            windowFrame: window,
+            displayFrames: displays)
+
+        #expect(match == .mapped(displayIndex: 1))
+    }
+
+    @Test("three-display L-shape Mac Mini configuration resolves a centered window deterministically")
+    func threeDisplayLShape() {
+        // Approximates the reporter's Mac Mini: primary + right + above-primary.
+        let displays = [
+            CGRect(x: 0, y: 0, width: 1920, height: 1080),
+            CGRect(x: 1920, y: 0, width: 1920, height: 1080),
+            CGRect(x: 0, y: -1080, width: 1920, height: 1080),
+        ]
+
+        let onPrimary = CGRect(x: 400, y: 400, width: 600, height: 400)
+        let onRight = CGRect(x: 2400, y: 400, width: 600, height: 400)
+        let onAbove = CGRect(x: 400, y: -700, width: 600, height: 400)
+
+        #expect(ScreenCapturePlanner.matchDisplay(
+            windowFrame: onPrimary,
+            displayFrames: displays) == .mapped(displayIndex: 0))
+        #expect(ScreenCapturePlanner.matchDisplay(
+            windowFrame: onRight,
+            displayFrames: displays) == .mapped(displayIndex: 1))
+        #expect(ScreenCapturePlanner.matchDisplay(
+            windowFrame: onAbove,
+            displayFrames: displays) == .mapped(displayIndex: 2))
+    }
+
+    // MARK: - Straddling and ambiguous geometry
+
+    @Test("window straddling two displays maps to whichever contains the center point")
+    func windowStraddlingTwoDisplaysPrefersCenter() {
+        let displays = [
+            CGRect(x: 0, y: 0, width: 1920, height: 1080),
+            CGRect(x: 1920, y: 0, width: 1920, height: 1080),
+        ]
+        // Window spans (1800..2200) horizontally — midX = 2000 sits on the second display.
+        let window = CGRect(x: 1800, y: 100, width: 400, height: 300)
+
+        let match = ScreenCapturePlanner.matchDisplay(
+            windowFrame: window,
+            displayFrames: displays)
+
+        #expect(match == .mapped(displayIndex: 1))
+    }
+
+    @Test("window with no center hit falls back to the display with the largest overlap area")
+    func windowFallsBackToLargestOverlapWhenCenterMisses() {
+        // Place displays with a gap so that no display contains the center, but one has more overlap.
+        let displays = [
+            CGRect(x: 0, y: 0, width: 100, height: 100),
+            CGRect(x: 200, y: 0, width: 100, height: 100),
+        ]
+        // Window spans both displays plus the 100px gap; center (150, 50) is in neither.
+        // Overlap with display 0: (50, 0, 50, 100) = 5000. Overlap with display 1: (200, 0, 50, 100) = 5000.
+        // Tie-breaker is iteration order, so the earlier index wins.
+        let window = CGRect(x: 50, y: 0, width: 200, height: 100)
+
+        let match = ScreenCapturePlanner.matchDisplay(
+            windowFrame: window,
+            displayFrames: displays)
+
+        #expect(match == .mapped(displayIndex: 0))
+    }
+
+    @Test("window with no center hit picks the display with strictly larger overlap")
+    func windowPicksLargerOverlapDisplay() {
+        let displays = [
+            CGRect(x: 0, y: 0, width: 100, height: 100),
+            CGRect(x: 200, y: 0, width: 100, height: 100),
+        ]
+        // Center (190, 50) is in neither. Overlap with display 0: (140, 0, 60, 100) — wait, that would
+        // actually contain the center. Use a window centered in the gap but skewed toward display 1.
+        // Window: x=110, w=180 → spans 110..290, center 200 is on display 1's left edge (200, 0).
+        // display 1 contains center? `.contains(CGPoint)` is inclusive of origin so yes — adjust.
+        // Use x=110, w=140 → spans 110..250, center=180 in the gap, no center hit.
+        // Overlap with display 0: (110, 0, ...) intersect (0,0,100,100) = (110..100) = empty. Hmm.
+        // Use x=80, w=140 → 80..220, center=150 in gap, overlap0 = (80..100)=20*100=2000, overlap1 = (200..220)=20*100=2000. Tie.
+        // Make it asymmetric: x=70, w=140 → 70..210, center=140 in gap, overlap0=(70..100)=30*100=3000, overlap1=(200..210)=10*100=1000. Display 0 wins.
+        let window = CGRect(x: 70, y: 0, width: 140, height: 100)
+
+        let match = ScreenCapturePlanner.matchDisplay(
+            windowFrame: window,
+            displayFrames: displays)
+
+        #expect(match == .mapped(displayIndex: 0))
+    }
+
+    // MARK: - Unmapped fallback paths (the core #143 fix)
+
+    @Test("window entirely outside every display returns .unmapped with a sensible fallback")
+    func windowEntirelyOffscreenReturnsUnmapped() {
+        let displays = [
+            CGRect(x: 0, y: 0, width: 1920, height: 1080),
+            CGRect(x: 1920, y: 0, width: 1920, height: 1080),
+        ]
+        // Window far below any display.
+        let window = CGRect(x: 100, y: 5000, width: 400, height: 300)
+
+        let match = ScreenCapturePlanner.matchDisplay(
+            windowFrame: window,
+            displayFrames: displays)
+
+        // Primary (origin == .zero) is preferred as the fallback for scale and metadata purposes;
+        // the operator will use a desktop-independent capture filter regardless.
+        #expect(match == .unmapped(fallbackDisplayIndex: 0))
+    }
+
+    @Test("degenerate zero-size window returns .unmapped (issue #143's likely failure mode)")
+    func zeroSizeWindowReturnsUnmapped() {
+        let displays = [
+            CGRect(x: 0, y: 0, width: 1920, height: 1080),
+        ]
+        // Reproduces the suspected Mac Mini failure: SCWindow.frame reports degenerate bounds on
+        // certain multi-display setups, which makes the old `.intersects` test return false for
+        // every display.
+        let window = CGRect.zero
+
+        let match = ScreenCapturePlanner.matchDisplay(
+            windowFrame: window,
+            displayFrames: displays)
+
+        #expect(match == .unmapped(fallbackDisplayIndex: 0))
+    }
+
+    @Test("null window rect returns .unmapped")
+    func nullWindowRectReturnsUnmapped() {
+        let displays = [
+            CGRect(x: 0, y: 0, width: 1920, height: 1080),
+        ]
+
+        let match = ScreenCapturePlanner.matchDisplay(
+            windowFrame: .null,
+            displayFrames: displays)
+
+        #expect(match == .unmapped(fallbackDisplayIndex: 0))
+    }
+
+    @Test("fallback prefers the display with origin (0, 0) even when listed second")
+    func fallbackPrefersOriginDisplay() {
+        // Primary is at (0,0) but listed second — emulates an enumeration order quirk.
+        let displays = [
+            CGRect(x: 1920, y: 0, width: 1920, height: 1080),
+            CGRect(x: 0, y: 0, width: 1920, height: 1080),
+        ]
+        let window = CGRect(x: 10000, y: 10000, width: 100, height: 100)
+
+        let match = ScreenCapturePlanner.matchDisplay(
+            windowFrame: window,
+            displayFrames: displays)
+
+        #expect(match == .unmapped(fallbackDisplayIndex: 1))
+    }
+
+    @Test("fallback uses index 0 when no display sits at origin")
+    func fallbackUsesFirstDisplayWhenNoOriginDisplay() {
+        // Pathological config where no display has origin (0,0) — e.g. only a single secondary display
+        // is enumerated. The fallback should still pick a deterministic index so capture can proceed.
+        let displays = [
+            CGRect(x: 1920, y: 0, width: 1920, height: 1080),
+        ]
+        let window = CGRect(x: 100, y: 100, width: 100, height: 100)
+
+        let match = ScreenCapturePlanner.matchDisplay(
+            windowFrame: window,
+            displayFrames: displays)
+
+        #expect(match == .unmapped(fallbackDisplayIndex: 0))
+    }
+
+    // MARK: - Empty enumeration
+
+    @Test("no displays returns .noDisplays so callers can throw with a clear error")
+    func noDisplaysReturnsNoDisplays() {
+        let match = ScreenCapturePlanner.matchDisplay(
+            windowFrame: CGRect(x: 0, y: 0, width: 100, height: 100),
+            displayFrames: [])
+
+        #expect(match == .noDisplays)
+    }
+
+    @Test("no displays with degenerate window also returns .noDisplays")
+    func noDisplaysWithDegenerateWindow() {
+        let match = ScreenCapturePlanner.matchDisplay(
+            windowFrame: .zero,
+            displayFrames: [])
+
+        #expect(match == .noDisplays)
+    }
+}

--- a/Core/PeekabooCore/Tests/PeekabooTests/ScreenCapturePlannerMatchDisplayTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/ScreenCapturePlannerMatchDisplayTests.swift
@@ -9,12 +9,11 @@ import Testing
 /// reported the same window as on-screen. The previous code used `SCDisplay.frame.intersects(window.frame)`
 /// directly and threw on `nil`, which left no recovery path for degenerate window frames or partial
 /// display enumeration. The new helper degrades gracefully to a desktop-independent capture filter.
-@Suite
 struct ScreenCapturePlannerMatchDisplayTests {
     // MARK: - Single-display happy paths
 
-    @Test("window inside the only display maps to index 0")
-    func windowInsideOnlyDisplay() {
+    @Test
+    func `window inside the only display maps to index 0`() {
         let displays = [CGRect(x: 0, y: 0, width: 1920, height: 1080)]
         let window = CGRect(x: 0, y: 30, width: 1920, height: 960)
 
@@ -25,8 +24,8 @@ struct ScreenCapturePlannerMatchDisplayTests {
         #expect(match == .mapped(displayIndex: 0))
     }
 
-    @Test("window matching the reporter's exact bounds maps to the primary display")
-    func windowMatchingReporterBounds() {
+    @Test
+    func `window matching the reporter's exact bounds maps to the primary display`() {
         // From issue #143: Telegram window reported at (0, 30, 1920, 960) on a Mac Mini.
         // The current `.intersects` test would also succeed for this geometry against the
         // primary display, but we lock the behavior in so any future refactor that drops
@@ -47,8 +46,8 @@ struct ScreenCapturePlannerMatchDisplayTests {
 
     // MARK: - Multi-display geometries
 
-    @Test("window centered on the secondary right-hand display maps to index 1")
-    func windowOnSecondaryRightDisplay() {
+    @Test
+    func `window centered on the secondary right-hand display maps to index 1`() {
         let displays = [
             CGRect(x: 0, y: 0, width: 1920, height: 1080),
             CGRect(x: 1920, y: 0, width: 2560, height: 1440),
@@ -62,8 +61,8 @@ struct ScreenCapturePlannerMatchDisplayTests {
         #expect(match == .mapped(displayIndex: 1))
     }
 
-    @Test("window on a display stacked above the primary (negative Y origin) maps correctly")
-    func windowOnDisplayAbovePrimary() {
+    @Test
+    func `window on a display stacked above the primary (negative Y origin) maps correctly`() {
         let displays = [
             CGRect(x: 0, y: 0, width: 1920, height: 1080),
             CGRect(x: 0, y: -1080, width: 1920, height: 1080),
@@ -77,8 +76,8 @@ struct ScreenCapturePlannerMatchDisplayTests {
         #expect(match == .mapped(displayIndex: 1))
     }
 
-    @Test("window on a display to the left of primary (negative X origin) maps correctly")
-    func windowOnDisplayLeftOfPrimary() {
+    @Test
+    func `window on a display to the left of primary (negative X origin) maps correctly`() {
         let displays = [
             CGRect(x: 0, y: 0, width: 1920, height: 1080),
             CGRect(x: -3008, y: 0, width: 3008, height: 1692),
@@ -92,8 +91,8 @@ struct ScreenCapturePlannerMatchDisplayTests {
         #expect(match == .mapped(displayIndex: 1))
     }
 
-    @Test("three-display L-shape Mac Mini configuration resolves a centered window deterministically")
-    func threeDisplayLShape() {
+    @Test
+    func `three-display L-shape Mac Mini configuration resolves a centered window deterministically`() {
         // Approximates the reporter's Mac Mini: primary + right + above-primary.
         let displays = [
             CGRect(x: 0, y: 0, width: 1920, height: 1080),
@@ -118,8 +117,8 @@ struct ScreenCapturePlannerMatchDisplayTests {
 
     // MARK: - Straddling and ambiguous geometry
 
-    @Test("window straddling two displays maps to whichever contains the center point")
-    func windowStraddlingTwoDisplaysPrefersCenter() {
+    @Test
+    func `window straddling two displays maps to whichever contains the center point`() {
         let displays = [
             CGRect(x: 0, y: 0, width: 1920, height: 1080),
             CGRect(x: 1920, y: 0, width: 1920, height: 1080),
@@ -134,8 +133,8 @@ struct ScreenCapturePlannerMatchDisplayTests {
         #expect(match == .mapped(displayIndex: 1))
     }
 
-    @Test("window with no center hit falls back to the display with the largest overlap area")
-    func windowFallsBackToLargestOverlapWhenCenterMisses() {
+    @Test
+    func `window with no center hit falls back to the display with the largest overlap area`() {
         // Place displays with a gap so that no display contains the center, but one has more overlap.
         let displays = [
             CGRect(x: 0, y: 0, width: 100, height: 100),
@@ -153,20 +152,13 @@ struct ScreenCapturePlannerMatchDisplayTests {
         #expect(match == .mapped(displayIndex: 0))
     }
 
-    @Test("window with no center hit picks the display with strictly larger overlap")
-    func windowPicksLargerOverlapDisplay() {
+    @Test
+    func `window with no center hit picks the display with strictly larger overlap`() {
         let displays = [
             CGRect(x: 0, y: 0, width: 100, height: 100),
             CGRect(x: 200, y: 0, width: 100, height: 100),
         ]
-        // Center (190, 50) is in neither. Overlap with display 0: (140, 0, 60, 100) — wait, that would
-        // actually contain the center. Use a window centered in the gap but skewed toward display 1.
-        // Window: x=110, w=180 → spans 110..290, center 200 is on display 1's left edge (200, 0).
-        // display 1 contains center? `.contains(CGPoint)` is inclusive of origin so yes — adjust.
-        // Use x=110, w=140 → spans 110..250, center=180 in the gap, no center hit.
-        // Overlap with display 0: (110, 0, ...) intersect (0,0,100,100) = (110..100) = empty. Hmm.
-        // Use x=80, w=140 → 80..220, center=150 in gap, overlap0 = (80..100)=20*100=2000, overlap1 = (200..220)=20*100=2000. Tie.
-        // Make it asymmetric: x=70, w=140 → 70..210, center=140 in gap, overlap0=(70..100)=30*100=3000, overlap1=(200..210)=10*100=1000. Display 0 wins.
+        // Center is in the gap. Display 0 has 30 px of overlap; display 1 has 10 px.
         let window = CGRect(x: 70, y: 0, width: 140, height: 100)
 
         let match = ScreenCapturePlanner.matchDisplay(
@@ -176,10 +168,39 @@ struct ScreenCapturePlannerMatchDisplayTests {
         #expect(match == .mapped(displayIndex: 0))
     }
 
+    @Test
+    func `capture pixel size never returns zero dimensions for degenerate window frames`() {
+        #expect(ScreenCapturePlanner.capturePixelSize(for: .zero, scale: 2).width == 1)
+        #expect(ScreenCapturePlanner.capturePixelSize(for: .zero, scale: 2).height == 1)
+        #expect(ScreenCapturePlanner.capturePixelSize(for: .null, scale: 2).width == 1)
+        #expect(ScreenCapturePlanner.capturePixelSize(for: .null, scale: 2).height == 1)
+    }
+
+    @Test
+    func `capture pixel size scales usable window frames`() {
+        let size = ScreenCapturePlanner.capturePixelSize(
+            for: CGRect(x: 0, y: 0, width: 320, height: 180),
+            scale: 2)
+
+        #expect(size.width == 640)
+        #expect(size.height == 360)
+    }
+
+    @Test
+    func `capture pixel size uses fallback frame when primary frame is degenerate`() {
+        let size = ScreenCapturePlanner.capturePixelSize(
+            for: .zero,
+            fallbackFrame: CGRect(x: 10, y: 20, width: 320, height: 180),
+            scale: 2)
+
+        #expect(size.width == 640)
+        #expect(size.height == 360)
+    }
+
     // MARK: - Unmapped fallback paths (the core #143 fix)
 
-    @Test("window entirely outside every display returns .unmapped with a sensible fallback")
-    func windowEntirelyOffscreenReturnsUnmapped() {
+    @Test
+    func `window entirely outside every display returns .unmapped with a sensible fallback`() {
         let displays = [
             CGRect(x: 0, y: 0, width: 1920, height: 1080),
             CGRect(x: 1920, y: 0, width: 1920, height: 1080),
@@ -196,8 +217,8 @@ struct ScreenCapturePlannerMatchDisplayTests {
         #expect(match == .unmapped(fallbackDisplayIndex: 0))
     }
 
-    @Test("degenerate zero-size window returns .unmapped (issue #143's likely failure mode)")
-    func zeroSizeWindowReturnsUnmapped() {
+    @Test
+    func `degenerate zero-size window returns .unmapped (issue #143's likely failure mode)`() {
         let displays = [
             CGRect(x: 0, y: 0, width: 1920, height: 1080),
         ]
@@ -213,8 +234,8 @@ struct ScreenCapturePlannerMatchDisplayTests {
         #expect(match == .unmapped(fallbackDisplayIndex: 0))
     }
 
-    @Test("null window rect returns .unmapped")
-    func nullWindowRectReturnsUnmapped() {
+    @Test
+    func `null window rect returns .unmapped`() {
         let displays = [
             CGRect(x: 0, y: 0, width: 1920, height: 1080),
         ]
@@ -226,8 +247,8 @@ struct ScreenCapturePlannerMatchDisplayTests {
         #expect(match == .unmapped(fallbackDisplayIndex: 0))
     }
 
-    @Test("fallback prefers the display with origin (0, 0) even when listed second")
-    func fallbackPrefersOriginDisplay() {
+    @Test
+    func `fallback prefers the display with origin (0, 0) even when listed second`() {
         // Primary is at (0,0) but listed second — emulates an enumeration order quirk.
         let displays = [
             CGRect(x: 1920, y: 0, width: 1920, height: 1080),
@@ -242,8 +263,8 @@ struct ScreenCapturePlannerMatchDisplayTests {
         #expect(match == .unmapped(fallbackDisplayIndex: 1))
     }
 
-    @Test("fallback uses index 0 when no display sits at origin")
-    func fallbackUsesFirstDisplayWhenNoOriginDisplay() {
+    @Test
+    func `fallback uses index 0 when no display sits at origin`() {
         // Pathological config where no display has origin (0,0) — e.g. only a single secondary display
         // is enumerated. The fallback should still pick a deterministic index so capture can proceed.
         let displays = [
@@ -260,8 +281,8 @@ struct ScreenCapturePlannerMatchDisplayTests {
 
     // MARK: - Empty enumeration
 
-    @Test("no displays returns .noDisplays so callers can throw with a clear error")
-    func noDisplaysReturnsNoDisplays() {
+    @Test
+    func `no displays returns .noDisplays so callers can throw with a clear error`() {
         let match = ScreenCapturePlanner.matchDisplay(
             windowFrame: CGRect(x: 0, y: 0, width: 100, height: 100),
             displayFrames: [])
@@ -269,8 +290,8 @@ struct ScreenCapturePlannerMatchDisplayTests {
         #expect(match == .noDisplays)
     }
 
-    @Test("no displays with degenerate window also returns .noDisplays")
-    func noDisplaysWithDegenerateWindow() {
+    @Test
+    func `no displays with degenerate window also returns .noDisplays`() {
         let match = ScreenCapturePlanner.matchDisplay(
             windowFrame: .zero,
             displayFrames: [])


### PR DESCRIPTION
Closes #143.

### What was happening

On the reporter's Mac Mini with three displays, `peekaboo see --app <X>` returned `CAPTURE_FAILED: Window is not on any available display` for every app and every capture engine (`classic`, `cg`, `modern`, `sckit`) — even though `peekaboo window list` reported the same window as `is_on_screen: true` at `(0, 30, 1920, 960)`. Screen-mode capture worked, so the failure was in window→display mapping rather than permission or basic ScreenCaptureKit availability.

### Root cause

Both the modern and legacy paths gated window capture on:

```swift
displays.first(where: { $0.frame.intersects(window.frame) })
```

When that returned `nil` we threw and gave up. That `.intersects` check is fragile in three real-world conditions:

- **Degenerate `SCWindow.frame`** — on certain multi-display setups SCWindow reports a `.zero` (or otherwise empty) frame, and `CGRectIntersectsRect` returns `false` for any empty rect, regardless of where the actual window lives.
- **Partial `SCShareableContent.displays` enumeration** — dormant secondary displays, virtual / DisplayLink adapters, and per-display permission scoping can leave the display the window actually lives on out of the list entirely.
- **Straddling / edge cases** — a window spanning two displays maps non-deterministically with `first(where:)`.

### The fix

A new `ScreenCapturePlanner.matchDisplay(windowFrame:displayFrames:)` helper that:

1. Prefers the display containing the window's **center point**.
2. Falls back to the display with the **largest intersection area**.
3. Returns `.unmapped(fallbackDisplayIndex:)` when neither succeeds — instead of failing.

Callers that get `.unmapped` build `SCContentFilter(desktopIndependentWindow:)` — the ScreenCaptureKit API specifically designed to capture a window without needing to identify which display it lives on — and log a warning so the fallback is observable in support logs.

The existing display-bound filter path (`SCContentFilter(display:including:)`) is preserved for the common case. The PR explicitly keeps that path so iOS Simulator and other GPU-rendered windows — which the existing comment calls out as needing display-bound capture — continue to work as before. The desktop-independent filter is only used as a rescue when display resolution genuinely cannot find a match.

### Files changed

- `Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Capture/ScreenCapturePlanner.swift` — new `WindowDisplayMatch` enum + `matchDisplay` helper.
- `Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Capture/ScreenCaptureKitOperator+Support.swift` — new `resolveDisplayForWindow` helper; existing `display(for:)` rewritten on top of `matchDisplay`.
- `Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Capture/ScreenCaptureKitOperator+Window.swift` — both `captureWindowImpl` variants and `createScreenshot` accept a `useDisplayBoundFilter` flag and route to the appropriate `SCContentFilter`.
- `Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Capture/LegacyScreenCaptureOperator+Support.swift` — same routing in `captureWindowWithScreenshotManagerAttempt`. Scale planning now uses the fallback display's `displayID`.
- `Core/PeekabooCore/Tests/PeekabooTests/ScreenCapturePlannerMatchDisplayTests.swift` — 16 new regression tests.

### Test coverage

`ScreenCapturePlannerMatchDisplayTests` covers:

- Single-display happy path + the reporter's exact bounds `(0, 30, 1920, 960)`.
- Multi-display geometries: right-of-primary, above-primary (negative Y origin), left-of-primary (negative X origin), three-display L-shape Mac Mini configuration.
- Window straddling two displays — locks in center-point preference.
- Largest-overlap fallback when center misses (both unambiguous and tie cases).
- Degenerate windows: `.zero` size, `.null` rect — the suspected #143 failure mode.
- Empty display enumeration → `.noDisplays` (preserves the ability to surface a clear error).
- Fallback display selection: prefers origin-at-(0,0), else index 0.

```
✔ Test run with 16 tests in 1 suite passed after 0.001 seconds.
```

Plus the full existing screen capture test suites (36 tests across `ScreenCaptureServicePlanTests`, `ScreenCaptureServiceFlowTests`, etc.) still pass, and the broader safe suite (`pnpm run test:safe`) shows **439 tests across 63 suites all green** with no regressions. SwiftLint clean on all changed files.

### Verification I could and could not perform

- **Could**: full Swift compilation of `PeekabooAutomationKit`, the 16-test regression suite, all existing screen-capture flow tests, the repo's safe test suite, SwiftLint on every changed file.
- **Could not**: end-to-end reproduction on the reporter's specific Mac Mini multi-display hardware — my dev machine doesn't have that rig. The fix targets the most plausible failure modes (degenerate frame, missing display in enumeration) and gives ScreenCaptureKit a path it can use without needing to identify which display the window is on. Happy to iterate based on feedback from the reporter or anyone with multi-display hardware.

### Behavior summary

| Scenario | Before | After |
| --- | --- | --- |
| Window cleanly on one display | display-bound filter | display-bound filter (unchanged) |
| Window straddles two displays | first-match wins (non-deterministic) | display containing center wins |
| `SCWindow.frame` is degenerate | throws `CAPTURE_FAILED` | desktop-independent filter rescues capture |
| Display the window lives on is missing from enumeration | throws `CAPTURE_FAILED` | desktop-independent filter rescues capture |
| No displays enumerated at all | throws `CAPTURE_FAILED` | still throws (now with `"No displays available for window capture"`) |

### Notes for reviewers

- The new `.unmapped` path logs a `warning` with `windowID`, `windowFrame`, and `displayCount` so we have signal if this fires in the wild and need to chase the underlying SCShareableContent enumeration gap.
- `displayLocalSourceRect` is intentionally only applied on the display-bound branch — the desktop-independent filter captures the window's full content without a `sourceRect`.
- I kept `display(for:displays:)` as a thin wrapper over `matchDisplay` to avoid disturbing any external callers, but the operator code now uses `resolveDisplayForWindow` to get both the chosen display and the `isMapped` flag in one shot.