### PR TITLE
fix(cli): resolve targeted click coordinates

### DIFF
--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Interaction/ClickCommand+CommanderMetadata.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Interaction/ClickCommand+CommanderMetadata.swift
@@ -25,6 +25,7 @@ extension ClickCommand: CommanderBindableCommand {
         self.id = values.singleOption("id")
         self.target = try values.makeInteractionTargetOptions()
         self.coords = values.singleOption("coords")
+        self.globalCoords = values.flag("globalCoords")
         if let wait: Int = try values.decodeOption("waitFor", as: Int.self) {
             self.waitFor = wait
         }
@@ -62,7 +63,7 @@ extension ClickCommand: CommanderSignatureProviding {
                 ),
                 .commandOption(
                     "coords",
-                    help: "Click at coordinates (x,y)",
+                    help: "Click at x,y. Target-relative when --app/--pid/--window-* is supplied; global otherwise.",
                     long: "coords"
                 ),
                 .commandOption(
@@ -81,6 +82,11 @@ extension ClickCommand: CommanderSignatureProviding {
                     "right",
                     help: "Right-click (secondary click)",
                     long: "right"
+                ),
+                .commandFlag(
+                    "globalCoords",
+                    help: "Treat --coords as global screen coordinates even with target options",
+                    long: "global-coords"
                 ),
             ],
             optionGroups: [

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Interaction/ClickCommand+FocusVerification.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Interaction/ClickCommand+FocusVerification.swift
@@ -43,14 +43,78 @@ struct FrontmostApplicationIdentity: Equatable {
     }
 }
 
+struct FocusedWindowIdentity: Equatable {
+    let windowID: Int?
+    let title: String?
+
+    init(
+        windowID: Int? = nil,
+        title: String? = nil
+    ) {
+        self.windowID = windowID
+        self.title = title?.nilIfEmpty
+    }
+
+    init(window: ServiceWindowInfo?) {
+        self.init(
+            windowID: window?.windowID,
+            title: window?.title
+        )
+    }
+
+    var displayDescription: String {
+        var components: [String] = []
+        if let title = self.title {
+            components.append("'\(title)'")
+        }
+        if let windowID = self.windowID {
+            components.append("window \(windowID)")
+        }
+        if components.isEmpty {
+            return "unknown window"
+        }
+        return components.joined(separator: " ")
+    }
+}
+
 enum CoordinateClickFocusVerifier {
     static func mismatchMessage(
         targetApp: String?,
         targetPID: Int32?,
-        frontmost: FrontmostApplicationIdentity
+        frontmost: FrontmostApplicationIdentity,
+        targetWindowID: Int? = nil,
+        targetWindowTitle: String? = nil,
+        focusedWindow: FocusedWindowIdentity? = nil
     ) -> String? {
-        guard targetApp != nil || targetPID != nil else {
+        guard targetApp != nil || targetPID != nil || targetWindowID != nil else {
             return nil
+        }
+
+        if let targetWindowID {
+            if focusedWindow?.windowID == targetWindowID {
+                return nil
+            }
+
+            let targetDescription = self.targetDescription(
+                targetApp: targetApp,
+                targetPID: targetPID,
+                targetWindowID: targetWindowID,
+                targetWindowTitle: targetWindowTitle
+            )
+            let focusedWindowDescription = focusedWindow?.displayDescription ?? "unknown window"
+            let frontmostDescription = frontmost.displayDescription
+
+            return """
+            \(targetDescription) is not focused before the coordinate click. Focused window: \(
+                focusedWindowDescription
+            ). Currently frontmost: \(frontmostDescription).
+            The coordinate click would land on the focused/frontmost window instead.
+
+            Hints:
+              - Ensure no other window is overlapping the target
+              - Try clicking by element ID (--on) instead of coordinates
+              - Close or minimize interfering windows first
+            """
         }
 
         if let targetPID, frontmost.processIdentifier == targetPID {
@@ -61,11 +125,16 @@ enum CoordinateClickFocusVerifier {
             return nil
         }
 
-        let targetDescription = self.targetDescription(targetApp: targetApp, targetPID: targetPID)
+        let targetDescription = self.targetDescription(
+            targetApp: targetApp,
+            targetPID: targetPID,
+            targetWindowID: targetWindowID,
+            targetWindowTitle: targetWindowTitle
+        )
         let frontmostDescription = frontmost.displayDescription
 
         return """
-        \(targetDescription) is not frontmost after the focus attempt. Currently frontmost: \(frontmostDescription).
+        \(targetDescription) is not frontmost before the coordinate click. Currently frontmost: \(frontmostDescription).
         The coordinate click would land on the frontmost window instead.
 
         Hints:
@@ -75,7 +144,18 @@ enum CoordinateClickFocusVerifier {
         """
     }
 
-    static func targetDescription(targetApp: String?, targetPID: Int32?) -> String {
+    static func targetDescription(
+        targetApp: String?,
+        targetPID: Int32?,
+        targetWindowID: Int? = nil,
+        targetWindowTitle: String? = nil
+    ) -> String {
+        if let targetWindowID {
+            if let targetWindowTitle {
+                return "Target window \(targetWindowID) '\(targetWindowTitle)'"
+            }
+            return "Target window \(targetWindowID)"
+        }
         if let targetApp {
             return "Target app '\(targetApp)'"
         }
@@ -119,18 +199,31 @@ enum CoordinateClickFocusVerifier {
 @available(macOS 14.0, *)
 @MainActor
 extension ClickCommand {
-    /// Verify that the target app is actually frontmost before dispatching a coordinate click.
-    func verifyFocusForCoordinateClick() async throws {
+    /// Verify that the resolved target is actually focused before dispatching a coordinate click.
+    func verifyFocusForCoordinateClick(coordinateResolution: InteractionCoordinateResolution?) async throws {
         let frontmostInfo = try? await self.services.applications.getFrontmostApplication()
         let frontmost = FrontmostApplicationIdentity(application: frontmostInfo)
+        let targetWindowID = coordinateResolution?.targetWindowID
+        let focusedWindow = if targetWindowID != nil {
+            await FocusedWindowIdentity(window: try? self.services.windows.getFocusedWindow())
+        } else {
+            nil as FocusedWindowIdentity?
+        }
+        let targetApp = coordinateResolution?.targetApplicationName ?? self.target.app
+        let targetPID = coordinateResolution?.targetProcessIdentifier ?? self.target.pid
         if let message = CoordinateClickFocusVerifier.mismatchMessage(
-            targetApp: self.target.app,
-            targetPID: self.target.pid,
-            frontmost: frontmost
+            targetApp: targetApp,
+            targetPID: targetPID,
+            frontmost: frontmost,
+            targetWindowID: targetWindowID,
+            targetWindowTitle: coordinateResolution?.targetWindowTitle,
+            focusedWindow: focusedWindow
         ) {
             let targetDescription = CoordinateClickFocusVerifier.targetDescription(
-                targetApp: self.target.app,
-                targetPID: self.target.pid
+                targetApp: targetApp,
+                targetPID: targetPID,
+                targetWindowID: targetWindowID,
+                targetWindowTitle: coordinateResolution?.targetWindowTitle
             )
             self.outputLogger.warn(
                 "Coordinate click focus mismatch for " +

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Interaction/ClickCommand+Output.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Interaction/ClickCommand+Output.swift
@@ -8,6 +8,11 @@ struct ClickResult: Codable {
     let waitTime: Double
     let executionTime: TimeInterval
     let targetApp: String
+    let targetWindowId: Int?
+    let targetWindowTitle: String?
+    let coordinateSpace: String?
+    let inputCoordinates: [String: Double]?
+    let screenCoordinates: [String: Double]?
     let targetPoint: InteractionTargetPointDiagnostics?
 
     init(
@@ -17,6 +22,11 @@ struct ClickResult: Codable {
         waitTime: Double,
         executionTime: TimeInterval,
         targetApp: String,
+        targetWindowId: Int? = nil,
+        targetWindowTitle: String? = nil,
+        coordinateSpace: String? = nil,
+        inputCoordinates: CGPoint? = nil,
+        screenCoordinates: CGPoint? = nil,
         targetPoint: InteractionTargetPointDiagnostics? = nil
     ) {
         self.success = success
@@ -25,6 +35,11 @@ struct ClickResult: Codable {
         self.waitTime = waitTime
         self.executionTime = executionTime
         self.targetApp = targetApp
+        self.targetWindowId = targetWindowId
+        self.targetWindowTitle = targetWindowTitle
+        self.coordinateSpace = coordinateSpace
+        self.inputCoordinates = inputCoordinates.map { ["x": $0.x, "y": $0.y] }
+        self.screenCoordinates = screenCoordinates.map { ["x": $0.x, "y": $0.y] }
         self.targetPoint = targetPoint
     }
 }

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Interaction/ClickCommand+Validation.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Interaction/ClickCommand+Validation.swift
@@ -21,6 +21,10 @@ extension ClickCommand {
         if let coordString = self.coords, Self.parseCoordinates(coordString) == nil {
             throw ValidationError("Invalid coordinates format. Use: x,y")
         }
+
+        if self.globalCoords && self.coords == nil {
+            throw ValidationError("--global-coords requires --coords")
+        }
     }
 
     func formatElementInfo(_ element: DetectedElement) -> String {

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Interaction/ClickCommand.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Interaction/ClickCommand.swift
@@ -25,6 +25,9 @@ struct ClickCommand: ErrorHandlingCommand, OutputFormattable, RuntimeOptionsConf
     @Option(help: "Click at coordinates (x,y)")
     var coords: String?
 
+    @Flag(help: "Treat --coords as global screen coordinates even when target options are supplied")
+    var globalCoords = false
+
     @Option(help: "Maximum milliseconds to wait for element")
     var waitFor: Int = 5000
 
@@ -76,6 +79,7 @@ struct ClickCommand: ErrorHandlingCommand, OutputFormattable, RuntimeOptionsConf
             let waitResult: WaitForElementResult
             var activeSnapshotId: String
             var observationForInvalidation: InteractionObservationContext?
+            var coordinateResolution: InteractionCoordinateResolution?
 
             // Check if we're clicking by coordinates (doesn't need snapshot)
             if let coordString = coords {
@@ -83,17 +87,27 @@ struct ClickCommand: ErrorHandlingCommand, OutputFormattable, RuntimeOptionsConf
                 guard let point = Self.parseCoordinates(coordString) else {
                     throw ValidationError("Invalid coordinates format. Use: x,y")
                 }
-                clickTarget = .coordinates(point)
+                let resolvedCoordinates = try await InteractionCoordinateResolver.resolveClickCoordinates(
+                    point,
+                    target: self.target,
+                    services: self.services,
+                    forceGlobal: self.globalCoords
+                )
+                coordinateResolution = resolvedCoordinates
+                clickTarget = .coordinates(resolvedCoordinates.screenPoint)
                 waitResult = WaitForElementResult(found: true, element: nil, waitTime: 0)
                 activeSnapshotId = "" // Not needed for coordinate clicks
-                try await self.focusApplicationIfNeeded(snapshotId: nil)
+                try await self.focusApplicationIfNeeded(
+                    snapshotId: nil,
+                    coordinateResolution: resolvedCoordinates
+                )
 
-                // Verify target app is actually frontmost after focus attempt.
+                // Verify the resolved target is actually frontmost after focus attempt.
                 // InputDriver.click() sends a CGEvent at screen-absolute coordinates,
                 // so if the target window is not frontmost, the click will land on
                 // whatever window is at that position (see #90).
                 if !self.focusOptions.focusBackground {
-                    try await self.verifyFocusForCoordinateClick()
+                    try await self.verifyFocusForCoordinateClick(coordinateResolution: resolvedCoordinates)
                 }
 
             } else {
@@ -185,12 +199,16 @@ struct ClickCommand: ErrorHandlingCommand, OutputFormattable, RuntimeOptionsConf
             // Brief delay to ensure click is processed
             try await Task.sleep(nanoseconds: 20_000_000) // 0.02 seconds
 
-            let appName = await self.resultApplicationName(snapshotId: activeSnapshotId)
+            let appName = await self.resultApplicationName(
+                snapshotId: activeSnapshotId,
+                coordinateResolution: coordinateResolution
+            )
 
             let details = try await self.clickOutputDetails(
                 clickTarget: clickTarget,
                 waitResult: waitResult,
-                snapshotId: activeSnapshotId
+                snapshotId: activeSnapshotId,
+                coordinateResolution: coordinateResolution
             )
 
             // Output results
@@ -201,6 +219,11 @@ struct ClickCommand: ErrorHandlingCommand, OutputFormattable, RuntimeOptionsConf
                 waitTime: waitResult.waitTime,
                 executionTime: Date().timeIntervalSince(startTime),
                 targetApp: appName,
+                targetWindowId: coordinateResolution?.targetWindowID,
+                targetWindowTitle: coordinateResolution?.targetWindowTitle,
+                coordinateSpace: coordinateResolution?.coordinateSpace.rawValue,
+                inputCoordinates: coordinateResolution?.inputPoint,
+                screenCoordinates: coordinateResolution?.screenPoint,
                 targetPoint: details.targetPointDiagnostics
             )
 
@@ -224,7 +247,8 @@ struct ClickCommand: ErrorHandlingCommand, OutputFormattable, RuntimeOptionsConf
     private func clickOutputDetails(
         clickTarget: ClickTarget,
         waitResult: WaitForElementResult,
-        snapshotId: String
+        snapshotId: String,
+        coordinateResolution: InteractionCoordinateResolution?
     ) async throws
     -> (location: CGPoint, clickedElement: String?, targetPointDiagnostics: InteractionTargetPointDiagnostics?) {
         switch clickTarget {
@@ -241,7 +265,19 @@ struct ClickCommand: ErrorHandlingCommand, OutputFormattable, RuntimeOptionsConf
             return (resolution.point, self.formatElementInfo(element), resolution.diagnostics)
 
         case let .coordinates(point):
-            let diagnostics = InteractionTargetPointResolver.coordinate(point, source: .coordinates).diagnostics
+            let diagnostics = if let coordinateResolution {
+                InteractionTargetPointDiagnostics(
+                    source: InteractionTargetPointSource.coordinates.rawValue,
+                    elementId: nil,
+                    snapshotId: nil,
+                    original: InteractionPoint(coordinateResolution.inputPoint),
+                    resolved: InteractionPoint(coordinateResolution.screenPoint),
+                    windowAdjustment: nil,
+                    coordinate: coordinateResolution.diagnostics
+                )
+            } else {
+                InteractionTargetPointResolver.coordinate(point, source: .coordinates).diagnostics
+            }
             return (point, nil, diagnostics)
 
         case let .query(query):
@@ -262,7 +298,20 @@ struct ClickCommand: ErrorHandlingCommand, OutputFormattable, RuntimeOptionsConf
         await (try? self.services.applications.getFrontmostApplication().name) ?? "Unknown"
     }
 
-    private func resultApplicationName(snapshotId: String) async -> String {
+    private func resultApplicationName(
+        snapshotId: String,
+        coordinateResolution: InteractionCoordinateResolution? = nil
+    ) async -> String {
+        if let targetApplicationName = coordinateResolution?.targetApplicationName {
+            return targetApplicationName
+        }
+        if let processIdentifier = coordinateResolution?.targetProcessIdentifier {
+            return await self.applicationName(processIdentifier: processIdentifier) ?? "PID \(processIdentifier)"
+        }
+        if let windowID = coordinateResolution?.targetWindowID {
+            return "window \(windowID)"
+        }
+
         guard self.focusOptions.focusBackground else {
             return await self.frontmostApplicationName()
         }
@@ -307,6 +356,16 @@ struct ClickCommand: ErrorHandlingCommand, OutputFormattable, RuntimeOptionsConf
             print("🎯 App: \(result.targetApp)")
             if self.focusOptions.focusBackground {
                 print("🎯 Mode: background")
+            }
+            if let coordinateSpace = result.coordinateSpace {
+                print("🎯 Coordinate space: \(coordinateSpace)")
+            }
+            if let windowID = result.targetWindowId {
+                if let title = result.targetWindowTitle, !title.isEmpty {
+                    print("🪟 Window: \(windowID) (\(title))")
+                } else {
+                    print("🪟 Window: \(windowID)")
+                }
             }
             if let info = result.clickedElement {
                 print("📱 Clicked: \(info)")
@@ -423,7 +482,10 @@ struct ClickCommand: ErrorHandlingCommand, OutputFormattable, RuntimeOptionsConf
         }
     }
 
-    private func focusApplicationIfNeeded(snapshotId: String?) async throws {
+    private func focusApplicationIfNeeded(
+        snapshotId: String?,
+        coordinateResolution: InteractionCoordinateResolution? = nil
+    ) async throws {
         if self.focusOptions.focusBackground {
             try self.validateBackgroundClickOptions()
             return
@@ -434,6 +496,18 @@ struct ClickCommand: ErrorHandlingCommand, OutputFormattable, RuntimeOptionsConf
         }
 
         if snapshotId == nil, !self.target.hasAnyTarget {
+            return
+        }
+
+        if let targetWindowID = coordinateResolution?.targetWindowID {
+            try await ensureFocused(
+                windowID: CGWindowID(targetWindowID),
+                applicationName: coordinateResolution?.targetApplicationIdentifier,
+                windowTitle: coordinateResolution?.targetWindowTitle,
+                options: self.focusOptions,
+                services: self.services
+            )
+            try await Task.sleep(nanoseconds: 100_000_000)
             return
         }
 

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Shared/InteractionCoordinateResolver.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Shared/InteractionCoordinateResolver.swift
@@ -1,0 +1,254 @@
+import Commander
+import CoreGraphics
+import Foundation
+import PeekabooCore
+import PeekabooFoundation
+
+@MainActor
+enum InteractionCoordinateResolver {
+    static func resolveClickCoordinates(
+        _ inputPoint: CGPoint,
+        target: InteractionTargetOptions,
+        services: any PeekabooServiceProviding,
+        forceGlobal: Bool = false
+    ) async throws -> InteractionCoordinateResolution {
+        guard target.hasAnyTarget, !forceGlobal else {
+            return InteractionCoordinateResolution(
+                inputPoint: inputPoint,
+                screenPoint: inputPoint,
+                coordinateSpace: .global,
+                windowInfo: nil,
+                targetApplication: nil
+            )
+        }
+
+        guard let windowTarget = try target.toWindowTarget() else {
+            throw ValidationError("Coordinate target could not be resolved from the supplied target options.")
+        }
+
+        let windowInfo = try await self.resolveWindowInfo(
+            windowTarget: windowTarget,
+            target: target,
+            services: services
+        )
+
+        let targetApplication = await self.resolveTargetApplication(
+            windowInfo: windowInfo,
+            target: target,
+            services: services
+        )
+
+        return try self.resolveTargetWindowCoordinates(
+            inputPoint,
+            windowInfo: windowInfo,
+            targetApplication: targetApplication
+        )
+    }
+
+    static func resolveTargetWindowCoordinates(
+        _ inputPoint: CGPoint,
+        windowInfo: ServiceWindowInfo?,
+        targetApplication: ServiceApplicationInfo?,
+        forceGlobal: Bool = false
+    ) throws -> InteractionCoordinateResolution {
+        guard let windowInfo, !forceGlobal else {
+            return InteractionCoordinateResolution(
+                inputPoint: inputPoint,
+                screenPoint: inputPoint,
+                coordinateSpace: .global,
+                windowInfo: nil,
+                targetApplication: nil
+            )
+        }
+
+        try self.validate(inputPoint: inputPoint, within: windowInfo)
+
+        let screenPoint = CGPoint(
+            x: windowInfo.bounds.minX + inputPoint.x,
+            y: windowInfo.bounds.minY + inputPoint.y
+        )
+
+        return InteractionCoordinateResolution(
+            inputPoint: inputPoint,
+            screenPoint: screenPoint,
+            coordinateSpace: .windowRelative,
+            windowInfo: windowInfo,
+            targetApplication: targetApplication
+        )
+    }
+
+    private static func resolveWindowInfo(
+        windowTarget: WindowTarget,
+        target: InteractionTargetOptions,
+        services: any PeekabooServiceProviding
+    ) async throws -> ServiceWindowInfo {
+        let windows = try await services.windows.listWindows(target: windowTarget)
+        guard let window = windows.first else {
+            throw PeekabooError.windowNotFound(criteria: self.targetDescription(target))
+        }
+        return window
+    }
+
+    private static func validate(inputPoint: CGPoint, within windowInfo: ServiceWindowInfo) throws {
+        guard inputPoint.x >= 0, inputPoint.y >= 0,
+              inputPoint.x < windowInfo.bounds.width,
+              inputPoint.y < windowInfo.bounds.height
+        else {
+            let x = Self.clean(inputPoint.x)
+            let y = Self.clean(inputPoint.y)
+            let width = Self.clean(windowInfo.bounds.width)
+            let height = Self.clean(windowInfo.bounds.height)
+            throw ValidationError(
+                "Coordinates \(x),\(y) are outside target window \(windowInfo.windowID) " +
+                    "bounds 0,0-\(width),\(height). Use --global-coords for screen coordinates."
+            )
+        }
+    }
+
+    private static func resolveTargetApplication(
+        windowInfo: ServiceWindowInfo,
+        target: InteractionTargetOptions,
+        services: any PeekabooServiceProviding
+    ) async -> ServiceApplicationInfo? {
+        if let identifier = try? target.resolveApplicationIdentifierOptional(),
+           let application = try? await services.applications.findApplication(identifier: identifier) {
+            return application
+        }
+
+        guard let output = try? await services.applications.listApplications() else {
+            return nil
+        }
+
+        for application in output.data.applications {
+            let identifiers = [
+                application.name,
+                application.bundleIdentifier,
+                "PID:\(application.processIdentifier)",
+            ].compactMap(\.self)
+
+            for identifier in identifiers {
+                guard let windows = try? await services.windows.listWindows(target: .application(identifier)),
+                      windows.contains(where: { $0.windowID == windowInfo.windowID })
+                else { continue }
+                return application
+            }
+        }
+
+        return nil
+    }
+
+    private static func targetDescription(_ target: InteractionTargetOptions) -> String {
+        if let windowId = target.windowId {
+            return "window id \(windowId)"
+        }
+        if let windowTitle = target.windowTitle {
+            return "window title '\(windowTitle)'"
+        }
+        if let windowIndex = target.windowIndex {
+            return "window index \(windowIndex)"
+        }
+        if let pid = target.pid {
+            return "PID \(pid)"
+        }
+        if let app = target.app {
+            return "app '\(app)'"
+        }
+        return "target"
+    }
+
+    private static func clean(_ value: CGFloat) -> String {
+        let doubleValue = Double(value)
+        if doubleValue.rounded() == doubleValue {
+            return String(Int(doubleValue))
+        }
+        return String(format: "%.2f", doubleValue)
+    }
+}
+
+struct InteractionCoordinateResolution {
+    let inputPoint: CGPoint
+    let screenPoint: CGPoint
+    let coordinateSpace: InteractionCoordinateSpace
+    let windowInfo: ServiceWindowInfo?
+    let targetApplication: ServiceApplicationInfo?
+
+    var targetApplicationName: String? {
+        self.targetApplication?.name
+    }
+
+    var targetProcessIdentifier: Int32? {
+        self.targetApplication?.processIdentifier
+    }
+
+    var targetApplicationIdentifier: String? {
+        if let bundleIdentifier = self.targetApplication?.bundleIdentifier, !bundleIdentifier.isEmpty {
+            return bundleIdentifier
+        }
+        if let name = self.targetApplication?.name, !name.isEmpty {
+            return name
+        }
+        if let processIdentifier = self.targetProcessIdentifier {
+            return "PID:\(processIdentifier)"
+        }
+        return nil
+    }
+
+    var targetWindowTitle: String? {
+        self.windowInfo?.title
+    }
+
+    var targetWindowID: Int? {
+        self.windowInfo?.windowID
+    }
+
+    var diagnostics: InteractionCoordinateDiagnostics {
+        InteractionCoordinateDiagnostics(
+            coordinateSpace: self.coordinateSpace.rawValue,
+            input: InteractionPoint(self.inputPoint),
+            resolved: InteractionPoint(self.screenPoint),
+            targetWindow: self.windowInfo.map(InteractionTargetWindowDiagnostics.init),
+            targetApp: self.targetApplicationName,
+            targetPID: self.targetProcessIdentifier
+        )
+    }
+}
+
+enum InteractionCoordinateSpace: String {
+    case global
+    case windowRelative = "window_relative"
+}
+
+struct InteractionCoordinateDiagnostics: Codable, Equatable {
+    let coordinateSpace: String
+    let input: InteractionPoint
+    let resolved: InteractionPoint
+    let targetWindow: InteractionTargetWindowDiagnostics?
+    let targetApp: String?
+    let targetPID: Int32?
+}
+
+struct InteractionTargetWindowDiagnostics: Codable, Equatable {
+    let windowID: Int
+    let title: String
+    let bounds: InteractionRect
+
+    init(_ windowInfo: ServiceWindowInfo) {
+        self.windowID = windowInfo.windowID
+        self.title = windowInfo.title
+        self.bounds = InteractionRect(windowInfo.bounds)
+    }
+}
+
+struct InteractionRect: Codable, Equatable {
+    let x: Double
+    let y: Double
+    let width: Double
+    let height: Double
+
+    init(_ rect: CGRect) {
+        self.x = Double(rect.origin.x)
+        self.y = Double(rect.origin.y)
+        self.width = Double(rect.width)
+        self.height = Double(rect.height)
+    }
+}

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Shared/InteractionTargetOptions.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Shared/InteractionTargetOptions.swift
@@ -95,4 +95,25 @@ struct InteractionTargetOptions: CommanderParsable, ApplicationResolvable {
         let windows = try await services.windows.listWindows(target: .index(app: appIdentifier, index: windowIndex))
         return windows.first?.title
     }
+
+    func toWindowTarget() throws -> WindowTarget? {
+        if let windowId {
+            return .windowId(windowId)
+        }
+
+        guard let appIdentifier = try self.resolveApplicationIdentifierOptional() else {
+            return nil
+        }
+
+        if let windowTitle = self.windowTitle?.trimmingCharacters(in: .whitespacesAndNewlines),
+           !windowTitle.isEmpty {
+            return .applicationAndTitle(app: appIdentifier, title: windowTitle)
+        }
+
+        if let windowIndex {
+            return .index(app: appIdentifier, index: windowIndex)
+        }
+
+        return .application(appIdentifier)
+    }
 }

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Shared/InteractionTargetPointResolver.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Shared/InteractionTargetPointResolver.swift
@@ -209,6 +209,25 @@ struct InteractionTargetPointDiagnostics: Codable, Equatable {
     let original: InteractionPoint
     let resolved: InteractionPoint
     let windowAdjustment: InteractionWindowAdjustmentDiagnostics?
+    let coordinate: InteractionCoordinateDiagnostics?
+
+    init(
+        source: String,
+        elementId: String?,
+        snapshotId: String?,
+        original: InteractionPoint,
+        resolved: InteractionPoint,
+        windowAdjustment: InteractionWindowAdjustmentDiagnostics?,
+        coordinate: InteractionCoordinateDiagnostics? = nil
+    ) {
+        self.source = source
+        self.elementId = elementId
+        self.snapshotId = snapshotId
+        self.original = original
+        self.resolved = resolved
+        self.windowAdjustment = windowAdjustment
+        self.coordinate = coordinate
+    }
 }
 
 struct InteractionWindowAdjustmentDiagnostics: Codable, Equatable {

--- a/Apps/CLI/Tests/CLIAutomationTests/ClickCommandTests.swift
+++ b/Apps/CLI/Tests/CLIAutomationTests/ClickCommandTests.swift
@@ -46,7 +46,7 @@ struct ClickCommandTests {
     func `Click command supports background coordinate clicks`() async throws {
         let context = await self.makeContext()
         let result = try await InProcessCommandRunner.run(
-            ["click", "--coords", "100,200", "--pid", "12345", "--focus-background", "--json"],
+            ["click", "--coords", "100,200", "--pid", "12345", "--focus-background", "--global-coords", "--json"],
             services: context.services
         )
 

--- a/Apps/CLI/Tests/CoreCLITests/ClickCommandFocusVerificationTests.swift
+++ b/Apps/CLI/Tests/CoreCLITests/ClickCommandFocusVerificationTests.swift
@@ -96,4 +96,48 @@ struct ClickCommandFocusVerificationTests {
         #expect(message?.contains("com.google.Chrome") == true)
         #expect(message?.contains("PID 512") == true)
     }
+
+    @Test
+    func `Resolved focused window match passes`() {
+        let frontmost = FrontmostApplicationIdentity(
+            name: "OpenClaw Settings",
+            bundleIdentifier: "com.openclaw.settings",
+            processIdentifier: 99
+        )
+        let focusedWindow = FocusedWindowIdentity(windowID: 59620, title: "Settings")
+
+        let message = CoordinateClickFocusVerifier.mismatchMessage(
+            targetApp: "OpenClaw Settings",
+            targetPID: 99,
+            frontmost: frontmost,
+            targetWindowID: 59620,
+            targetWindowTitle: "Settings",
+            focusedWindow: focusedWindow
+        )
+
+        #expect(message == nil)
+    }
+
+    @Test
+    func `Resolved focused window mismatch fails`() {
+        let frontmost = FrontmostApplicationIdentity(
+            name: "Discord",
+            bundleIdentifier: "com.hnc.Discord",
+            processIdentifier: 512
+        )
+        let focusedWindow = FocusedWindowIdentity(windowID: 123, title: "Discord")
+
+        let message = CoordinateClickFocusVerifier.mismatchMessage(
+            targetApp: "OpenClaw Settings",
+            targetPID: 99,
+            frontmost: frontmost,
+            targetWindowID: 59620,
+            targetWindowTitle: "Settings",
+            focusedWindow: focusedWindow
+        )
+
+        #expect(message?.contains("Target window 59620 'Settings'") == true)
+        #expect(message?.contains("'Discord' window 123") == true)
+        #expect(message?.contains("com.hnc.Discord") == true)
+    }
 }

--- a/Apps/CLI/Tests/CoreCLITests/InteractionCoordinateResolverTests.swift
+++ b/Apps/CLI/Tests/CoreCLITests/InteractionCoordinateResolverTests.swift
@@ -1,0 +1,119 @@
+import CoreGraphics
+import PeekabooCore
+import Testing
+@testable import PeekabooCLI
+
+struct InteractionCoordinateResolverTests {
+    @Test
+    @MainActor
+    func `target window coordinates resolve relative to window origin`() throws {
+        let window = Self.makeWindow(
+            id: 59620,
+            title: "Settings",
+            bounds: CGRect(x: 200, y: 260, width: 420, height: 300)
+        )
+        let app = Self.makeApp(name: "OpenClaw Settings", pid: 12345)
+
+        let resolution = try InteractionCoordinateResolver.resolveTargetWindowCoordinates(
+            CGPoint(x: 20, y: 19),
+            windowInfo: window,
+            targetApplication: app
+        )
+
+        #expect(resolution.coordinateSpace == .windowRelative)
+        #expect(resolution.screenPoint == CGPoint(x: 220, y: 279))
+        #expect(resolution.targetWindowID == 59620)
+        #expect(resolution.targetApplicationName == "OpenClaw Settings")
+        #expect(resolution.diagnostics.coordinateSpace == "window_relative")
+        #expect(resolution.diagnostics.targetWindow?.windowID == 59620)
+    }
+
+    @Test
+    @MainActor
+    func `global coordinates stay global without a target window`() throws {
+        let resolution = try InteractionCoordinateResolver.resolveTargetWindowCoordinates(
+            CGPoint(x: 20, y: 19),
+            windowInfo: nil,
+            targetApplication: nil
+        )
+
+        #expect(resolution.coordinateSpace == .global)
+        #expect(resolution.screenPoint == CGPoint(x: 20, y: 19))
+        #expect(resolution.windowInfo == nil)
+        #expect(resolution.targetApplication == nil)
+    }
+
+    @Test
+    @MainActor
+    func `explicit global coordinates bypass target window conversion`() throws {
+        let window = Self.makeWindow(
+            id: 59620,
+            title: "Settings",
+            bounds: CGRect(x: 200, y: 260, width: 420, height: 300)
+        )
+        let app = Self.makeApp(name: "OpenClaw Settings", pid: 12345)
+
+        let resolution = try InteractionCoordinateResolver.resolveTargetWindowCoordinates(
+            CGPoint(x: 220, y: 279),
+            windowInfo: window,
+            targetApplication: app,
+            forceGlobal: true
+        )
+
+        #expect(resolution.coordinateSpace == .global)
+        #expect(resolution.screenPoint == CGPoint(x: 220, y: 279))
+        #expect(resolution.windowInfo == nil)
+    }
+
+    @Test
+    @MainActor
+    func `out of window coordinates fail before click synthesis`() throws {
+        let window = Self.makeWindow(
+            id: 59620,
+            title: "Settings",
+            bounds: CGRect(x: 200, y: 260, width: 420, height: 300)
+        )
+
+        #expect(throws: (any Error).self) {
+            _ = try InteractionCoordinateResolver.resolveTargetWindowCoordinates(
+                CGPoint(x: 421, y: 10),
+                windowInfo: window,
+                targetApplication: nil
+            )
+        }
+
+        #expect(throws: (any Error).self) {
+            _ = try InteractionCoordinateResolver.resolveTargetWindowCoordinates(
+                CGPoint(x: 420, y: 10),
+                windowInfo: window,
+                targetApplication: nil
+            )
+        }
+    }
+
+    private static func makeApp(name: String, pid: Int32) -> ServiceApplicationInfo {
+        ServiceApplicationInfo(
+            processIdentifier: pid,
+            bundleIdentifier: "com.example.\(name.replacingOccurrences(of: " ", with: "-").lowercased())",
+            name: name,
+            bundlePath: nil,
+            isActive: true,
+            isHidden: false,
+            windowCount: 1,
+            activationPolicy: .regular
+        )
+    }
+
+    private static func makeWindow(id: Int, title: String, bounds: CGRect) -> ServiceWindowInfo {
+        ServiceWindowInfo(
+            windowID: id,
+            title: title,
+            bounds: bounds,
+            isMinimized: false,
+            isMainWindow: true,
+            windowLevel: 0,
+            alpha: 1.0,
+            index: 0
+        )
+    }
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [3.2.1] - Unreleased
 
 ### Fixed
+- `peekaboo click --coords` now treats coordinates as target-window-relative when app/window target flags are supplied, reports resolved target metadata, and requires `--global-coords` for targeted global clicks.
 - `peekaboo-mcp` now shuts down cleanly during restart backoff and repairs executable permissions without shelling out through an install path.
 - `pnpm run peekaboo:dev` no longer depends on a hardcoded local checkout path.
 - `peekaboo agent` now tells models to use the current tool schema instead of stale tool names and arguments. Thanks @vyctorbrzezowski for #139.

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/ToolRegistry/ToolDefinitions.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/ToolRegistry/ToolDefinitions.swift
@@ -62,7 +62,8 @@ public enum UIAutomationToolDefinitions {
         abstract: "Click on UI elements or coordinates",
         discussion: """
         Clicks on UI elements or coordinates. Supports element queries,
-        specific IDs from `see` or `inspect_ui`, or raw coordinates.
+        specific IDs from `see` or `inspect_ui`, or coordinates. CLI coordinate
+        clicks are target-window-relative when app/window target flags are supplied.
         """,
         category: .ui,
         parameters: [
@@ -79,7 +80,7 @@ public enum UIAutomationToolDefinitions {
             ParameterDefinition(
                 name: "coords",
                 type: .string,
-                description: "Click at specific coordinates in format 'x,y'",
+                description: "Click at coordinates in format 'x,y'",
                 required: false),
             ParameterDefinition(
                 name: "double",

--- a/docs/automation.md
+++ b/docs/automation.md
@@ -17,7 +17,7 @@ Every input command accepts one of three target shapes:
 
 - **Element ID** — `--id E12` (from `peekaboo see`); the most reliable.
 - **Label / role / app** — positional query text such as `peekaboo click "Send" --app Mail`; resolved via the AX tree.
-- **Coordinates** — `--coords 480,120`; the fallback when the AX tree lies.
+- **Coordinates** — `--coords 480,120`; target-relative when paired with `--app`, `--pid`, or `--window-*`, global otherwise. Add `--global-coords` to force screen coordinates with a target.
 
 Prefer IDs when you can capture them, labels when you can't, and coordinates only as a last resort. The agent and MCP tooling default to the first two.
 

--- a/docs/commands/click.md
+++ b/docs/commands/click.md
@@ -14,7 +14,8 @@ read_when:
 | --- | --- |
 | `[query]` | Optional positional text query (case-insensitive substring match). |
 | `--on <id>` / `--id <id>` | Target a specific Peekaboo element ID (e.g., `B1`, `T2`). |
-| `--coords x,y` | Click exact coordinates without touching the snapshot cache. |
+| `--coords x,y` | Click coordinates. With target flags, coordinates are relative to the resolved target window; without target flags, they are global screen coordinates. |
+| `--global-coords` | Treat `--coords` as global screen coordinates even when target flags are supplied. |
 | `--snapshot <id>` | Reuse a prior snapshot; defaults to `services.snapshots.getMostRecentSnapshot()` when omitted. |
 | Target flags | `--app <name>`, `--pid <pid>`, `--window-id <id>`, `--window-title <title>`, `--window-index <n>` — focus a specific app/window before clicking. (`--window-title`/`--window-index` require `--app` or `--pid`; `--window-id` does not.) |
 | `--wait-for <ms>` | Millisecond timeout while waiting for the element to appear (default 5000). |
@@ -23,12 +24,12 @@ read_when:
 | `--focus-background` | Send the click to a target process without focusing it. Use `--app`, `--pid`, or a snapshot with process metadata. |
 
 ## Implementation notes
-- Validation makes sure you only provide one targeting strategy (ID/query vs. `--coords`) and that coordinate strings parse cleanly into doubles.
-- When no `--snapshot` is provided, the command grabs the most recent snapshot ID (if any) before waiting for elements. Coordinate clicks skip snapshot usage entirely to avoid stale caches.
+- Validation makes sure you only provide one targeting strategy (ID/query vs. `--coords`) and that coordinate strings parse cleanly into doubles. Target-relative coordinate clicks fail if the point is outside the resolved window.
+- When no `--snapshot` is provided, the command grabs the most recent snapshot ID (if any) before waiting for elements. Coordinate clicks skip snapshot usage entirely to avoid stale caches, but targeted coordinate clicks resolve the target window before synthesizing the final screen point.
 - Element-based clicks call `AutomationServiceBridge.waitForElement` with the supplied timeout so you don’t have to insert manual sleeps. Helpful hints are printed when timeouts expire.
 - Focus is enforced just before the click by `ensureFocused`; by default it will hop Spaces if necessary unless you pass `--no-auto-focus`.
 - `--focus-background` uses process-targeted CoreGraphics mouse events and skips foreground focus. It requires Event Synthesizing access and a resolvable target process. Coordinate clicks need explicit `--app` or `--pid`; element clicks can reuse snapshot process metadata.
-- JSON output reports `clickedElement`, the resolved coordinates, wait time, execution time, the frontmost app after the click, and `targetPoint` diagnostics for element/query targets. `targetPoint` includes the original snapshot midpoint, the final resolved point, the snapshot ID, and whether a moved-window adjustment was applied.
+- JSON output reports `clickedElement`, input coordinates, resolved screen coordinates, coordinate space, target window metadata, wait time, execution time, and `targetPoint` diagnostics. Element/query `targetPoint` includes the original snapshot midpoint, the final resolved point, the snapshot ID, and whether a moved-window adjustment was applied.
 
 ## Examples
 ```bash
@@ -38,11 +39,17 @@ peekaboo click --on B12
 # Fuzzy search + extra wait for a slow dialog
 peekaboo click "Allow" --wait-for 8000 --space-switch
 
-# Issue a right-click at raw coordinates
+# Issue a right-click at global screen coordinates
 peekaboo click --coords 1024,88 --right --no-auto-focus
 
+# Click 20,40 inside a resolved app window
+peekaboo click --app Safari --coords 20,40
+
+# Force global screen coordinates while still focusing a target first
+peekaboo click --window-id 59620 --coords 1024,88 --global-coords
+
 # Click Safari coordinates without activating Safari
-peekaboo click --coords 420,180 --app Safari --focus-background
+peekaboo click --coords 420,180 --app Safari --focus-background --global-coords
 ```
 
 ## Troubleshooting

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -58,7 +58,7 @@ peekaboo click "Address and search bar" --app Safari
 peekaboo type "github.com/openclaw/Peekaboo" --return
 ```
 
-Coordinates also work: `peekaboo click --coords 480,120`. See [automation.md](automation.md) for the full input vocabulary.
+Coordinates also work: `peekaboo click --coords 480,120`. With app/window target flags, click coordinates are target-window-relative; add `--global-coords` for screen coordinates. See [automation.md](automation.md) for the full input vocabulary.
 
 ## 5. Run an agent
 


### PR DESCRIPTION
## Summary
- resolve `click --coords` relative to the selected window when `--window-id`, `--window-title`, `--window-index`, `--app`, or `--pid` is supplied
- add `--global-coords` for explicit screen-coordinate clicks with target options
- report resolved target window/app and coordinate metadata in JSON, plus docs/changelog updates
- verify focus against the resolved target window before dispatching coordinate clicks

## Proof
- `pnpm run build:cli`
- `pnpm run lint` (exit 0; existing non-serious parameter-count warnings remain)
- `git diff --check`
- `swift test --package-path Apps/CLI -Xswiftc -DPEEKABOO_SKIP_AUTOMATION --filter InteractionCoordinateResolverTests --no-parallel`
- `swift test --package-path Apps/CLI -Xswiftc -DPEEKABOO_SKIP_AUTOMATION --filter ClickCommandFocusVerificationTests --no-parallel`
- `pnpm run test:safe` (445 tests / 64 suites)
- live: `peekaboo click --window-id 10734 --coords "1,1" --json --no-remote` resolved Finder window-relative `1,1` to screen `1045,311`
- live: `peekaboo click --window-id 10734 --coords "920,1" --json --no-remote` failed with out-of-window validation
- live: `peekaboo click --coords "1045,311" --json --no-remote` preserved global coordinate behavior
- Codex review: `/Users/steipete/Projects/agent-scripts/skills/codex-review/scripts/codex-review` clean, no accepted/actionable findings
