### PR TITLE
fix(agent): treat OAuth access tokens as Bearer auth not API keys

### DIFF
--- a/Apps/CLI/CHANGELOG.md
+++ b/Apps/CLI/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Custom provider docs, CLI help, and macOS settings now prefer `${VAR}` API key references and shell examples that preserve them literally. Thanks @scotthuang for #142.
 - `peekaboo agent` now refreshes desktop context before each model turn and wires opt-in action verification through the configured capture strategy. Thanks @lonexreb for #148.
 - AX traversal budgets now have wider defaults plus CLI, MCP, and environment overrides for complex app trees. Thanks @widdowson for #150 and #151.
+- `peekaboo agent` now keeps OAuth access tokens on Bearer auth paths instead of misclassifying them as API keys, including config-dir overrides and audio transcription. Thanks @Crux0453 for #154.
 
 ## [3.2.0] - 2026-05-15
 

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/AI/AgentCommand+ModelParsing.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/AI/AgentCommand+ModelParsing.swift
@@ -100,9 +100,9 @@ extension AgentCommand {
         case .ollama, .lmstudio:
             return true
         case .openai:
-            return configuration.getOpenAIAPIKey()?.isEmpty == false
+            return configuration.hasOpenAIAuth()
         case .anthropic:
-            return configuration.getAnthropicAPIKey()?.isEmpty == false
+            return configuration.hasAnthropicAuth()
         case .google:
             return configuration.getGeminiAPIKey()?.isEmpty == false
         case .minimax:

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/AI/AgentCommand.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/AI/AgentCommand.swift
@@ -333,8 +333,8 @@ extension AgentCommand {
     }
 
     private func hasConfiguredAIProvider(configuration: PeekabooCore.ConfigurationManager) -> Bool {
-        let hasOpenAI = configuration.getOpenAIAPIKey()?.isEmpty == false
-        let hasAnthropic = configuration.getAnthropicAPIKey()?.isEmpty == false
+        let hasOpenAI = configuration.hasOpenAIAuth()
+        let hasAnthropic = configuration.hasAnthropicAuth()
         let hasGemini = configuration.getGeminiAPIKey()?.isEmpty == false
         let hasMiniMax = configuration.getMiniMaxAPIKey()?.isEmpty == false
         let hasLocalProvider = configuration.getAIProviders()

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Base/CommandRuntime.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Base/CommandRuntime.swift
@@ -11,7 +11,6 @@ import PeekabooBridge
 import PeekabooCore
 import PeekabooFoundation
 import PeekabooProtocols
-import Tachikoma
 
 /// Shared options that control logging and output behavior.
 struct CommandRuntimeOptions {
@@ -82,7 +81,7 @@ struct CommandRuntime {
         hostDescription: String = "local (in-process)"
     ) {
         // Keep Tachikoma credential/profile resolution aligned with Peekaboo CLI storage.
-        TachikomaConfiguration.profileDirectoryName = ".peekaboo"
+        PeekabooCore.ConfigurationManager.configureTachikomaProfileDirectory()
 
         self.configuration = configuration
         self.services = services

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Core/ConfigCommand+Shared.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Core/ConfigCommand+Shared.swift
@@ -7,7 +7,6 @@ import Commander
 import Foundation
 import PeekabooCore
 import PeekabooFoundation
-import Tachikoma
 
 @MainActor
 protocol ConfigRuntimeCommand {
@@ -37,7 +36,7 @@ extension ConfigRuntimeCommand {
         self.runtime = runtime
         self.logger.setJsonOutputMode(self.jsonOutput)
         // Align Tachikoma profile dir with Peekaboo storage
-        TachikomaConfiguration.profileDirectoryName = ".peekaboo"
+        PeekabooCore.ConfigurationManager.configureTachikomaProfileDirectory()
     }
 
     var output: ConfigCommandOutput {

--- a/Apps/CLI/Tests/CLIRuntimeTests/CommandRuntimeInjectionTests.swift
+++ b/Apps/CLI/Tests/CLIRuntimeTests/CommandRuntimeInjectionTests.swift
@@ -50,7 +50,7 @@ struct CommandRuntimeInjectionTests {
             services: services
         )
 
-        #expect(TachikomaConfiguration.profileDirectoryName == ".peekaboo")
+        #expect(TachikomaConfiguration.profileDirectoryPath == PeekabooCore.ConfigurationManager.baseDir)
     }
 
     @Test

--- a/Apps/Mac/Peekaboo/Services/SessionTitleGenerator.swift
+++ b/Apps/Mac/Peekaboo/Services/SessionTitleGenerator.swift
@@ -15,8 +15,8 @@ final class SessionTitleGenerator {
             .getAIProviders()
             .split(separator: ",")
             .map { $0.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() }
-        let hasOpenAI = self.configuration.getOpenAIAPIKey() != nil
-        let hasAnthropic = self.configuration.getAnthropicAPIKey() != nil
+        let hasOpenAI = self.configuration.hasOpenAIAuth()
+        let hasAnthropic = self.configuration.hasAnthropicAuth()
 
         return await withTaskGroup(of: String.self) { group in
             group.addTask { await Self.timeoutTitle() }
@@ -85,13 +85,13 @@ final class SessionTitleGenerator {
         hasOpenAI: Bool,
         hasAnthropic: Bool) -> LanguageModel
     {
-        if providers.contains("anthropic"), hasAnthropic {
+        if providers.contains(where: { $0 == "anthropic" || $0.hasPrefix("anthropic/") }), hasAnthropic {
             return .anthropic(.opus47)
         }
-        if providers.contains("openai"), hasOpenAI {
+        if providers.contains(where: { $0 == "openai" || $0.hasPrefix("openai/") }), hasOpenAI {
             return .openai(.gpt55)
         }
-        if providers.contains("ollama") {
+        if providers.contains(where: { $0 == "ollama" || $0.hasPrefix("ollama/") }) {
             return .ollama(.llama33)
         }
         return .anthropic(.opus47)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Custom provider docs, CLI help, and macOS settings now prefer `${VAR}` API key references and shell examples that preserve them literally. Thanks @scotthuang for #142.
 - `peekaboo agent` now refreshes desktop context before each model turn and wires opt-in action verification through the configured capture strategy. Thanks @lonexreb for #148.
 - AX traversal budgets now have wider defaults plus CLI, MCP, and environment overrides for complex app trees. Thanks @widdowson for #150 and #151.
+- `peekaboo agent` now keeps OAuth access tokens on Bearer auth paths instead of misclassifying them as API keys, including config-dir overrides and audio transcription. Thanks @Crux0453 for #154.
 
 ## [3.2.0] - 2026-05-15
 

--- a/Core/PeekabooCore/Sources/PeekabooAutomation/Configuration/ConfigurationManager+Accessors.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAutomation/Configuration/ConfigurationManager+Accessors.swift
@@ -37,14 +37,17 @@ extension ConfigurationManager {
             defaultValue: "openai/gpt-5.5,anthropic/claude-opus-4-7")
     }
 
-    /// Get OpenAI API key with proper precedence
+    /// Get OpenAI API key with proper precedence.
+    ///
+    /// Returns only true API keys. OAuth access tokens (e.g. `OPENAI_ACCESS_TOKEN`
+    /// from `peekaboo config login openai`) intentionally flow through
+    /// `TKAuthManager.resolveAuth(for:)` instead so they can be sent as
+    /// `Authorization: Bearer …`. Routing them through `applyAIProviderKeys()` →
+    /// `TachikomaConfiguration.setAPIKey(for: .openai)` would force the OpenAI
+    /// provider to send them as an API key, breaking OAuth-based logins.
     public func getOpenAIAPIKey() -> String? {
         if let envValue = self.environmentValue(for: "OPENAI_API_KEY") {
             return envValue
-        }
-
-        if let token = self.validOAuthAccessToken(prefix: "OPENAI") {
-            return token
         }
 
         if let credValue = credentials["OPENAI_API_KEY"] {
@@ -58,14 +61,19 @@ extension ConfigurationManager {
         return nil
     }
 
-    /// Get Anthropic API key with proper precedence
+    /// Get Anthropic API key with proper precedence.
+    ///
+    /// Returns only true API keys. OAuth access tokens (e.g. `ANTHROPIC_ACCESS_TOKEN`
+    /// from `peekaboo config login anthropic`) intentionally flow through
+    /// `TKAuthManager.resolveAuth(for:)` instead so they can be sent as
+    /// `Authorization: Bearer …` with the Claude Max beta headers attached.
+    /// Returning them here would route them through `applyAIProviderKeys()` →
+    /// `TachikomaConfiguration.setAPIKey(for: .anthropic)`, which the Anthropic
+    /// provider sends as `x-api-key` — Anthropic rejects that with
+    /// `401 invalid x-api-key`.
     public func getAnthropicAPIKey() -> String? {
         if let envValue = self.environmentValue(for: "ANTHROPIC_API_KEY") {
             return envValue
-        }
-
-        if let token = self.validOAuthAccessToken(prefix: "ANTHROPIC") {
-            return token
         }
 
         if let credValue = credentials["ANTHROPIC_API_KEY"] {
@@ -77,6 +85,26 @@ extension ConfigurationManager {
         }
 
         return nil
+    }
+
+    /// Whether any OpenAI authentication material is available — either an API
+    /// key (via `getOpenAIAPIKey()`) or a non-expired OAuth access token (via
+    /// `peekaboo config login openai`). Use this for agent-availability gates;
+    /// `getOpenAIAPIKey()` alone deliberately ignores OAuth tokens so they are
+    /// not misclassified as `x-api-key` material.
+    public func hasOpenAIAuth() -> Bool {
+        if self.getOpenAIAPIKey()?.isEmpty == false { return true }
+        return self.validOAuthAccessToken(prefix: "OPENAI") != nil
+    }
+
+    /// Whether any Anthropic authentication material is available — either an
+    /// API key (via `getAnthropicAPIKey()`) or a non-expired OAuth access token
+    /// (via `peekaboo config login anthropic`). Use this for agent-availability
+    /// gates; `getAnthropicAPIKey()` alone deliberately ignores OAuth tokens so
+    /// they are not misclassified as `x-api-key` material.
+    public func hasAnthropicAuth() -> Bool {
+        if self.getAnthropicAPIKey()?.isEmpty == false { return true }
+        return self.validOAuthAccessToken(prefix: "ANTHROPIC") != nil
     }
 
     /// Get Gemini API key with proper precedence

--- a/Core/PeekabooCore/Sources/PeekabooAutomation/Configuration/ConfigurationManager+Accessors.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAutomation/Configuration/ConfigurationManager+Accessors.swift
@@ -97,6 +97,15 @@ extension ConfigurationManager {
         return self.validOAuthAccessToken(prefix: "OPENAI") != nil
     }
 
+    /// OpenAI credential for APIs that accept Bearer tokens but still require
+    /// an explicit Tachikoma API-key slot, such as TachikomaAudio transcription.
+    public func getOpenAITranscriptionCredential() -> String? {
+        if let apiKey = self.getOpenAIAPIKey(), !apiKey.isEmpty {
+            return apiKey
+        }
+        return self.validOAuthAccessToken(prefix: "OPENAI")
+    }
+
     /// Whether any Anthropic authentication material is available — either an
     /// API key (via `getAnthropicAPIKey()`) or a non-expired OAuth access token
     /// (via `peekaboo config login anthropic`). Use this for agent-availability

--- a/Core/PeekabooCore/Sources/PeekabooAutomation/Configuration/ConfigurationManager.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAutomation/Configuration/ConfigurationManager.swift
@@ -50,6 +50,10 @@ public final class ConfigurationManager: @unchecked Sendable {
         "\(baseDir)/credentials"
     }
 
+    public static func configureTachikomaProfileDirectory() {
+        TachikomaConfiguration.profileDirectoryName = self.baseDir
+    }
+
     /// Loaded configuration
     var configuration: Configuration?
 
@@ -58,6 +62,7 @@ public final class ConfigurationManager: @unchecked Sendable {
 
     private init() {
         // Load configuration on init, but don't crash if it fails
+        Self.configureTachikomaProfileDirectory()
         _ = self.loadConfiguration()
     }
 
@@ -106,6 +111,7 @@ public final class ConfigurationManager: @unchecked Sendable {
 
     /// Load configuration from file
     public func loadConfiguration() -> Configuration? {
+        Self.configureTachikomaProfileDirectory()
         try? self.migrateIfNeeded()
         self.loadCredentials()
         self.configuration = self.loadConfigurationFromPath(Self.configPath)

--- a/Core/PeekabooCore/Sources/PeekabooAutomation/Services/AI/PeekabooAIService.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAutomation/Services/AI/PeekabooAIService.swift
@@ -300,8 +300,8 @@ public final class PeekabooAIService {
             }
         }
 
-        // Fallback: prefer Anthropic if a key is present, else OpenAI
-        if let key = configuration.getAnthropicAPIKey(), !key.isEmpty {
+        // Fallback: prefer Anthropic if any auth (API key or OAuth) is present
+        if configuration.hasAnthropicAuth() {
             return self.appendingGeneratedVisionFallbacks(from: parsed, to: [.anthropic(.opus47)])
         }
         if let key = configuration.getGeminiAPIKey(), !key.isEmpty {
@@ -377,9 +377,9 @@ public final class PeekabooAIService {
     {
         switch model {
         case .openai:
-            configuration.getOpenAIAPIKey()?.isEmpty == false
+            configuration.hasOpenAIAuth()
         case .anthropic:
-            configuration.getAnthropicAPIKey()?.isEmpty == false
+            configuration.hasAnthropicAuth()
         case .google:
             configuration.getGeminiAPIKey()?.isEmpty == false
         case .minimax:

--- a/Core/PeekabooCore/Sources/PeekabooAutomation/Services/AI/PeekabooAIService.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAutomation/Services/AI/PeekabooAIService.swift
@@ -118,7 +118,7 @@ public final class PeekabooAIService {
 
     public init(configuration: ConfigurationManager = .shared) {
         self.configuration = configuration
-        TachikomaConfiguration.profileDirectoryName = ".peekaboo"
+        ConfigurationManager.configureTachikomaProfileDirectory()
         _ = configuration.loadConfiguration()
         configuration.applyAIProviderKeys()
         self.resolvedModels = Self.resolveAvailableModels(configuration: configuration)

--- a/Core/PeekabooCore/Sources/PeekabooAutomation/Services/Audio/AudioInputService.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAutomation/Services/Audio/AudioInputService.swift
@@ -167,7 +167,8 @@ public final class AudioInputService {
             self.logger.info("Stopped audio recording")
 
             // Transcribe the recorded audio using TachikomaAudio
-            return try await transcribe(audioData)
+            let credential = try self.transcriptionCredential()
+            return try await self.aiService.transcribeAudio(audioData, openAICredential: credential)
         } catch let error as AudioRecordingError {
             // Convert AudioRecordingError to AudioInputError
             switch error {
@@ -225,11 +226,11 @@ public final class AudioInputService {
             }
         }
 
-        try self.requireTranscriptionCredentials()
+        let credential = try self.transcriptionCredential()
 
         // Use AI service to transcribe
         do {
-            let transcription = try await aiService.transcribeAudio(at: url)
+            let transcription = try await aiService.transcribeAudio(at: url, openAICredential: credential)
             self.logger.info("Successfully transcribed audio file")
             return transcription
         } catch let audioError as AudioInputError {
@@ -240,12 +241,13 @@ public final class AudioInputService {
         }
     }
 
-    private func requireTranscriptionCredentials() throws {
+    private func transcriptionCredential() throws -> String {
         guard let key = self.credentialProvider.currentOpenAIKey(),
               !key.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
         else {
             throw AudioInputError.apiKeyMissing
         }
+        return key
     }
 }
 
@@ -257,18 +259,24 @@ protocol AudioTranscriptionCredentialProviding: Sendable {
 
 struct ConfigurationCredentialProvider: AudioTranscriptionCredentialProviding {
     func currentOpenAIKey() -> String? {
-        ConfigurationManager.shared.getOpenAIAPIKey()
+        ConfigurationManager.shared.getOpenAITranscriptionCredential()
     }
 }
 
 // MARK: - PeekabooAIService Extension
 
 extension PeekabooAIService {
+    public func transcribeAudio(_ audioData: AudioData, openAICredential: String? = nil) async throws -> String {
+        let configuration = self.audioConfiguration(openAICredential: openAICredential)
+        return try await transcribe(audioData, configuration: configuration)
+    }
+
     /// Transcribe audio using TachikomaAudio's transcription API
-    public func transcribeAudio(at url: URL) async throws -> String {
+    public func transcribeAudio(at url: URL, openAICredential: String? = nil) async throws -> String {
+        let configuration = self.audioConfiguration(openAICredential: openAICredential)
         // Use TachikomaAudio's convenient transcribe function
         do {
-            return try await transcribe(contentsOf: url)
+            return try await transcribe(contentsOf: url, configuration: configuration)
         } catch {
             // Convert errors to AudioInputError for compatibility
             if let tachikomaError = error as? TachikomaError {
@@ -285,5 +293,13 @@ extension PeekabooAIService {
             }
             throw AudioInputError.transcriptionFailed(error.localizedDescription)
         }
+    }
+
+    private func audioConfiguration(openAICredential: String?) -> TachikomaConfiguration {
+        let configuration = TachikomaConfiguration(loadFromEnvironment: true)
+        if let openAICredential, !openAICredential.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            configuration.setAPIKey(openAICredential, for: .openai)
+        }
+        return configuration
     }
 }

--- a/Core/PeekabooCore/Sources/PeekabooAutomation/Services/Audio/AudioInputService.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAutomation/Services/Audio/AudioInputService.swift
@@ -179,6 +179,8 @@ public final class AudioInputService {
             default:
                 throw AudioInputError.audioSessionError(error.localizedDescription)
             }
+        } catch let error as AudioInputError {
+            throw error
         } catch let error as TachikomaError {
             // Convert TachikomaError to AudioInputError
             switch error {

--- a/Core/PeekabooCore/Sources/PeekabooCore/Support/PeekabooServices+Agent.swift
+++ b/Core/PeekabooCore/Sources/PeekabooCore/Support/PeekabooServices+Agent.swift
@@ -17,10 +17,9 @@ extension PeekabooServices {
 
         let providers = self.configuration.getAIProviders()
 
-        // Check for available providers
-        let hasOpenAI = self.configuration.getOpenAIAPIKey() != nil && !self.configuration.getOpenAIAPIKey()!.isEmpty
-        let hasAnthropic = self.configuration.getAnthropicAPIKey() != nil && !self.configuration.getAnthropicAPIKey()!
-            .isEmpty
+        // Check for available providers (API key or OAuth access token)
+        let hasOpenAI = self.configuration.hasOpenAIAuth()
+        let hasAnthropic = self.configuration.hasAnthropicAuth()
         let hasGemini = self.configuration.getGeminiAPIKey() != nil && !self.configuration.getGeminiAPIKey()!.isEmpty
         let hasMiniMax = self.configuration.getMiniMaxAPIKey() != nil && !self.configuration.getMiniMaxAPIKey()!.isEmpty
         let hasOllama = Self.providerList(providers, containsToolCapableLocalProvider: "ollama")

--- a/Core/PeekabooCore/Tests/PeekabooTests/ConfigurationAccessorsOAuthTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/ConfigurationAccessorsOAuthTests.swift
@@ -108,6 +108,29 @@ struct ConfigurationAccessorsOAuthTests {
     }
 
     @Test
+    func `OAuth availability uses same overridden config root as Tachikoma auth`() throws {
+        try withIsolatedConfigurationEnvironment { configDir in
+            self.unsetAllAnthropicEnv()
+            self.manager.resetForTesting()
+            try self.manager.saveCredentials([
+                "ANTHROPIC_ACCESS_TOKEN": "placeholder-anthropic-oauth-access",
+                "ANTHROPIC_BETA_HEADER": "oauth-2025-04-20",
+                "ANTHROPIC_ACCESS_EXPIRES": String(Int(Date().addingTimeInterval(3600).timeIntervalSince1970)),
+            ])
+            _ = self.manager.loadConfiguration()
+
+            #expect(TachikomaConfiguration.profileDirectoryPath == configDir.path)
+            #expect(self.manager.hasAnthropicAuth())
+            if case let .bearer(token, betaHeader)? = TKAuthManager.shared.resolveAuth(for: .anthropic) {
+                #expect(token == "placeholder-anthropic-oauth-access")
+                #expect(betaHeader == "oauth-2025-04-20")
+            } else {
+                Issue.record("Expected Anthropic OAuth bearer auth from isolated config root")
+            }
+        }
+    }
+
+    @Test
     func `applyAIProviderKeys leaves anthropic slot empty when only OAuth token is stored`() throws {
         try withIsolatedConfigurationEnvironment { _ in
             self.unsetAllAnthropicEnv()
@@ -165,6 +188,7 @@ private func withIsolatedConfigurationEnvironment(_ body: (URL) throws -> Void) 
         .appendingPathComponent("peekaboo-config-tests-\(UUID().uuidString)", isDirectory: true)
     try fileManager.createDirectory(at: configDir, withIntermediateDirectories: true)
 
+    let previousProfileDirectoryName = TachikomaConfiguration.profileDirectoryName
     let environmentKeys = [
         "PEEKABOO_CONFIG_DIR",
         "PEEKABOO_CONFIG_DISABLE_MIGRATION",
@@ -194,6 +218,7 @@ private func withIsolatedConfigurationEnvironment(_ body: (URL) throws -> Void) 
                 unsetenv(key)
             }
         }
+        TachikomaConfiguration.profileDirectoryName = previousProfileDirectoryName
         ConfigurationManager.shared.resetForTesting()
         try? fileManager.removeItem(at: configDir)
     }

--- a/Core/PeekabooCore/Tests/PeekabooTests/ConfigurationAccessorsOAuthTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/ConfigurationAccessorsOAuthTests.swift
@@ -79,6 +79,35 @@ struct ConfigurationAccessorsOAuthTests {
     }
 
     @Test
+    func `getOpenAITranscriptionCredential returns OAuth access token when no API key is stored`() throws {
+        try withIsolatedConfigurationEnvironment { _ in
+            self.unsetAllOpenAIEnv()
+            self.manager.resetForTesting()
+            try self.manager.saveCredentials([
+                "OPENAI_ACCESS_TOKEN": "openai-oauth-access-token",
+                "OPENAI_ACCESS_EXPIRES": String(Int(Date().addingTimeInterval(3600).timeIntervalSince1970)),
+            ])
+
+            #expect(self.manager.getOpenAITranscriptionCredential() == "openai-oauth-access-token")
+        }
+    }
+
+    @Test
+    func `getOpenAITranscriptionCredential prefers API key over OAuth access token`() throws {
+        try withIsolatedConfigurationEnvironment { _ in
+            self.unsetAllOpenAIEnv()
+            self.manager.resetForTesting()
+            try self.manager.saveCredentials([
+                "OPENAI_API_KEY": "placeholder-openai-api-key",
+                "OPENAI_ACCESS_TOKEN": "openai-oauth-access-token",
+                "OPENAI_ACCESS_EXPIRES": String(Int(Date().addingTimeInterval(3600).timeIntervalSince1970)),
+            ])
+
+            #expect(self.manager.getOpenAITranscriptionCredential() == "placeholder-openai-api-key")
+        }
+    }
+
+    @Test
     func `applyAIProviderKeys leaves anthropic slot empty when only OAuth token is stored`() throws {
         try withIsolatedConfigurationEnvironment { _ in
             self.unsetAllAnthropicEnv()

--- a/Core/PeekabooCore/Tests/PeekabooTests/ConfigurationAccessorsOAuthTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/ConfigurationAccessorsOAuthTests.swift
@@ -1,0 +1,154 @@
+import Darwin
+import Foundation
+import Testing
+import Tachikoma
+@testable import PeekabooAutomation
+@testable import PeekabooCore
+
+/// Regression tests for `getOpenAIAPIKey()` / `getAnthropicAPIKey()` and
+/// `applyAIProviderKeys()` to guarantee that OAuth access tokens stored in
+/// the credentials file (e.g. `ANTHROPIC_ACCESS_TOKEN` written by
+/// `peekaboo config login anthropic`) do NOT leak into the API-key code path.
+///
+/// Before this regression test existed, `getAnthropicAPIKey()` returned any
+/// valid `ANTHROPIC_ACCESS_TOKEN` from the credentials file, which then flowed
+/// through `applyAIProviderKeys()` → `TachikomaConfiguration.setAPIKey(for:
+/// .anthropic)` and ultimately the Anthropic provider sent the OAuth token as
+/// `x-api-key`, producing `401 invalid x-api-key`. See openclaw/Peekaboo#44.
+@Suite(.serialized)
+struct ConfigurationAccessorsOAuthTests {
+    private let manager = ConfigurationManager.shared
+
+    @Test
+    func `getAnthropicAPIKey returns nil when only OAuth access token is stored`() throws {
+        try withIsolatedConfigurationEnvironment { _ in
+            self.unsetAllAnthropicEnv()
+            self.manager.resetForTesting()
+            try self.manager.saveCredentials([
+                "ANTHROPIC_ACCESS_TOKEN": "placeholder-anthropic-oauth-access",
+                "ANTHROPIC_REFRESH_TOKEN": "placeholder-anthropic-oauth-refresh",
+                "ANTHROPIC_BETA_HEADER": "oauth-2025-04-20,claude-code-20250219",
+                "ANTHROPIC_ACCESS_EXPIRES": String(Int(Date().addingTimeInterval(3600).timeIntervalSince1970)),
+            ])
+
+            #expect(self.manager.getAnthropicAPIKey() == nil)
+        }
+    }
+
+    @Test
+    func `getAnthropicAPIKey returns API key from credentials when present`() throws {
+        try withIsolatedConfigurationEnvironment { _ in
+            self.unsetAllAnthropicEnv()
+            self.manager.resetForTesting()
+            try self.manager.saveCredentials([
+                "ANTHROPIC_API_KEY": "placeholder-anthropic-api-key",
+                "ANTHROPIC_ACCESS_TOKEN": "placeholder-anthropic-oauth-also-here",
+            ])
+
+            #expect(self.manager.getAnthropicAPIKey() == "placeholder-anthropic-api-key")
+        }
+    }
+
+    @Test
+    func `getOpenAIAPIKey returns nil when only OAuth access token is stored`() throws {
+        try withIsolatedConfigurationEnvironment { _ in
+            self.unsetAllOpenAIEnv()
+            self.manager.resetForTesting()
+            try self.manager.saveCredentials([
+                "OPENAI_ACCESS_TOKEN": "openai-oauth-access-token",
+                "OPENAI_REFRESH_TOKEN": "openai-oauth-refresh-token",
+                "OPENAI_ACCESS_EXPIRES": String(Int(Date().addingTimeInterval(3600).timeIntervalSince1970)),
+            ])
+
+            #expect(self.manager.getOpenAIAPIKey() == nil)
+        }
+    }
+
+    @Test
+    func `getOpenAIAPIKey returns API key from credentials when present`() throws {
+        try withIsolatedConfigurationEnvironment { _ in
+            self.unsetAllOpenAIEnv()
+            self.manager.resetForTesting()
+            try self.manager.saveCredentials([
+                "OPENAI_API_KEY": "placeholder-openai-api-key",
+                "OPENAI_ACCESS_TOKEN": "openai-oauth-token-also-here",
+            ])
+
+            #expect(self.manager.getOpenAIAPIKey() == "placeholder-openai-api-key")
+        }
+    }
+
+    @Test
+    func `applyAIProviderKeys leaves anthropic slot empty when only OAuth token is stored`() throws {
+        try withIsolatedConfigurationEnvironment { _ in
+            self.unsetAllAnthropicEnv()
+            self.manager.resetForTesting()
+            try self.manager.saveCredentials([
+                "ANTHROPIC_ACCESS_TOKEN": "placeholder-anthropic-oauth",
+                "ANTHROPIC_BETA_HEADER": "oauth-2025-04-20",
+                "ANTHROPIC_ACCESS_EXPIRES": String(Int(Date().addingTimeInterval(3600).timeIntervalSince1970)),
+            ])
+
+            let configuration = TachikomaConfiguration(loadFromEnvironment: false)
+            self.manager.applyAIProviderKeys(to: configuration)
+
+            #expect(configuration.getAPIKey(for: .anthropic) == nil)
+        }
+    }
+
+    @Test
+    func `applyAIProviderKeys propagates real anthropic API key into Tachikoma`() throws {
+        try withIsolatedConfigurationEnvironment { _ in
+            self.unsetAllAnthropicEnv()
+            self.manager.resetForTesting()
+            try self.manager.saveCredentials([
+                "ANTHROPIC_API_KEY": "placeholder-anthropic-key",
+            ])
+
+            let configuration = TachikomaConfiguration(loadFromEnvironment: false)
+            self.manager.applyAIProviderKeys(to: configuration)
+
+            #expect(configuration.getAPIKey(for: .anthropic) == "placeholder-anthropic-key")
+        }
+    }
+
+    // MARK: - Helpers
+
+    private func unsetAllAnthropicEnv() {
+        unsetenv("ANTHROPIC_API_KEY")
+    }
+
+    private func unsetAllOpenAIEnv() {
+        unsetenv("OPENAI_API_KEY")
+    }
+}
+
+private func withIsolatedConfigurationEnvironment(_ body: (URL) throws -> Void) throws {
+    let fileManager = FileManager.default
+    let configDir = fileManager.temporaryDirectory
+        .appendingPathComponent("peekaboo-config-tests-\(UUID().uuidString)", isDirectory: true)
+    try fileManager.createDirectory(at: configDir, withIntermediateDirectories: true)
+
+    let previousConfigDir = getenv("PEEKABOO_CONFIG_DIR").map { String(cString: $0) }
+    let previousDisableMigration = getenv("PEEKABOO_CONFIG_DISABLE_MIGRATION").map { String(cString: $0) }
+    setenv("PEEKABOO_CONFIG_DIR", configDir.path, 1)
+    setenv("PEEKABOO_CONFIG_DISABLE_MIGRATION", "1", 1)
+    ConfigurationManager.shared.resetForTesting()
+
+    defer {
+        if let previousConfigDir {
+            setenv("PEEKABOO_CONFIG_DIR", previousConfigDir, 1)
+        } else {
+            unsetenv("PEEKABOO_CONFIG_DIR")
+        }
+        if let previousDisableMigration {
+            setenv("PEEKABOO_CONFIG_DISABLE_MIGRATION", previousDisableMigration, 1)
+        } else {
+            unsetenv("PEEKABOO_CONFIG_DISABLE_MIGRATION")
+        }
+        ConfigurationManager.shared.resetForTesting()
+        try? fileManager.removeItem(at: configDir)
+    }
+
+    try body(configDir)
+}

--- a/Core/PeekabooCore/Tests/PeekabooTests/ConfigurationAccessorsOAuthTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/ConfigurationAccessorsOAuthTests.swift
@@ -136,22 +136,34 @@ private func withIsolatedConfigurationEnvironment(_ body: (URL) throws -> Void) 
         .appendingPathComponent("peekaboo-config-tests-\(UUID().uuidString)", isDirectory: true)
     try fileManager.createDirectory(at: configDir, withIntermediateDirectories: true)
 
-    let previousConfigDir = getenv("PEEKABOO_CONFIG_DIR").map { String(cString: $0) }
-    let previousDisableMigration = getenv("PEEKABOO_CONFIG_DISABLE_MIGRATION").map { String(cString: $0) }
+    let environmentKeys = [
+        "PEEKABOO_CONFIG_DIR",
+        "PEEKABOO_CONFIG_DISABLE_MIGRATION",
+        "ANTHROPIC_API_KEY",
+        "ANTHROPIC_ACCESS_TOKEN",
+        "ANTHROPIC_REFRESH_TOKEN",
+        "ANTHROPIC_ACCESS_EXPIRES",
+        "ANTHROPIC_BETA_HEADER",
+        "OPENAI_API_KEY",
+        "OPENAI_ACCESS_TOKEN",
+        "OPENAI_REFRESH_TOKEN",
+        "OPENAI_ACCESS_EXPIRES",
+    ]
+    let previousEnvironment = Dictionary(uniqueKeysWithValues: environmentKeys.map { key in
+        (key, getenv(key).map { String(cString: $0) })
+    })
+
     setenv("PEEKABOO_CONFIG_DIR", configDir.path, 1)
     setenv("PEEKABOO_CONFIG_DISABLE_MIGRATION", "1", 1)
     ConfigurationManager.shared.resetForTesting()
 
     defer {
-        if let previousConfigDir {
-            setenv("PEEKABOO_CONFIG_DIR", previousConfigDir, 1)
-        } else {
-            unsetenv("PEEKABOO_CONFIG_DIR")
-        }
-        if let previousDisableMigration {
-            setenv("PEEKABOO_CONFIG_DISABLE_MIGRATION", previousDisableMigration, 1)
-        } else {
-            unsetenv("PEEKABOO_CONFIG_DISABLE_MIGRATION")
+        for key in environmentKeys {
+            if case let value?? = previousEnvironment[key] {
+                setenv(key, value, 1)
+            } else {
+                unsetenv(key)
+            }
         }
         ConfigurationManager.shared.resetForTesting()
         try? fileManager.removeItem(at: configDir)

--- a/Core/PeekabooCore/Tests/PeekabooTests/ConfigurationAccessorsOAuthTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/ConfigurationAccessorsOAuthTests.swift
@@ -1,7 +1,7 @@
 import Darwin
 import Foundation
-import Testing
 import Tachikoma
+import Testing
 @testable import PeekabooAutomation
 @testable import PeekabooCore
 
@@ -116,10 +116,17 @@ struct ConfigurationAccessorsOAuthTests {
 
     private func unsetAllAnthropicEnv() {
         unsetenv("ANTHROPIC_API_KEY")
+        unsetenv("ANTHROPIC_ACCESS_TOKEN")
+        unsetenv("ANTHROPIC_REFRESH_TOKEN")
+        unsetenv("ANTHROPIC_ACCESS_EXPIRES")
+        unsetenv("ANTHROPIC_BETA_HEADER")
     }
 
     private func unsetAllOpenAIEnv() {
         unsetenv("OPENAI_API_KEY")
+        unsetenv("OPENAI_ACCESS_TOKEN")
+        unsetenv("OPENAI_REFRESH_TOKEN")
+        unsetenv("OPENAI_ACCESS_EXPIRES")
     }
 }
 


### PR DESCRIPTION
# fix(agent): treat OAuth access tokens as Bearer auth not API keys

## Summary
- `ConfigurationManager.getOpenAIAPIKey()` and `getAnthropicAPIKey()` no longer
  return OAuth access tokens. They now return only true API keys (env, credentials
  `*_API_KEY`, config). OAuth tokens (e.g. `ANTHROPIC_ACCESS_TOKEN` written by
  `peekaboo config login anthropic`) flow exclusively through
  `TKAuthManager.resolveAuth(for:)` so they reach the wire as
  `Authorization: Bearer …` with the Claude Max beta headers attached, not as
  `x-api-key`.
- Adds two helpers `hasOpenAIAuth()` / `hasAnthropicAuth()` for
  agent-availability gates (which previously used the now-API-key-only
  `getXxxAPIKey()` and therefore reported "no provider" when only an OAuth
  token was present).
- Updates the four availability call sites (`AgentCommand`,
  `AgentCommand+ModelParsing`, `PeekabooAIService`,
  `PeekabooServices+Agent`) to use the new `hasXxxAuth()` helpers.
- Adds 6 regression tests in
  `Core/PeekabooCore/Tests/PeekabooTests/ConfigurationAccessorsOAuthTests.swift`.

## Bug
Closes #44.

`peekaboo config login anthropic` → success, credentials stored.
`peekaboo agent "ping" --model claude-opus-4-7 --max-steps 1` →
`401: authentication_error / invalid x-api-key`.

Root cause: `ConfigurationManager+Accessors.swift:67` returned
`ANTHROPIC_ACCESS_TOKEN` from `getAnthropicAPIKey()`, which then flowed
into `applyAIProviderKeys()` → `TachikomaConfiguration.setAPIKey(for:
.anthropic)` → `AnthropicProvider.init` chose the `.apiKey(token)`
branch → `makeURLRequest` sent the OAuth token as `x-api-key`.

The OAuth-aware `TKAuthManager.resolveAuth(for: .anthropic)` was
unreachable (Tachikoma's `AnthropicProvider.init` falls through to it
only when `configuration.getAPIKey(for: .anthropic)` returns `nil`).

## Behavior change

Before (3.2.0):

```
$ peekaboo agent "say hello" --model claude-opus-4-7 --max-steps 1
"error": "API error: Anthropic Error (HTTP 401):
  \"type\":\"authentication_error\",\"message\":\"invalid x-api-key\""
```

After (this PR):

```
$ peekaboo agent "say hello" --model claude-opus-4-7 --max-steps 1
"error": "API error: Anthropic Error (HTTP 429):
  \"type\":\"rate_limit_error\""
```

(429 = subscription rate limit, but auth handshake now succeeds —
`Authorization: Bearer` + `anthropic-beta: oauth-2025-04-20, claude-code-…,
interleaved-thinking-…, fine-grained-tool-streaming-…`.)

## Test plan

- [x] `swift build --package-path Apps/CLI -c release --product peekaboo` (53.5MB binary)
- [x] Manual live verification on macOS 26.0:
  - `peekaboo config login anthropic` (OAuth flow stores
    ANTHROPIC_ACCESS_TOKEN + ANTHROPIC_BETA_HEADER + REFRESH_TOKEN)
  - `peekaboo agent "say hello" --model claude-opus-4-7 --max-steps 1`
  - Verified HTTP 401 → HTTP 429 (auth path now correct)
- [x] Same verification with `--model claude-sonnet-4-6`,
  `--model claude-haiku-4-5` (all 429, all reach Anthropic correctly)
- [ ] Unit tests in `ConfigurationAccessorsOAuthTests.swift` not runnable
  locally — Command Line Tools missing the `Testing` framework module
  resolution. Source-build of tests is green via `swift build`. Tests
  will run via maintainer CI.
- [x] `ggshield secret scan path …` clean (test fixtures use
  `placeholder-…` strings)

## Notes
- No behavior change for setups with `*_API_KEY` set — the API-key path is
  unchanged.
- No behavior change for OAuth-only setups EXCEPT the bug being fixed.
- `validOAuthAccessToken(prefix:)` stays in the codebase (used by the new
  `hasXxxAuth()` helpers and `ConfigCommand+Status.swift` source-of-truth
  detection).
- Same pattern applied symmetrically to OpenAI (OAuth-Codex flow) to
  prevent the symmetric regression.
