### PR TITLE
feat: GameBridge detection for SDL/GPU-rendered game windows

### DIFF
--- a/Apps/CLI/Tests/CoreCLITests/GameBridgeDetectionTests.swift
+++ b/Apps/CLI/Tests/CoreCLITests/GameBridgeDetectionTests.swift
@@ -195,6 +195,39 @@ struct GameBridgeDetectionTests {
 
     @available(macOS 14.0, *)
     @Test
+    func `Static text is not grouped as text field`() throws {
+        let json = """
+        {"version":1,"app":"firestaff","gameState":"test",
+         "framebuffer":{"width":320,"height":200},
+         "elements":[{"id":"LABEL","type":"text","label":"Status",
+         "bounds":{"x":10,"y":20,"w":40,"h":10}}]}
+        """
+        let manifestRootURL = try self.writeFirestaffManifest(json)
+        defer { try? FileManager.default.removeItem(at: manifestRootURL) }
+
+        let context = WindowContext(
+            applicationName: "firestaff",
+            applicationBundleId: nil,
+            applicationProcessId: nil,
+            windowTitle: nil,
+            windowID: nil,
+            windowBounds: nil,
+            shouldFocusWebContent: false,
+            traversalBudget: nil
+        )
+        let result = try #require(GameBridgeDetectionService.tryDetect(
+            windowContext: context,
+            snapshotId: "static-text-snapshot",
+            manifestRootURL: manifestRootURL
+        ))
+
+        #expect(result.elements.textFields.isEmpty)
+        #expect(result.elements.other.count == 1)
+        #expect(result.elements.other[0].type == .staticText)
+    }
+
+    @available(macOS 14.0, *)
+    @Test
     func `Stale manifest is ignored`() throws {
         let json = """
         {"version":1,"app":"firestaff","gameState":"stale",

--- a/Apps/CLI/Tests/CoreCLITests/GameBridgeDetectionTests.swift
+++ b/Apps/CLI/Tests/CoreCLITests/GameBridgeDetectionTests.swift
@@ -4,25 +4,24 @@ import Testing
 
 @Suite("GameBridge Detection Tests")
 struct GameBridgeDetectionTests {
-
     @available(macOS 14.0, *)
-    @Test("Known app is recognized")
-    func knownAppRecognized() {
+    @Test
+    func `Known app is recognized`() {
         #expect(GameBridgeDetectionService.isGameBridgeApp(appName: "firestaff"))
         #expect(GameBridgeDetectionService.isGameBridgeApp(appName: "Firestaff"))
     }
 
     @available(macOS 14.0, *)
-    @Test("Unknown app is not recognized")
-    func unknownAppNotRecognized() {
+    @Test
+    func `Unknown app is not recognized`() {
         #expect(!GameBridgeDetectionService.isGameBridgeApp(appName: "Safari"))
         #expect(!GameBridgeDetectionService.isGameBridgeApp(appName: nil))
         #expect(!GameBridgeDetectionService.isGameBridgeApp(appName: ""))
     }
 
     @available(macOS 14.0, *)
-    @Test("Manifest parsing from temp file")
-    func manifestParsing() throws {
+    @Test
+    func `Manifest parsing from temp file`() throws {
         let json = """
         {
           "version": 1,
@@ -49,10 +48,11 @@ struct GameBridgeDetectionTests {
           ]
         }
         """
-        let data = json.data(using: .utf8)!
+        let data = try #require(json.data(using: .utf8))
         let manifest = try JSONDecoder().decode(
             GameBridgeDetectionService.GameManifest.self,
-            from: data)
+            from: data
+        )
 
         #expect(manifest.version == 1)
         #expect(manifest.app == "firestaff")
@@ -67,8 +67,8 @@ struct GameBridgeDetectionTests {
     }
 
     @available(macOS 14.0, *)
-    @Test("Manifest elements default omitted optional Firestaff fields")
-    func manifestElementDefaults() throws {
+    @Test
+    func `Manifest elements default omitted optional Firestaff fields`() throws {
         let json = """
         {
           "version": 1,
@@ -85,10 +85,11 @@ struct GameBridgeDetectionTests {
           ]
         }
         """
-        let data = json.data(using: .utf8)!
+        let data = try #require(json.data(using: .utf8))
         let manifest = try JSONDecoder().decode(
             GameBridgeDetectionService.GameManifest.self,
-            from: data)
+            from: data
+        )
 
         #expect(manifest.elements.count == 1)
         #expect(manifest.elements[0].enabled)
@@ -96,8 +97,8 @@ struct GameBridgeDetectionTests {
     }
 
     @available(macOS 14.0, *)
-    @Test("Element scaling with window bounds")
-    func elementScaling() throws {
+    @Test
+    func `Element scaling with window bounds`() throws {
         let json = """
         {
           "version": 1,
@@ -116,16 +117,18 @@ struct GameBridgeDetectionTests {
           ]
         }
         """
-        let data = json.data(using: .utf8)!
+        let data = try #require(json.data(using: .utf8))
         let manifest = try JSONDecoder().decode(
             GameBridgeDetectionService.GameManifest.self,
-            from: data)
+            from: data
+        )
 
         // Window is 2x the framebuffer at offset (50, 50)
         let windowBounds = CGRect(x: 50, y: 50, width: 640, height: 400)
         let elements = GameBridgeDetectionService.detectElements(
             from: manifest,
-            windowBounds: windowBounds)
+            windowBounds: windowBounds
+        )
 
         #expect(elements.count == 1)
         let e = elements[0]
@@ -140,8 +143,8 @@ struct GameBridgeDetectionTests {
     }
 
     @available(macOS 14.0, *)
-    @Test("tryDetect returns nil for unknown app")
-    func tryDetectUnknownApp() {
+    @Test
+    func `tryDetect returns nil for unknown app`() {
         let context = WindowContext(
             applicationName: "Safari",
             applicationBundleId: "com.apple.Safari",
@@ -150,22 +153,24 @@ struct GameBridgeDetectionTests {
             windowID: 1,
             windowBounds: CGRect(x: 0, y: 0, width: 800, height: 600),
             shouldFocusWebContent: false,
-            traversalBudget: nil)
+            traversalBudget: nil
+        )
         let result = GameBridgeDetectionService.tryDetect(
             windowContext: context,
-            snapshotId: "test-snap")
+            snapshotId: "test-snap"
+        )
         #expect(result == nil)
     }
 
     @available(macOS 14.0, *)
-    @Test("Snapshot ID is preserved")
-    func snapshotIdPreserved() throws {
+    @Test
+    func `Snapshot ID is preserved`() throws {
         let json = """
         {"version":1,"app":"firestaff","gameState":"test",
          "framebuffer":{"width":320,"height":200},"elements":[]}
         """
-        let restoreManifest = try writeFirestaffManifest(json)
-        defer { restoreManifest() }
+        let manifestRootURL = try self.writeFirestaffManifest(json)
+        defer { try? FileManager.default.removeItem(at: manifestRootURL) }
 
         let context = WindowContext(
             applicationName: "firestaff",
@@ -175,31 +180,61 @@ struct GameBridgeDetectionTests {
             windowID: nil,
             windowBounds: nil,
             shouldFocusWebContent: false,
-            traversalBudget: nil)
+            traversalBudget: nil
+        )
         let result = GameBridgeDetectionService.tryDetect(
             windowContext: context,
-            snapshotId: "my-custom-snapshot-id")
+            snapshotId: "my-custom-snapshot-id",
+            manifestRootURL: manifestRootURL
+        )
 
         #expect(result != nil)
         #expect(result?.snapshotId == "my-custom-snapshot-id")
         #expect(result?.metadata.method == "gameBridge")
     }
 
-    private func writeFirestaffManifest(_ json: String) throws -> () -> Void {
-        let home = FileManager.default.homeDirectoryForCurrentUser
-        let dir = home.appendingPathComponent(".firestaff")
+    @available(macOS 14.0, *)
+    @Test
+    func `Stale manifest is ignored`() throws {
+        let json = """
+        {"version":1,"app":"firestaff","gameState":"stale",
+         "framebuffer":{"width":320,"height":200},"elements":[]}
+        """
+        let manifestRootURL = try self.writeFirestaffManifest(json)
+        defer { try? FileManager.default.removeItem(at: manifestRootURL) }
+
+        let manifestPath = manifestRootURL
+            .appendingPathComponent(".firestaff")
+            .appendingPathComponent("accessibility.json")
+        let staleDate = Date(timeIntervalSinceNow: -60)
+        try FileManager.default.setAttributes([.modificationDate: staleDate], ofItemAtPath: manifestPath.path)
+
+        let context = WindowContext(
+            applicationName: "firestaff",
+            applicationBundleId: nil,
+            applicationProcessId: nil,
+            windowTitle: nil,
+            windowID: nil,
+            windowBounds: nil,
+            shouldFocusWebContent: false,
+            traversalBudget: nil
+        )
+        let result = GameBridgeDetectionService.tryDetect(
+            windowContext: context,
+            snapshotId: "stale-snapshot",
+            manifestRootURL: manifestRootURL
+        )
+
+        #expect(result == nil)
+    }
+
+    private func writeFirestaffManifest(_ json: String) throws -> URL {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("peekaboo-gamebridge-tests-\(UUID().uuidString)")
+        let dir = root.appendingPathComponent(".firestaff")
         try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
         let manifestPath = dir.appendingPathComponent("accessibility.json")
-        let previousData = try? Data(contentsOf: manifestPath)
-
         try json.write(to: manifestPath, atomically: true, encoding: .utf8)
-
-        return {
-            if let previousData {
-                try? previousData.write(to: manifestPath, options: .atomic)
-            } else {
-                try? FileManager.default.removeItem(at: manifestPath)
-            }
-        }
+        return root
     }
 }

--- a/Apps/CLI/Tests/CoreCLITests/GameBridgeDetectionTests.swift
+++ b/Apps/CLI/Tests/CoreCLITests/GameBridgeDetectionTests.swift
@@ -1,0 +1,205 @@
+import Foundation
+import Testing
+@testable import PeekabooAutomationKit
+
+@Suite("GameBridge Detection Tests")
+struct GameBridgeDetectionTests {
+
+    @available(macOS 14.0, *)
+    @Test("Known app is recognized")
+    func knownAppRecognized() {
+        #expect(GameBridgeDetectionService.isGameBridgeApp(appName: "firestaff"))
+        #expect(GameBridgeDetectionService.isGameBridgeApp(appName: "Firestaff"))
+    }
+
+    @available(macOS 14.0, *)
+    @Test("Unknown app is not recognized")
+    func unknownAppNotRecognized() {
+        #expect(!GameBridgeDetectionService.isGameBridgeApp(appName: "Safari"))
+        #expect(!GameBridgeDetectionService.isGameBridgeApp(appName: nil))
+        #expect(!GameBridgeDetectionService.isGameBridgeApp(appName: ""))
+    }
+
+    @available(macOS 14.0, *)
+    @Test("Manifest parsing from temp file")
+    func manifestParsing() throws {
+        let json = """
+        {
+          "version": 1,
+          "app": "firestaff",
+          "gameState": "gameplay",
+          "framebuffer": { "width": 320, "height": 200 },
+          "elements": [
+            {
+              "id": "MOVE_FWD",
+              "type": "button",
+              "label": "Forward",
+              "bounds": { "x": 144, "y": 137, "w": 32, "h": 20 },
+              "enabled": true,
+              "value": null
+            },
+            {
+              "id": "VIEWPORT",
+              "type": "region",
+              "label": "Dungeon View",
+              "bounds": { "x": 0, "y": 0, "w": 224, "h": 136 },
+              "enabled": true,
+              "value": null
+            }
+          ]
+        }
+        """
+        let data = json.data(using: .utf8)!
+        let manifest = try JSONDecoder().decode(
+            GameBridgeDetectionService.GameManifest.self,
+            from: data)
+
+        #expect(manifest.version == 1)
+        #expect(manifest.app == "firestaff")
+        #expect(manifest.gameState == "gameplay")
+        #expect(manifest.framebuffer.width == 320)
+        #expect(manifest.framebuffer.height == 200)
+        #expect(manifest.elements.count == 2)
+        #expect(manifest.elements[0].id == "MOVE_FWD")
+        #expect(manifest.elements[0].type == "button")
+        #expect(manifest.elements[0].bounds.x == 144)
+        #expect(manifest.elements[1].id == "VIEWPORT")
+    }
+
+    @available(macOS 14.0, *)
+    @Test("Manifest elements default omitted optional Firestaff fields")
+    func manifestElementDefaults() throws {
+        let json = """
+        {
+          "version": 1,
+          "app": "firestaff",
+          "gameState": "gameplay",
+          "framebuffer": { "width": 320, "height": 200 },
+          "elements": [
+            {
+              "id": "MOVE_FWD",
+              "type": "button",
+              "label": "Forward",
+              "bounds": { "x": 144, "y": 137, "w": 32, "h": 20 }
+            }
+          ]
+        }
+        """
+        let data = json.data(using: .utf8)!
+        let manifest = try JSONDecoder().decode(
+            GameBridgeDetectionService.GameManifest.self,
+            from: data)
+
+        #expect(manifest.elements.count == 1)
+        #expect(manifest.elements[0].enabled)
+        #expect(manifest.elements[0].value == nil)
+    }
+
+    @available(macOS 14.0, *)
+    @Test("Element scaling with window bounds")
+    func elementScaling() throws {
+        let json = """
+        {
+          "version": 1,
+          "app": "firestaff",
+          "gameState": "gameplay",
+          "framebuffer": { "width": 320, "height": 200 },
+          "elements": [
+            {
+              "id": "B1",
+              "type": "button",
+              "label": "Test",
+              "bounds": { "x": 160, "y": 100, "w": 32, "h": 20 },
+              "enabled": true,
+              "value": null
+            }
+          ]
+        }
+        """
+        let data = json.data(using: .utf8)!
+        let manifest = try JSONDecoder().decode(
+            GameBridgeDetectionService.GameManifest.self,
+            from: data)
+
+        // Window is 2x the framebuffer at offset (50, 50)
+        let windowBounds = CGRect(x: 50, y: 50, width: 640, height: 400)
+        let elements = GameBridgeDetectionService.detectElements(
+            from: manifest,
+            windowBounds: windowBounds)
+
+        #expect(elements.count == 1)
+        let e = elements[0]
+        // 160 * (640/320) + 50 = 370
+        #expect(e.bounds.origin.x == 370)
+        // 100 * (400/200) + 50 = 250
+        #expect(e.bounds.origin.y == 250)
+        // 32 * 2 = 64
+        #expect(e.bounds.width == 64)
+        // 20 * 2 = 40
+        #expect(e.bounds.height == 40)
+    }
+
+    @available(macOS 14.0, *)
+    @Test("tryDetect returns nil for unknown app")
+    func tryDetectUnknownApp() {
+        let context = WindowContext(
+            applicationName: "Safari",
+            applicationBundleId: "com.apple.Safari",
+            applicationProcessId: 1234,
+            windowTitle: "Test",
+            windowID: 1,
+            windowBounds: CGRect(x: 0, y: 0, width: 800, height: 600),
+            shouldFocusWebContent: false,
+            traversalBudget: nil)
+        let result = GameBridgeDetectionService.tryDetect(
+            windowContext: context,
+            snapshotId: "test-snap")
+        #expect(result == nil)
+    }
+
+    @available(macOS 14.0, *)
+    @Test("Snapshot ID is preserved")
+    func snapshotIdPreserved() throws {
+        let json = """
+        {"version":1,"app":"firestaff","gameState":"test",
+         "framebuffer":{"width":320,"height":200},"elements":[]}
+        """
+        let restoreManifest = try writeFirestaffManifest(json)
+        defer { restoreManifest() }
+
+        let context = WindowContext(
+            applicationName: "firestaff",
+            applicationBundleId: nil,
+            applicationProcessId: nil,
+            windowTitle: nil,
+            windowID: nil,
+            windowBounds: nil,
+            shouldFocusWebContent: false,
+            traversalBudget: nil)
+        let result = GameBridgeDetectionService.tryDetect(
+            windowContext: context,
+            snapshotId: "my-custom-snapshot-id")
+
+        #expect(result != nil)
+        #expect(result?.snapshotId == "my-custom-snapshot-id")
+        #expect(result?.metadata.method == "gameBridge")
+    }
+
+    private func writeFirestaffManifest(_ json: String) throws -> () -> Void {
+        let home = FileManager.default.homeDirectoryForCurrentUser
+        let dir = home.appendingPathComponent(".firestaff")
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        let manifestPath = dir.appendingPathComponent("accessibility.json")
+        let previousData = try? Data(contentsOf: manifestPath)
+
+        try json.write(to: manifestPath, atomically: true, encoding: .utf8)
+
+        return {
+            if let previousData {
+                try? previousData.write(to: manifestPath, options: .atomic)
+            } else {
+                try? FileManager.default.removeItem(at: manifestPath)
+            }
+        }
+    }
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [3.2.2] - Unreleased
 
+### Added
+- GameBridge manifests now let `peekaboo see` expose Firestaff/SDL game UI zones from GPU-rendered windows. Thanks @yeager for #152.
+
 ### Fixed
 - `peekaboo agent` now accepts OpenRouter model IDs and can use `OPENROUTER_API_KEY` from env or credentials. Thanks @delort for #155.
 

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/GameBridge/GameBridgeDetectionIntegration.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/GameBridge/GameBridgeDetectionIntegration.swift
@@ -64,7 +64,7 @@ extension GameBridgeDetectionService {
             case "button":
                 buttons.append(element)
             case "staticText":
-                textFields.append(element)
+                other.append(element)
             case "image":
                 images.append(element)
             case "group":

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/GameBridge/GameBridgeDetectionIntegration.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/GameBridge/GameBridgeDetectionIntegration.swift
@@ -1,0 +1,102 @@
+import CoreGraphics
+import Foundation
+import PeekabooFoundation
+
+/// Extension to integrate GameBridge detection into the observation pipeline.
+///
+/// When the target window belongs to a game-bridge app (e.g. Firestaff),
+/// elements are read from the app's JSON accessibility manifest instead of
+/// the macOS Accessibility API. This works for SDL/GPU-rendered windows
+/// that don't expose AXUIElement trees.
+@available(macOS 14.0, *)
+public extension GameBridgeDetectionService {
+
+    /// Try game-bridge detection for a window context.
+    /// Returns nil if the app is not a known game-bridge app or has no manifest.
+    static func tryDetect(windowContext: WindowContext?) -> ElementDetectionResult? {
+        guard let appName = windowContext?.applicationName,
+              isGameBridgeApp(appName: appName) else {
+            return nil
+        }
+
+        guard let manifest = readManifest(appName: appName) else {
+            return nil
+        }
+
+        let bridgeElements = detectElements(
+            from: manifest,
+            windowBounds: windowContext?.windowBounds
+        )
+
+        // Convert to Peekaboo DetectedElements
+        var buttons: [DetectedElement] = []
+        var textFields: [DetectedElement] = []
+        var images: [DetectedElement] = []
+        var groups: [DetectedElement] = []
+        var other: [DetectedElement] = []
+
+        for ge in bridgeElements {
+            let element = DetectedElement(
+                id: ge.id,
+                type: mapToElementType(ge.type),
+                label: ge.label,
+                value: ge.value,
+                bounds: ge.bounds,
+                isEnabled: ge.enabled,
+                attributes: [
+                    "source": "gameBridge",
+                    "gameState": ge.gameState,
+                    "fbX": "\(Int(ge.framebufferBounds.origin.x))",
+                    "fbY": "\(Int(ge.framebufferBounds.origin.y))",
+                    "fbW": "\(Int(ge.framebufferBounds.width))",
+                    "fbH": "\(Int(ge.framebufferBounds.height))"
+                ]
+            )
+
+            switch ge.type {
+            case "button":
+                buttons.append(element)
+            case "staticText":
+                textFields.append(element)
+            case "image":
+                images.append(element)
+            case "group":
+                groups.append(element)
+            default:
+                other.append(element)
+            }
+        }
+
+        let elements = DetectedElements(
+            buttons: buttons,
+            textFields: textFields,
+            images: images,
+            groups: groups,
+            other: other
+        )
+
+        return ElementDetectionResult(
+            snapshotId: UUID().uuidString,
+            screenshotPath: "",
+            elements: elements,
+            metadata: DetectionMetadata(
+                detectionTime: 0.001, // Near-instant: just reading a file
+                elementCount: bridgeElements.count,
+                method: "gameBridge",
+                warnings: [],
+                windowContext: windowContext,
+                isDialog: false
+            )
+        )
+    }
+
+    private static func mapToElementType(_ type: String) -> ElementType {
+        switch type {
+        case "button": return .button
+        case "staticText": return .staticText
+        case "image": return .image
+        case "group": return .group
+        default: return .other
+        }
+    }
+}

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/GameBridge/GameBridgeDetectionIntegration.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/GameBridge/GameBridgeDetectionIntegration.swift
@@ -13,7 +13,11 @@ public extension GameBridgeDetectionService {
 
     /// Try game-bridge detection for a window context.
     /// Returns nil if the app is not a known game-bridge app or has no manifest.
-    static func tryDetect(windowContext: WindowContext?) -> ElementDetectionResult? {
+    /// - Parameters:
+    ///   - windowContext: Resolved window context with app name and bounds.
+    ///   - snapshotId: Caller-provided snapshot ID to preserve in the result.
+    static func tryDetect(windowContext: WindowContext?,
+                          snapshotId: String? = nil) -> ElementDetectionResult? {
         guard let appName = windowContext?.applicationName,
               isGameBridgeApp(appName: appName) else {
             return nil
@@ -76,7 +80,7 @@ public extension GameBridgeDetectionService {
         )
 
         return ElementDetectionResult(
-            snapshotId: UUID().uuidString,
+            snapshotId: snapshotId ?? UUID().uuidString,
             screenshotPath: "",
             elements: elements,
             metadata: DetectionMetadata(

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/GameBridge/GameBridgeDetectionIntegration.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/GameBridge/GameBridgeDetectionIntegration.swift
@@ -9,28 +9,32 @@ import PeekabooFoundation
 /// the macOS Accessibility API. This works for SDL/GPU-rendered windows
 /// that don't expose AXUIElement trees.
 @available(macOS 14.0, *)
-public extension GameBridgeDetectionService {
-
+extension GameBridgeDetectionService {
     /// Try game-bridge detection for a window context.
     /// Returns nil if the app is not a known game-bridge app or has no manifest.
     /// - Parameters:
     ///   - windowContext: Resolved window context with app name and bounds.
     ///   - snapshotId: Caller-provided snapshot ID to preserve in the result.
-    static func tryDetect(windowContext: WindowContext?,
-                          snapshotId: String? = nil) -> ElementDetectionResult? {
+    ///   - manifestRootURL: Base directory for game manifest paths. Defaults to the user's home directory.
+    public static func tryDetect(
+        windowContext: WindowContext?,
+        snapshotId: String? = nil,
+        manifestRootURL: URL = FileManager.default
+            .homeDirectoryForCurrentUser) -> ElementDetectionResult?
+    {
         guard let appName = windowContext?.applicationName,
-              isGameBridgeApp(appName: appName) else {
+              isGameBridgeApp(appName: appName)
+        else {
             return nil
         }
 
-        guard let manifest = readManifest(appName: appName) else {
+        guard let manifest = readManifest(appName: appName, manifestRootURL: manifestRootURL) else {
             return nil
         }
 
         let bridgeElements = detectElements(
             from: manifest,
-            windowBounds: windowContext?.windowBounds
-        )
+            windowBounds: windowContext?.windowBounds)
 
         // Convert to Peekaboo DetectedElements
         var buttons: [DetectedElement] = []
@@ -42,7 +46,7 @@ public extension GameBridgeDetectionService {
         for ge in bridgeElements {
             let element = DetectedElement(
                 id: ge.id,
-                type: mapToElementType(ge.type),
+                type: self.mapToElementType(ge.type),
                 label: ge.label,
                 value: ge.value,
                 bounds: ge.bounds,
@@ -53,9 +57,8 @@ public extension GameBridgeDetectionService {
                     "fbX": "\(Int(ge.framebufferBounds.origin.x))",
                     "fbY": "\(Int(ge.framebufferBounds.origin.y))",
                     "fbW": "\(Int(ge.framebufferBounds.width))",
-                    "fbH": "\(Int(ge.framebufferBounds.height))"
-                ]
-            )
+                    "fbH": "\(Int(ge.framebufferBounds.height))",
+                ])
 
             switch ge.type {
             case "button":
@@ -76,8 +79,7 @@ public extension GameBridgeDetectionService {
             textFields: textFields,
             images: images,
             groups: groups,
-            other: other
-        )
+            other: other)
 
         return ElementDetectionResult(
             snapshotId: snapshotId ?? UUID().uuidString,
@@ -89,18 +91,16 @@ public extension GameBridgeDetectionService {
                 method: "gameBridge",
                 warnings: [],
                 windowContext: windowContext,
-                isDialog: false
-            )
-        )
+                isDialog: false))
     }
 
     private static func mapToElementType(_ type: String) -> ElementType {
         switch type {
-        case "button": return .button
-        case "staticText": return .staticText
-        case "image": return .image
-        case "group": return .group
-        default: return .other
+        case "button": .button
+        case "staticText": .staticText
+        case "image": .image
+        case "group": .group
+        default: .other
         }
     }
 }

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/GameBridge/GameBridgeDetectionService.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/GameBridge/GameBridgeDetectionService.swift
@@ -42,11 +42,53 @@ public final class GameBridgeDetectionService: Sendable {
             public let enabled: Bool
             public let value: String?
 
+            private enum CodingKeys: String, CodingKey {
+                case id
+                case type
+                case label
+                case bounds
+                case enabled
+                case value
+            }
+
+            public init(
+                id: String,
+                type: String,
+                label: String?,
+                bounds: Bounds,
+                enabled: Bool = true,
+                value: String? = nil)
+            {
+                self.id = id
+                self.type = type
+                self.label = label
+                self.bounds = bounds
+                self.enabled = enabled
+                self.value = value
+            }
+
+            public init(from decoder: any Decoder) throws {
+                let container = try decoder.container(keyedBy: CodingKeys.self)
+                self.id = try container.decode(String.self, forKey: .id)
+                self.type = try container.decode(String.self, forKey: .type)
+                self.label = try container.decodeIfPresent(String.self, forKey: .label)
+                self.bounds = try container.decode(Bounds.self, forKey: .bounds)
+                self.enabled = try container.decodeIfPresent(Bool.self, forKey: .enabled) ?? true
+                self.value = try container.decodeIfPresent(String.self, forKey: .value)
+            }
+
             public struct Bounds: Codable, Sendable {
                 public let x: Int
                 public let y: Int
                 public let w: Int
                 public let h: Int
+
+                public init(x: Int, y: Int, w: Int, h: Int) {
+                    self.x = x
+                    self.y = y
+                    self.w = w
+                    self.h = h
+                }
 
                 public var cgRect: CGRect {
                     CGRect(x: x, y: y, width: w, height: h)

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/GameBridge/GameBridgeDetectionService.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/GameBridge/GameBridgeDetectionService.swift
@@ -1,0 +1,145 @@
+import CoreGraphics
+import Foundation
+
+/// Detects UI elements in SDL/GPU-rendered game windows by reading a JSON
+/// accessibility manifest that the game writes each frame.
+///
+/// Protocol: the game writes `~/.{appname}/accessibility.json` atomically.
+/// Peekaboo reads this file during element detection when the target window
+/// belongs to a known game-bridge app.
+///
+/// This avoids relying on macOS Accessibility API (which doesn't see into
+/// GPU-rendered content) while still allowing `peekaboo see`, `peekaboo click`,
+/// and other automation commands to work with game windows.
+@available(macOS 14.0, *)
+public final class GameBridgeDetectionService: Sendable {
+
+    /// Known game-bridge apps and their manifest paths.
+    /// The path is relative to the user's home directory.
+    private static let knownApps: [String: String] = [
+        "firestaff": ".firestaff/accessibility.json",
+        "Firestaff": ".firestaff/accessibility.json",
+    ]
+
+    /// Manifest JSON structure matching Firestaff's accessibility output
+    public struct GameManifest: Codable, Sendable {
+        public let version: Int
+        public let app: String
+        public let gameState: String
+        public let framebuffer: FramebufferSize
+        public let elements: [GameElement]
+
+        public struct FramebufferSize: Codable, Sendable {
+            public let width: Int
+            public let height: Int
+        }
+
+        public struct GameElement: Codable, Sendable {
+            public let id: String
+            public let type: String
+            public let label: String?
+            public let bounds: Bounds
+            public let enabled: Bool
+            public let value: String?
+
+            public struct Bounds: Codable, Sendable {
+                public let x: Int
+                public let y: Int
+                public let w: Int
+                public let h: Int
+
+                public var cgRect: CGRect {
+                    CGRect(x: x, y: y, width: w, height: h)
+                }
+            }
+        }
+    }
+
+    /// Check if a window belongs to a game-bridge app
+    public static func isGameBridgeApp(appName: String?) -> Bool {
+        guard let name = appName else { return false }
+        return knownApps[name] != nil
+    }
+
+    /// Read the accessibility manifest for a game-bridge app
+    public static func readManifest(appName: String) -> GameManifest? {
+        guard let relativePath = knownApps[appName] else { return nil }
+        let home = FileManager.default.homeDirectoryForCurrentUser
+        let manifestURL = home.appendingPathComponent(relativePath)
+
+        guard let data = try? Data(contentsOf: manifestURL) else { return nil }
+        return try? JSONDecoder().decode(GameManifest.self, from: data)
+    }
+
+    /// Convert game manifest elements to Peekaboo DetectedElements
+    public static func detectElements(
+        from manifest: GameManifest,
+        windowBounds: CGRect?
+    ) -> [GameBridgeDetectedElement] {
+        let scaleX: CGFloat
+        let scaleY: CGFloat
+        let offsetX: CGFloat
+        let offsetY: CGFloat
+
+        if let wb = windowBounds {
+            // Scale framebuffer coordinates to window coordinates
+            scaleX = wb.width / CGFloat(manifest.framebuffer.width)
+            scaleY = wb.height / CGFloat(manifest.framebuffer.height)
+            offsetX = wb.origin.x
+            offsetY = wb.origin.y
+        } else {
+            scaleX = 1
+            scaleY = 1
+            offsetX = 0
+            offsetY = 0
+        }
+
+        return manifest.elements.enumerated().map { index, element in
+            let scaledBounds = CGRect(
+                x: CGFloat(element.bounds.x) * scaleX + offsetX,
+                y: CGFloat(element.bounds.y) * scaleY + offsetY,
+                width: CGFloat(element.bounds.w) * scaleX,
+                height: CGFloat(element.bounds.h) * scaleY
+            )
+
+            return GameBridgeDetectedElement(
+                id: element.id,
+                type: mapElementType(element.type),
+                label: element.label,
+                value: element.value,
+                bounds: scaledBounds,
+                enabled: element.enabled,
+                framebufferBounds: element.bounds.cgRect,
+                gameState: manifest.gameState
+            )
+        }
+    }
+
+    /// Map game element type strings to Peekaboo-compatible types
+    private static func mapElementType(_ gameType: String) -> String {
+        switch gameType {
+        case "button", "movement", "dialogChoice":
+            return "button"
+        case "slot", "portrait", "championMirror":
+            return "image"
+        case "text":
+            return "staticText"
+        case "region":
+            return "group"
+        default:
+            return "other"
+        }
+    }
+}
+
+/// A detected element from a game bridge manifest
+public struct GameBridgeDetectedElement: Sendable {
+    public let id: String
+    public let type: String
+    public let label: String?
+    public let value: String?
+    public let bounds: CGRect        // Screen coordinates
+    public let enabled: Bool
+    public let framebufferBounds: CGRect  // Original game framebuffer coords
+    public let gameState: String
+}

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/GameBridge/GameBridgeDetectionService.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/GameBridge/GameBridgeDetectionService.swift
@@ -13,7 +13,6 @@ import Foundation
 /// and other automation commands to work with game windows.
 @available(macOS 14.0, *)
 public final class GameBridgeDetectionService: Sendable {
-
     /// Known game-bridge apps and their manifest paths.
     /// The path is relative to the user's home directory.
     private static let knownApps: [String: String] = [
@@ -91,7 +90,7 @@ public final class GameBridgeDetectionService: Sendable {
                 }
 
                 public var cgRect: CGRect {
-                    CGRect(x: x, y: y, width: w, height: h)
+                    CGRect(x: self.x, y: self.y, width: self.w, height: self.h)
                 }
             }
         }
@@ -100,24 +99,40 @@ public final class GameBridgeDetectionService: Sendable {
     /// Check if a window belongs to a game-bridge app
     public static func isGameBridgeApp(appName: String?) -> Bool {
         guard let name = appName else { return false }
-        return knownApps[name] != nil
+        return self.knownApps[name] != nil
     }
 
-    /// Read the accessibility manifest for a game-bridge app
-    public static func readManifest(appName: String) -> GameManifest? {
+    /// Read the accessibility manifest for a game-bridge app.
+    public static func readManifest(
+        appName: String,
+        manifestRootURL: URL = FileManager.default.homeDirectoryForCurrentUser,
+        now: Date = Date(),
+        maxManifestAge: TimeInterval = 5) -> GameManifest?
+    {
         guard let relativePath = knownApps[appName] else { return nil }
-        let home = FileManager.default.homeDirectoryForCurrentUser
-        let manifestURL = home.appendingPathComponent(relativePath)
+        let manifestURL = manifestRootURL.appendingPathComponent(relativePath)
 
+        guard self.isFreshManifest(at: manifestURL, now: now, maxAge: maxManifestAge) else { return nil }
         guard let data = try? Data(contentsOf: manifestURL) else { return nil }
         return try? JSONDecoder().decode(GameManifest.self, from: data)
+    }
+
+    private static func isFreshManifest(at url: URL, now: Date, maxAge: TimeInterval) -> Bool {
+        guard
+            let attributes = try? FileManager.default.attributesOfItem(atPath: url.path),
+            let modificationDate = attributes[.modificationDate] as? Date
+        else {
+            return false
+        }
+
+        return now.timeIntervalSince(modificationDate) <= maxAge
     }
 
     /// Convert game manifest elements to Peekaboo DetectedElements
     public static func detectElements(
         from manifest: GameManifest,
-        windowBounds: CGRect?
-    ) -> [GameBridgeDetectedElement] {
+        windowBounds: CGRect?) -> [GameBridgeDetectedElement]
+    {
         let scaleX: CGFloat
         let scaleY: CGFloat
         let offsetX: CGFloat
@@ -136,24 +151,22 @@ public final class GameBridgeDetectionService: Sendable {
             offsetY = 0
         }
 
-        return manifest.elements.enumerated().map { index, element in
+        return manifest.elements.map { element in
             let scaledBounds = CGRect(
                 x: CGFloat(element.bounds.x) * scaleX + offsetX,
                 y: CGFloat(element.bounds.y) * scaleY + offsetY,
                 width: CGFloat(element.bounds.w) * scaleX,
-                height: CGFloat(element.bounds.h) * scaleY
-            )
+                height: CGFloat(element.bounds.h) * scaleY)
 
             return GameBridgeDetectedElement(
                 id: element.id,
-                type: mapElementType(element.type),
+                type: self.mapElementType(element.type),
                 label: element.label,
                 value: element.value,
                 bounds: scaledBounds,
                 enabled: element.enabled,
                 framebufferBounds: element.bounds.cgRect,
-                gameState: manifest.gameState
-            )
+                gameState: manifest.gameState)
         }
     }
 
@@ -161,15 +174,15 @@ public final class GameBridgeDetectionService: Sendable {
     private static func mapElementType(_ gameType: String) -> String {
         switch gameType {
         case "button", "movement", "dialogChoice":
-            return "button"
+            "button"
         case "slot", "portrait", "championMirror":
-            return "image"
+            "image"
         case "text":
-            return "staticText"
+            "staticText"
         case "region":
-            return "group"
+            "group"
         default:
-            return "other"
+            "other"
         }
     }
 }
@@ -180,8 +193,8 @@ public struct GameBridgeDetectedElement: Sendable {
     public let type: String
     public let label: String?
     public let value: String?
-    public let bounds: CGRect        // Screen coordinates
+    public let bounds: CGRect // Screen coordinates
     public let enabled: Bool
-    public let framebufferBounds: CGRect  // Original game framebuffer coords
+    public let framebufferBounds: CGRect // Original game framebuffer coords
     public let gameState: String
 }

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/ElementDetectionService.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/ElementDetectionService.swift
@@ -94,6 +94,16 @@ public final class ElementDetectionService {
             windowBounds: windowContext?.windowBounds,
             shouldFocusWebContent: windowContext?.shouldFocusWebContent,
             traversalBudget: budget)
+
+        // GameBridge: check if this is a known game-bridge app (SDL/GPU-rendered)
+        // before attempting AX tree traversal, which won't find elements in GPU windows.
+        if let gameBridgeResult = GameBridgeDetectionService.tryDetect(
+            windowContext: resolvedWindowContext,
+            snapshotId: effectiveSnapshotId) {
+            self.logger.info("GameBridge: detected \(gameBridgeResult.elements.all.count) elements from manifest")
+            return gameBridgeResult
+        }
+
         let detectedElements: [DetectedElement]
         let usedCache: Bool
         let truncationInfo: DetectionTruncationInfo?

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/ElementDetectionService.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/ElementDetectionService.swift
@@ -85,13 +85,14 @@ public final class ElementDetectionService {
         let allowWebFocus = windowContext?.shouldFocusWebContent ?? true
         let budget = AXTraversalBudget.normalizedForTraversal(windowContext?.traversalBudget)
         let usesDefaultBudget = budget == AXTraversalBudget()
+        let resolvedWindowBounds = windowContext?.windowBounds ?? windowResolution.window.frame()
         let resolvedWindowContext = WindowContext(
             applicationName: windowContext?.applicationName ?? targetApp.localizedName,
             applicationBundleId: windowContext?.applicationBundleId ?? targetApp.bundleIdentifier,
             applicationProcessId: windowContext?.applicationProcessId ?? targetApp.processIdentifier,
             windowTitle: windowName,
             windowID: resolvedWindowID,
-            windowBounds: windowContext?.windowBounds,
+            windowBounds: resolvedWindowBounds,
             shouldFocusWebContent: windowContext?.shouldFocusWebContent,
             traversalBudget: budget)
 
@@ -99,7 +100,8 @@ public final class ElementDetectionService {
         // before attempting AX tree traversal, which won't find elements in GPU windows.
         if let gameBridgeResult = GameBridgeDetectionService.tryDetect(
             windowContext: resolvedWindowContext,
-            snapshotId: effectiveSnapshotId) {
+            snapshotId: effectiveSnapshotId)
+        {
             self.logger.info("GameBridge: detected \(gameBridgeResult.elements.all.count) elements from manifest")
             return gameBridgeResult
         }


### PR DESCRIPTION
## Summary

Adds a new element detection backend for SDL/GPU-rendered game windows that don't expose macOS Accessibility API elements.

### Problem
SDL3, Metal, and OpenGL game windows render via GPU. macOS Accessibility API can't see inside them — `peekaboo see` shows no interactive elements, and `peekaboo click --on B1` doesn't work.

### Solution
**GameBridge protocol**: games write a JSON accessibility manifest (`~/.{appname}/accessibility.json`) each frame with all interactive UI zones. Peekaboo reads this during element detection, giving full `see`/`click`/`type` support.

### How it works
1. Game writes `~/.firestaff/accessibility.json` atomically (rename)
2. Peekaboo checks if target app is a known game-bridge app
3. If yes, reads manifest instead of AX tree traversal
4. Elements are scaled from framebuffer coords → screen coords
5. Standard Peekaboo IDs (B1, T2, etc.) work as expected

### Manifest format
```json
{
  "version": 1,
  "app": "firestaff",
  "gameState": "gameplay",
  "framebuffer": { "width": 320, "height": 200 },
  "elements": [
    { "id": "MOVE_FWD", "type": "button", "label": "Forward",
      "bounds": { "x": 144, "y": 137, "w": 32, "h": 20 },
      "enabled": true, "value": null }
  ]
}
```

### Files
- `GameBridgeDetectionService.swift` — manifest reader + coordinate scaling
- `GameBridgeDetectionIntegration.swift` — converts to `DetectedElements`/`ElementDetectionResult`

### Adding new games
One line in `knownApps` dictionary:
```swift
"mygame": ".mygame/accessibility.json"
```

### Testing
- Builds clean against PeekabooAutomationKit + PeekabooFoundation
- Tested with Firestaff (Dungeon Master remake using SDL3)

### Notes
- Detection is near-instant (~1ms, just reading a JSON file)
- No new dependencies
- Gracefully falls back if manifest is missing or stale