### PR TITLE
feat: adding openrouter as llm provider

### DIFF
--- a/Apps/CLI/Sources/PeekabooCLI/Commands/AI/AgentCommand+ModelParsing.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/AI/AgentCommand+ModelParsing.swift
@@ -32,6 +32,8 @@ extension AgentCommand {
             }
         case .ollama, .lmstudio:
             return parsed.supportsTools ? parsed : nil
+        case .openRouter:
+            return parsed.supportsTools ? parsed : nil
         default:
             break
         }
@@ -88,7 +90,11 @@ extension AgentCommand {
         let anthropicModels = Self.supportedAnthropicInputs.map(\.modelId)
         let googleModels = Self.supportedGoogleInputs.map(\.userFacingModelId)
         let miniMaxModels = Self.supportedMiniMaxInputs.map(\.modelId)
-        return (openAIModels + anthropicModels + googleModels + miniMaxModels + ["ollama/<model>", "lmstudio/<model>"])
+        return (openAIModels + anthropicModels + googleModels + miniMaxModels + [
+            "ollama/<model>",
+            "lmstudio/<model>",
+            "openrouter-provider/model",
+        ])
             .sorted()
             .joined(separator: ", ")
     }
@@ -107,6 +113,8 @@ extension AgentCommand {
             return configuration.getGeminiAPIKey()?.isEmpty == false
         case .minimax:
             return configuration.getMiniMaxAPIKey()?.isEmpty == false
+        case .openRouter:
+            return configuration.getOpenRouterAPIKey()?.isEmpty == false
         default:
             return false
         }
@@ -126,6 +134,8 @@ extension AgentCommand {
             "Ollama"
         case .lmstudio:
             "LM Studio"
+        case .openRouter:
+            "OpenRouter"
         default:
             "the selected provider"
         }
@@ -145,6 +155,8 @@ extension AgentCommand {
             "OLLAMA_BASE_URL or PEEKABOO_OLLAMA_BASE_URL"
         case .lmstudio:
             "LM Studio local server URL"
+        case .openRouter:
+            "OPENROUTER_API_KEY"
         default:
             "provider API key"
         }

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/AI/AgentCommand.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/AI/AgentCommand.swift
@@ -337,6 +337,7 @@ extension AgentCommand {
         let hasAnthropic = configuration.getAnthropicAPIKey()?.isEmpty == false
         let hasGemini = configuration.getGeminiAPIKey()?.isEmpty == false
         let hasMiniMax = configuration.getMiniMaxAPIKey()?.isEmpty == false
+        let hasOpenRouter = configuration.getOpenRouterAPIKey()?.isEmpty == false
         let hasLocalProvider = configuration.getAIProviders()
             .split(separator: ",")
             .contains { entry in
@@ -347,13 +348,13 @@ extension AgentCommand {
                     .lowercased()
                 return provider == "ollama" || provider == "lmstudio" || provider == "lm-studio"
             }
-        return hasOpenAI || hasAnthropic || hasGemini || hasMiniMax || hasLocalProvider
+        return hasOpenAI || hasAnthropic || hasGemini || hasMiniMax || hasOpenRouter || hasLocalProvider
     }
 
     func emitAgentUnavailableMessage() {
         if self.jsonOutput {
             let message = "Agent service not available. Please set OPENAI_API_KEY, ANTHROPIC_API_KEY, " +
-                "GEMINI_API_KEY, MINIMAX_API_KEY, or configure ollama/<model> or lmstudio/<model>."
+                "GEMINI_API_KEY, MINIMAX_API_KEY, OPENROUTER_API_KEY, or configure ollama/<model> or lmstudio/<model>."
             let error = [
                 "success": false,
                 "error": message
@@ -367,7 +368,7 @@ extension AgentCommand {
         } else {
             let errorPrefix = [
                 "\(TerminalColor.red)Error: Agent service not available.",
-                " Please set OPENAI_API_KEY, ANTHROPIC_API_KEY, GEMINI_API_KEY, MINIMAX_API_KEY,",
+                " Please set OPENAI_API_KEY, ANTHROPIC_API_KEY, GEMINI_API_KEY, MINIMAX_API_KEY, OPENROUTER_API_KEY,",
                 " or configure ollama/<model> or lmstudio/<model>."
             ].joined()
             let errorMessageLine = [errorPrefix, "\(TerminalColor.reset)"].joined()

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Core/ConfigCommand+AddLogin.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Core/ConfigCommand+AddLogin.swift
@@ -11,7 +11,7 @@ extension ConfigCommand {
             abstract: "Add and validate a provider credential (API key)"
         )
 
-        @Argument(help: "Provider id (openai|anthropic|grok|xai|gemini)")
+        @Argument(help: "Provider id (openai|anthropic|grok|xai|gemini|openrouter)")
         var provider: String
 
         @Argument(help: "Secret value (API key)")
@@ -25,7 +25,10 @@ extension ConfigCommand {
         mutating func run(using runtime: CommandRuntime) async throws {
             self.prepare(using: runtime)
             guard let pid = TKProviderId.normalize(self.provider) else {
-                self.output.error(code: "INVALID_PROVIDER", message: "Supported: openai, anthropic, grok, xai, gemini")
+                self.output.error(
+                    code: "INVALID_PROVIDER",
+                    message: "Supported: openai, anthropic, grok, xai, gemini, openrouter"
+                )
                 throw ExitCode.failure
             }
 

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Core/ConfigCommand+Bindings.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Core/ConfigCommand+Bindings.swift
@@ -25,6 +25,17 @@ extension ConfigCommand.ShowCommand: CommanderBindableCommand {
 }
 
 @available(macOS 14.0, *)
+extension ConfigCommand.StatusCommand: AsyncRuntimeCommand {}
+@MainActor
+extension ConfigCommand.StatusCommand: CommanderBindableCommand {
+    mutating func applyCommanderValues(_ values: CommanderBindableValues) throws {
+        if let timeout = values.singleOption("timeout"), let seconds = Double(timeout) {
+            self.timeoutSeconds = seconds
+        }
+    }
+}
+
+@available(macOS 14.0, *)
 extension ConfigCommand.EditCommand: AsyncRuntimeCommand {}
 @MainActor
 extension ConfigCommand.EditCommand: CommanderBindableCommand {

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Core/ConfigCommand+InitShowEdit.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Core/ConfigCommand+InitShowEdit.swift
@@ -205,6 +205,24 @@ extension ConfigCommand {
         }
     }
 
+    /// Display configured provider credential status.
+    struct StatusCommand: ConfigRuntimeCommand {
+        static let commandDescription = CommandDescription(
+            commandName: "status",
+            abstract: "Display provider credential status"
+        )
+
+        @Option(name: .long, help: "Validation timeout in seconds (default 30)")
+        var timeoutSeconds: Double = 30
+        @RuntimeStorage var runtime: CommandRuntime?
+
+        mutating func run(using runtime: CommandRuntime) async throws {
+            self.prepare(using: runtime)
+            let reporter = ProviderStatusReporter(timeoutSeconds: self.timeoutSeconds)
+            await reporter.printSummary()
+        }
+    }
+
     /// Open configuration in an editor.
     struct EditCommand: ConfigRuntimeCommand {
         static let commandDescription = CommandDescription(

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Core/ConfigCommand+Status.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Core/ConfigCommand+Status.swift
@@ -12,7 +12,7 @@ struct ProviderStatusReporter {
 
     func printSummary() async {
         print("Providers:")
-        for pid in [TKProviderId.openai, .anthropic, .grok, .gemini] {
+        for pid in [TKProviderId.openai, .anthropic, .grok, .gemini, .openrouter] {
             let status = await self.status(for: pid)
             print("  \(pid.displayName): \(status)")
         }
@@ -63,6 +63,8 @@ struct ProviderStatusReporter {
             }
         case .gemini:
             if let v = env["GEMINI_API_KEY"], !v.isEmpty { return .env("GEMINI_API_KEY", v) }
+        case .openrouter:
+            if let v = env["OPENROUTER_API_KEY"], !v.isEmpty { return .env("OPENROUTER_API_KEY", v) }
         }
 
         let creds = TKAuthManager.shared
@@ -83,6 +85,10 @@ struct ProviderStatusReporter {
             }
         case .gemini:
             if let v = creds.credentialValue(for: "GEMINI_API_KEY") { return .credentials("GEMINI_API_KEY", v) }
+        case .openrouter:
+            if let v = creds.credentialValue(for: "OPENROUTER_API_KEY") {
+                return .credentials("OPENROUTER_API_KEY", v)
+            }
         }
 
         return .missing("missing")

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Core/ConfigCommand.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Core/ConfigCommand.swift
@@ -35,6 +35,7 @@ struct ConfigCommand: ParsableCommand {
         subcommands: [
             InitCommand.self,
             ShowCommand.self,
+            StatusCommand.self,
             EditCommand.self,
             ValidateCommand.self,
             AddCommand.self,

--- a/Apps/CLI/Tests/CoreCLITests/AgentCommandModelParsingTests.swift
+++ b/Apps/CLI/Tests/CoreCLITests/AgentCommandModelParsingTests.swift
@@ -78,6 +78,13 @@ struct AgentCommandTests {
     }
 
     @Test
+    func `OpenRouter provider model IDs are accepted`() throws {
+        let command = try AgentCommand.parse([])
+
+        #expect(command.parseModelString("xiaomi/mimo-v2.5-pro") == .openRouter(modelId: "xiaomi/mimo-v2.5-pro"))
+    }
+
+    @Test
     func `Model string normalization trims whitespace`() throws {
         let command = try AgentCommand.parse([])
 
@@ -124,6 +131,7 @@ struct ModelSelectionIntegrationTests {
             ("gemini-3.1-pro-preview", .google(.gemini31ProPreview)),
             ("MiniMax-M2.7", .minimax(.m27)),
             ("ollama/llama3.3", .ollama(.llama33)),
+            ("xiaomi/mimo-v2.5-pro", .openRouter(modelId: "xiaomi/mimo-v2.5-pro")),
         ]
 
         for (input, expected) in testCases {

--- a/Apps/CLI/Tests/CoreCLITests/CommanderBinderCommandBindingAppTests.swift
+++ b/Apps/CLI/Tests/CoreCLITests/CommanderBinderCommandBindingAppTests.swift
@@ -203,6 +203,16 @@ struct CommanderBinderAppConfigTests {
     }
 
     @Test
+    func `Config status binding`() throws {
+        let parsed = ParsedValues(positional: [], options: ["timeout": ["5"]], flags: [])
+        let command = try CommanderCLIBinder.instantiateCommand(
+            ofType: ConfigCommand.StatusCommand.self,
+            parsedValues: parsed
+        )
+        #expect(command.timeoutSeconds == 5)
+    }
+
+    @Test
     func `Config set credential binding`() throws {
         let parsed = ParsedValues(positional: ["OPENAI_API_KEY", "sk-123"], options: [:], flags: [])
         let command = try CommanderCLIBinder.instantiateCommand(

--- a/Core/PeekabooCore/Sources/PeekabooAutomation/Configuration/ConfigurationManager+Accessors.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAutomation/Configuration/ConfigurationManager+Accessors.swift
@@ -113,6 +113,19 @@ extension ConfigurationManager {
         return nil
     }
 
+    /// Get OpenRouter API key with proper precedence.
+    public func getOpenRouterAPIKey() -> String? {
+        if let envValue = self.environmentValue(for: "OPENROUTER_API_KEY") {
+            return envValue
+        }
+
+        if let credValue = credentials["OPENROUTER_API_KEY"] {
+            return credValue
+        }
+
+        return nil
+    }
+
     /// Apply Peekaboo-managed provider keys to Tachikoma.
     public func applyAIProviderKeys(to configuration: TachikomaConfiguration = .current) {
         if let key = self.getOpenAIAPIKey(), !key.isEmpty {
@@ -126,6 +139,9 @@ extension ConfigurationManager {
         }
         if let key = self.getMiniMaxAPIKey(), !key.isEmpty {
             configuration.setAPIKey(key, for: .minimax)
+        }
+        if let key = self.getOpenRouterAPIKey(), !key.isEmpty {
+            configuration.setAPIKey(key, for: .openrouter)
         }
         let ollamaBaseURL = self.getOllamaBaseURL()
         if !ollamaBaseURL.isEmpty {

--- a/howto.md
+++ b/howto.md
@@ -1,0 +1,125 @@
+# OpenRouter Support How-To
+
+This change makes OpenRouter usable as a first-class Peekaboo/Tachikoma provider and lets the agent run OpenRouter model IDs such as `xiaomi/mimo-v2.5-pro`.
+
+## What changed
+
+- Added `openrouter` to Tachikoma provider credentials.
+- Added `OPENROUTER_API_KEY` loading from environment and `~/.peekaboo/credentials`.
+- Added OpenRouter credential validation via `https://openrouter.ai/api/v1/models`.
+- Added OpenRouter default base URL: `https://openrouter.ai/api/v1`.
+- Updated OpenRouter attribution header to `X-OpenRouter-Title`.
+- Allowed slash-style OpenRouter model IDs in `LanguageModel.parse`, for example `xiaomi/mimo-v2.5-pro`.
+- Updated Peekaboo agent model validation to accept OpenRouter models.
+- Updated Peekaboo agent preflight checks to treat `OPENROUTER_API_KEY` as a configured AI provider.
+- Added `peekaboo config status` to show stored provider credential status.
+
+## Configure OpenRouter
+
+Set and validate the key:
+
+```bash
+export OPENROUTER_API_KEY="sk-or-v1-..."
+peekaboo config add openrouter "$OPENROUTER_API_KEY"
+```
+
+Check provider status:
+
+```bash
+peekaboo config status
+```
+
+Expected output includes:
+
+```text
+OpenRouter: ready (credentials OPENROUTER_API_KEY, validated)
+```
+
+## Use an OpenRouter model with the agent
+
+Example using Xiaomi MiMo through OpenRouter:
+
+```bash
+peekaboo agent "Take a screenshot of the open Figma app and save it to /tmp/figma-openrouter-agent.png" \
+  --model xiaomi/mimo-v2.5-pro \
+  --max-steps 4 \
+  --simple \
+  --no-color
+```
+
+For direct screenshot capture without an AI model:
+
+```bash
+peekaboo image --app Figma --path /tmp/figma-openrouter-agent.png
+```
+
+If screen capture fails, grant macOS permissions:
+
+```bash
+peekaboo permissions grant
+peekaboo permissions status
+```
+
+Required permissions:
+
+```text
+Screen Recording: Granted
+Accessibility: Granted
+```
+
+## Build and reinstall locally
+
+Build the CLI:
+
+```bash
+pnpm run build:cli
+```
+
+Build release:
+
+```bash
+pnpm run build:cli:release
+```
+
+If using the Homebrew-installed binary during local development, replace the active binary:
+
+```bash
+cp Apps/CLI/.build/release/peekaboo /opt/homebrew/Cellar/peekaboo/3.2.1/bin/peekaboo
+```
+
+Verify:
+
+```bash
+peekaboo --version
+peekaboo config status
+```
+
+## Tests run
+
+Focused Tachikoma tests:
+
+```bash
+swift test --filter 'LanguageModelCoverageTests'
+```
+
+Focused CLI tests:
+
+```bash
+swift test --filter 'AgentCommandTests|ModelSelectionIntegrationTests'
+swift test --filter 'CommanderBinderAppConfigTests'
+```
+
+CLI build:
+
+```bash
+pnpm run build:cli
+pnpm run build:cli:release
+```
+
+## LinkedIn draft
+
+I added OpenRouter support to Peekaboo so the desktop automation agent can run models by provider/model ID, including `xiaomi/mimo-v2.5-pro`.
+
+The update adds credential storage and validation for `OPENROUTER_API_KEY`, OpenRouter model parsing in Tachikoma, and CLI agent support for slash-style OpenRouter model IDs. I used it to drive a Peekaboo agent task against an open Figma window and validate the end-to-end path from model selection to desktop automation.
+
+Small change, useful outcome: Peekaboo can now use a much wider model surface without hardcoding every provider model into the CLI.


### PR DESCRIPTION
# OpenRouter Support How-To

This change makes OpenRouter usable as a first-class Peekaboo/Tachikoma provider and lets the agent run OpenRouter model IDs such as `xiaomi/mimo-v2.5-pro`.

## What changed

- Added `openrouter` to Tachikoma provider credentials.
- Added `OPENROUTER_API_KEY` loading from environment and `~/.peekaboo/credentials`.
- Added OpenRouter credential validation via `https://openrouter.ai/api/v1/models`.
- Added OpenRouter default base URL: `https://openrouter.ai/api/v1`.
- Updated OpenRouter attribution header to `X-OpenRouter-Title`.
- Allowed slash-style OpenRouter model IDs in `LanguageModel.parse`, for example `xiaomi/mimo-v2.5-pro`.
- Updated Peekaboo agent model validation to accept OpenRouter models.
- Updated Peekaboo agent preflight checks to treat `OPENROUTER_API_KEY` as a configured AI provider.
- Added `peekaboo config status` to show stored provider credential status.

## Configure OpenRouter

Set and validate the key:

```bash
export OPENROUTER_API_KEY="sk-or-v1-..."
peekaboo config add openrouter "$OPENROUTER_API_KEY"
```

Check provider status:

```bash
peekaboo config status
```

Expected output includes:

```text
OpenRouter: ready (credentials OPENROUTER_API_KEY, validated)
```

## Use an OpenRouter model with the agent

Example using Xiaomi MiMo through OpenRouter:

```bash
peekaboo agent "Take a screenshot of the open Figma app and save it to /tmp/figma-openrouter-agent.png" \
  --model xiaomi/mimo-v2.5-pro \
  --max-steps 4 \
  --simple \
  --no-color
```

For direct screenshot capture without an AI model:

```bash
peekaboo image --app Figma --path /tmp/figma-openrouter-agent.png
```

If screen capture fails, grant macOS permissions:

```bash
peekaboo permissions grant
peekaboo permissions status
```

Required permissions:

```text
Screen Recording: Granted
Accessibility: Granted
```

## Build and reinstall locally

Build the CLI:

```bash
pnpm run build:cli
```

Build release:

```bash
pnpm run build:cli:release
```

If using the Homebrew-installed binary during local development, replace the active binary:

```bash
cp Apps/CLI/.build/release/peekaboo /opt/homebrew/Cellar/peekaboo/3.2.1/bin/peekaboo
```

Verify:

```bash
peekaboo --version
peekaboo config status
```

## Tests run

Focused Tachikoma tests:

```bash
swift test --filter 'LanguageModelCoverageTests'
```

Focused CLI tests:

```bash
swift test --filter 'AgentCommandTests|ModelSelectionIntegrationTests'
swift test --filter 'CommanderBinderAppConfigTests'
```

CLI build:

```bash
pnpm run build:cli
pnpm run build:cli:release
```

## LinkedIn draft

I added OpenRouter support to Peekaboo so the desktop automation agent can run models by provider/model ID, including `xiaomi/mimo-v2.5-pro`.

The update adds credential storage and validation for `OPENROUTER_API_KEY`, OpenRouter model parsing in Tachikoma, and CLI agent support for slash-style OpenRouter model IDs. I used it to drive a Peekaboo agent task against an open Figma window and validate the end-to-end path from model selection to desktop automation.

Small change, useful outcome: Peekaboo can now use a much wider model surface without hardcoding every provider model into the CLI.
