### PR TITLE
Improve Peekaboo CLI capture ergonomics

### DIFF
--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Core/ImageCommand+CaptureFiles.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Core/ImageCommand+CaptureFiles.swift
@@ -17,7 +17,9 @@ extension ImageCommand {
             ),
             observation: ImageObservationDiagnostics(
                 timings: observation.timings,
-                diagnostics: observation.diagnostics
+                diagnostics: observation.diagnostics,
+                capture: observation.capture,
+                rawImagePath: observation.files.rawScreenshotPath
             )
         )
     }

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Core/ImageCommand+Output.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Core/ImageCommand+Output.swift
@@ -1,3 +1,4 @@
+import AppKit
 import Commander
 import Foundation
 import PeekabooCore
@@ -19,12 +20,127 @@ struct ImageObservationDiagnostics: Codable {
     let warnings: [String]
     let state_snapshot: SeeDesktopStateSnapshotSummary?
     let target: SeeObservationTargetDiagnostics?
+    let coordinates: ImageCoordinateDiagnostics?
 
-    init(timings: ObservationTimings, diagnostics: DesktopObservationDiagnostics) {
+    init(
+        timings: ObservationTimings,
+        diagnostics: DesktopObservationDiagnostics,
+        capture: CaptureResult? = nil,
+        rawImagePath: String? = nil
+    ) {
         self.spans = timings.spans.map(SeeObservationSpan.init)
-        self.warnings = diagnostics.warnings
+        self.warnings = diagnostics.warnings + ImageBlankCaptureDiagnostics.warnings(
+            rawImagePath: rawImagePath,
+            capture: capture
+        )
         self.state_snapshot = diagnostics.stateSnapshot.map(SeeDesktopStateSnapshotSummary.init)
         self.target = diagnostics.target.map(SeeObservationTargetDiagnostics.init)
+        self.coordinates = capture.map(ImageCoordinateDiagnostics.init)
+    }
+}
+
+struct ImageCoordinateDiagnostics: Codable {
+    let coordinate_space: String
+    let logical_bounds: CGRect?
+    let image_size_pixels: ImageSizeDiagnostics
+    let scale_factor: CGFloat?
+    let screen_index: Int?
+    let screen_name: String?
+
+    init(capture: CaptureResult) {
+        let metadata = capture.metadata
+        self.coordinate_space = "global_display_points"
+        self.logical_bounds = metadata.windowInfo?.bounds ?? metadata.displayInfo?.bounds
+        self.image_size_pixels = ImageSizeDiagnostics(metadata.size)
+        self.scale_factor = metadata.diagnostics?.outputScale
+            ?? metadata.displayInfo?.scaleFactor
+            ?? Self.inferredScale(imageSize: metadata.size, bounds: self.logical_bounds)
+        self.screen_index = metadata.windowInfo?.screenIndex ?? metadata.displayInfo?.index
+        self.screen_name = metadata.windowInfo?.screenName ?? metadata.displayInfo?.name
+    }
+
+    private static func inferredScale(imageSize: CGSize, bounds: CGRect?) -> CGFloat? {
+        guard let bounds, bounds.width > .zero else {
+            return nil
+        }
+        return imageSize.width / bounds.width
+    }
+}
+
+struct ImageSizeDiagnostics: Codable {
+    let width: Double
+    let height: Double
+
+    init(_ size: CGSize) {
+        self.width = size.width
+        self.height = size.height
+    }
+}
+
+enum ImageBlankCaptureDiagnostics {
+    static func warnings(rawImagePath: String?, capture: CaptureResult?) -> [String] {
+        guard let rawImagePath,
+              let capture,
+              capture.metadata.mode == .window,
+              let data = try? Data(contentsOf: URL(fileURLWithPath: rawImagePath)),
+              let bitmap = NSBitmapImageRep(data: data)
+        else {
+            return []
+        }
+
+        return self.blankWarning(bitmap: bitmap).map { [$0] } ?? []
+    }
+
+    private static func blankWarning(bitmap: NSBitmapImageRep) -> String? {
+        let width = bitmap.pixelsWide
+        let height = bitmap.pixelsHigh
+        guard width > 1, height > 1 else {
+            return nil
+        }
+
+        let sampleCount = min(width, 20) * min(height, 20)
+        guard sampleCount > 0 else { return nil }
+
+        var alphaSum = 0.0
+        var luminanceSum = 0.0
+        var luminanceSquaredSum = 0.0
+
+        let xStep = max(1, width / min(width, 20))
+        let yStep = max(1, height / min(height, 20))
+        var actualSamples = 0
+
+        for y in stride(from: 0, to: height, by: yStep) {
+            for x in stride(from: 0, to: width, by: xStep) {
+                guard let color = bitmap.colorAt(x: x, y: y)?.usingColorSpace(.deviceRGB) else {
+                    continue
+                }
+                let alpha = Double(color.alphaComponent)
+                let luminance = Double(0.2126 * color.redComponent + 0.7152 * color.greenComponent + 0.0722 * color
+                    .blueComponent)
+                alphaSum += alpha
+                luminanceSum += luminance
+                luminanceSquaredSum += luminance * luminance
+                actualSamples += 1
+            }
+        }
+
+        guard actualSamples > 0 else { return nil }
+
+        let alphaMean = alphaSum / Double(actualSamples)
+        if alphaMean < 0.01 {
+            return "Captured window image appears transparent; target may be hidden or non-renderable."
+        }
+
+        let luminanceMean = luminanceSum / Double(actualSamples)
+        let variance = max(0, luminanceSquaredSum / Double(actualSamples) - luminanceMean * luminanceMean)
+        if variance < 0.0001, luminanceMean < 0.02 {
+            return "Captured window image appears solid black; target may be occluded, transparent, or non-renderable."
+        }
+        if variance < 0.0001, luminanceMean > 0.98 {
+            return "Captured window image appears blank white; target may be empty or non-renderable."
+        }
+
+        return nil
     }
 }
 
@@ -82,7 +198,10 @@ extension ImageCommand {
         if self.jsonOutput {
             outputSuccessCodable(data: output, logger: self.outputLogger)
         } else {
-            captures.map(\.file).forEach { print("📸 \(self.describeSavedFile($0))") }
+            for capture in captures {
+                print("📸 \(self.describeSavedFile(capture.file))")
+                self.printWarnings(capture.observation.warnings)
+            }
         }
     }
 
@@ -95,7 +214,10 @@ extension ImageCommand {
         if self.jsonOutput {
             outputSuccessCodable(data: output, logger: self.outputLogger)
         } else {
-            captures.map(\.file).forEach { print("📸 \(self.describeSavedFile($0))") }
+            for capture in captures {
+                print("📸 \(self.describeSavedFile(capture.file))")
+                self.printWarnings(capture.observation.warnings)
+            }
             print("\n🤖 Analysis (\(analysis.provider)) - \(analysis.model):")
             print(analysis.text)
         }
@@ -116,6 +238,10 @@ extension ImageCommand {
         }
         segments.append("→ \(file.path)")
         return segments.joined(separator: " ")
+    }
+
+    private func printWarnings(_ warnings: [String]) {
+        warnings.forEach { print("⚠️  \($0)") }
     }
 }
 

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Interaction/ClickCommand+CommanderMetadata.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Interaction/ClickCommand+CommanderMetadata.swift
@@ -48,7 +48,7 @@ extension ClickCommand: CommanderSignatureProviding {
             options: [
                 .commandOption(
                     "snapshot",
-                    help: "Snapshot ID (uses latest if not specified)",
+                    help: "Snapshot ID, or 'latest' (uses latest if not specified)",
                     long: "snapshot"
                 ),
                 .commandOption(

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Interaction/ClickCommand.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Interaction/ClickCommand.swift
@@ -11,7 +11,7 @@ struct ClickCommand: ErrorHandlingCommand, OutputFormattable, RuntimeOptionsConf
     @Argument(help: "Element text or query to click")
     var query: String?
 
-    @Option(help: "Snapshot ID (uses latest if not specified)")
+    @Option(help: "Snapshot ID, or 'latest' (uses latest if not specified)")
     var snapshot: String?
 
     @Option(help: "Element ID to click (e.g., B1, T2)")

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Interaction/DragCommand+CommanderMetadata.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Interaction/DragCommand+CommanderMetadata.swift
@@ -31,7 +31,7 @@ extension DragCommand: CommanderSignatureProviding {
                 ),
                 .commandOption(
                     "snapshot",
-                    help: "Snapshot ID for element resolution",
+                    help: "Snapshot ID for element resolution, or 'latest'",
                     long: "snapshot"
                 ),
                 .commandOption(

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Interaction/DragCommand.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Interaction/DragCommand.swift
@@ -25,7 +25,7 @@ struct DragCommand: ErrorHandlingCommand, OutputFormattable {
     @Option(help: "Target application (e.g., 'Trash', 'Finder')")
     var toApp: String?
 
-    @Option(help: "Snapshot ID for element resolution")
+    @Option(help: "Snapshot ID for element resolution, or 'latest'")
     var snapshot: String?
 
     @Option(help: "Duration of drag in milliseconds (default: 500)")

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Interaction/HotkeyCommand+CommanderMetadata.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Interaction/HotkeyCommand+CommanderMetadata.swift
@@ -23,7 +23,7 @@ extension HotkeyCommand: CommanderSignatureProviding {
                 ),
                 .commandOption(
                     "snapshot",
-                    help: "Snapshot ID (uses latest if not specified)",
+                    help: "Snapshot ID, or 'latest' (uses latest if not specified)",
                     long: "snapshot"
                 ),
             ],

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Interaction/HotkeyCommand.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Interaction/HotkeyCommand.swift
@@ -18,7 +18,7 @@ struct HotkeyCommand: ErrorHandlingCommand, OutputFormattable {
     @Option(help: "Delay between key press and release in milliseconds")
     var holdDuration: Int = 50
 
-    @Option(help: "Snapshot ID (uses latest if not specified)")
+    @Option(help: "Snapshot ID, or 'latest' (uses latest if not specified)")
     var snapshot: String?
 
     @Flag(name: .customLong("focus-background"), help: "Send the hotkey to the target process without focusing it")

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Interaction/MoveCommand+CommanderMetadata.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Interaction/MoveCommand+CommanderMetadata.swift
@@ -109,7 +109,7 @@ extension MoveCommand: CommanderSignatureProviding {
                 ),
                 .commandOption(
                     "snapshot",
-                    help: "Snapshot ID for element resolution",
+                    help: "Snapshot ID for element resolution, or 'latest'",
                     long: "snapshot"
                 ),
             ],

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Interaction/MoveCommand.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Interaction/MoveCommand.swift
@@ -41,7 +41,7 @@ struct MoveCommand: ErrorHandlingCommand, OutputFormattable {
     @Option(help: "Movement profile: linear (default) or human.")
     var profile: String?
 
-    @Option(help: "Snapshot ID for element resolution")
+    @Option(help: "Snapshot ID for element resolution, or 'latest'")
     var snapshot: String?
     @RuntimeStorage private var runtime: CommandRuntime?
 

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Interaction/PerformActionCommand.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Interaction/PerformActionCommand.swift
@@ -12,7 +12,7 @@ struct PerformActionCommand: ErrorHandlingCommand, OutputFormattable, RuntimeOpt
     @Option(help: "Accessibility action name, e.g. AXPress, AXShowMenu, AXIncrement")
     var action: String?
 
-    @Option(help: "Snapshot ID (uses latest if not specified)")
+    @Option(help: "Snapshot ID, or 'latest' (uses latest if not specified)")
     var snapshot: String?
 
     @RuntimeStorage private var runtime: CommandRuntime?
@@ -145,7 +145,11 @@ extension PerformActionCommand: CommanderSignatureProviding {
                     help: "Accessibility action name, e.g. AXPress, AXShowMenu, AXIncrement",
                     long: "action"
                 ),
-                .commandOption("snapshot", help: "Snapshot ID (uses latest if not specified)", long: "snapshot"),
+                .commandOption(
+                    "snapshot",
+                    help: "Snapshot ID, or 'latest' (uses latest if not specified)",
+                    long: "snapshot"
+                ),
             ]
         )
     }

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Interaction/PressCommand+CommanderMetadata.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Interaction/PressCommand+CommanderMetadata.swift
@@ -33,7 +33,7 @@ extension PressCommand: CommanderSignatureProviding {
                 ),
                 .commandOption(
                     "snapshot",
-                    help: "Snapshot ID (uses latest if not specified)",
+                    help: "Snapshot ID, or 'latest' (uses latest if not specified)",
                     long: "snapshot"
                 ),
             ],

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Interaction/PressCommand.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Interaction/PressCommand.swift
@@ -21,7 +21,7 @@ struct PressCommand: ErrorHandlingCommand, OutputFormattable, RuntimeOptionsConf
     @Option(help: "Hold duration for each key in milliseconds")
     var hold: Int = 50
 
-    @Option(help: "Snapshot ID (uses latest if not specified)")
+    @Option(help: "Snapshot ID, or 'latest' (uses latest if not specified)")
     var snapshot: String?
 
     @OptionGroup var focusOptions: FocusCommandOptions

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Interaction/ScrollCommand+CommanderMetadata.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Interaction/ScrollCommand+CommanderMetadata.swift
@@ -21,7 +21,7 @@ extension ScrollCommand: CommanderSignatureProviding {
                 ),
                 .commandOption(
                     "snapshot",
-                    help: "Snapshot ID (uses latest if not specified)",
+                    help: "Snapshot ID, or 'latest' (uses latest if not specified)",
                     long: "snapshot"
                 ),
                 .commandOption(

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Interaction/ScrollCommand.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Interaction/ScrollCommand.swift
@@ -18,7 +18,7 @@ struct ScrollCommand: ErrorHandlingCommand, OutputFormattable, RuntimeOptionsCon
     @Option(help: "Element ID to scroll on (from 'see' command)")
     var on: String?
 
-    @Option(help: "Snapshot ID (uses latest if not specified)")
+    @Option(help: "Snapshot ID, or 'latest' (uses latest if not specified)")
     var snapshot: String?
 
     @Option(help: "Delay between scroll ticks in milliseconds")

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Interaction/SetValueCommand.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Interaction/SetValueCommand.swift
@@ -12,7 +12,7 @@ struct SetValueCommand: ErrorHandlingCommand, OutputFormattable, RuntimeOptionsC
     @Option(help: "Element ID or query to set")
     var on: String?
 
-    @Option(help: "Snapshot ID (uses latest if not specified)")
+    @Option(help: "Snapshot ID, or 'latest' (uses latest if not specified)")
     var snapshot: String?
 
     @RuntimeStorage private var runtime: CommandRuntime?
@@ -147,7 +147,11 @@ extension SetValueCommand: CommanderSignatureProviding {
             options: [
                 .commandOption("value", help: "Value to set (alternative to positional argument)", long: "value"),
                 .commandOption("on", help: "Element ID or query to set", long: "on"),
-                .commandOption("snapshot", help: "Snapshot ID (uses latest if not specified)", long: "snapshot"),
+                .commandOption(
+                    "snapshot",
+                    help: "Snapshot ID, or 'latest' (uses latest if not specified)",
+                    long: "snapshot"
+                ),
             ]
         )
     }

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Interaction/SwipeCommand+CommanderMetadata.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Interaction/SwipeCommand+CommanderMetadata.swift
@@ -26,7 +26,7 @@ extension SwipeCommand: CommanderSignatureProviding {
                 ),
                 .commandOption(
                     "snapshot",
-                    help: "Snapshot ID (uses latest if not specified)",
+                    help: "Snapshot ID, or 'latest' (uses latest if not specified)",
                     long: "snapshot"
                 ),
                 .commandOption(

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Interaction/SwipeCommand.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Interaction/SwipeCommand.swift
@@ -20,7 +20,7 @@ struct SwipeCommand: ErrorHandlingCommand, OutputFormattable, RuntimeOptionsConf
     @Option(help: "Destination coordinates (x,y)")
     var toCoords: String?
 
-    @Option(help: "Snapshot ID (uses latest if not specified)")
+    @Option(help: "Snapshot ID, or 'latest' (uses latest if not specified)")
     var snapshot: String?
 
     @Option(help: "Duration of the swipe in milliseconds")

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Interaction/TypeCommand+CommanderMetadata.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Interaction/TypeCommand+CommanderMetadata.swift
@@ -18,7 +18,7 @@ extension TypeCommand: CommanderSignatureProviding {
                 ),
                 .commandOption(
                     "snapshot",
-                    help: "Snapshot ID (uses latest if not specified)",
+                    help: "Snapshot ID, or 'latest' (uses latest if not specified)",
                     long: "snapshot"
                 ),
                 .commandOption(

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Interaction/TypeCommand.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Interaction/TypeCommand.swift
@@ -13,7 +13,7 @@ struct TypeCommand: ErrorHandlingCommand, OutputFormattable, RuntimeOptionsConfi
     @Option(name: .customLong("text"), help: "Text to type (alternative to positional argument)")
     var textOption: String?
 
-    @Option(help: "Snapshot ID (uses latest if not specified)")
+    @Option(help: "Snapshot ID, or 'latest' (uses latest if not specified)")
     var snapshot: String?
 
     @Option(help: "Delay between keystrokes in milliseconds")

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Shared/InteractionObservationContext.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Shared/InteractionObservationContext.swift
@@ -52,7 +52,7 @@ struct InteractionObservationContext {
         fallbackToLatest: Bool,
         snapshots: any SnapshotManagerProtocol
     ) async -> InteractionObservationContext {
-        if let explicitSnapshotId = normalizedSnapshotId(rawSnapshot) {
+        if let explicitSnapshotId = normalizedSnapshotId(rawSnapshot), !isLatestAlias(explicitSnapshotId) {
             return InteractionObservationContext(
                 explicitSnapshotId: explicitSnapshotId,
                 snapshotId: explicitSnapshotId,
@@ -78,6 +78,15 @@ struct InteractionObservationContext {
     private static func normalizedSnapshotId(_ snapshotId: String?) -> String? {
         let trimmed = snapshotId?.trimmingCharacters(in: .whitespacesAndNewlines)
         return trimmed?.isEmpty == false ? trimmed : nil
+    }
+
+    private static func isLatestAlias(_ snapshotId: String) -> Bool {
+        switch snapshotId.lowercased() {
+        case "latest", "most-recent", "most_recent":
+            true
+        default:
+            false
+        }
     }
 }
 

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Shared/SnapshotValidation.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Shared/SnapshotValidation.swift
@@ -12,7 +12,7 @@ enum SnapshotValidation {
             throw PeekabooError.snapshotNotFound(
                 """
                 Snapshot '\(snapshotId)' was not found (or has no UI map). \
-                Run 'peekaboo see' again or omit --snapshot to use the most recent snapshot.
+                Run 'peekaboo see' again, omit --snapshot, or pass --snapshot latest.
                 """
             )
         }

--- a/Apps/CLI/Tests/CLIAutomationTests/ImageCommandDiagnosticsTests.swift
+++ b/Apps/CLI/Tests/CLIAutomationTests/ImageCommandDiagnosticsTests.swift
@@ -1,5 +1,7 @@
+import AppKit
 import CoreGraphics
 import Foundation
+import PeekabooCore
 import Testing
 @testable import PeekabooCLI
 
@@ -38,7 +40,91 @@ extension ImageCommandTests {
         #expect(response.data.observations.count == 1)
         #expect(response.data.observations[0].spans.contains { $0.name == "capture.screen" })
         #expect(response.data.observations[0].state_snapshot != nil)
+        let coordinates = try #require(response.data.observations[0].coordinates)
+        #expect(coordinates.coordinate_space == "global_display_points")
+        #expect(coordinates.image_size_pixels.width == 1200)
+        #expect(coordinates.image_size_pixels.height == 800)
+        #expect(coordinates.logical_bounds?.width == 1200)
+        #expect(coordinates.scale_factor == 1)
         try? FileManager.default.removeItem(atPath: path)
+    }
+
+    @Test(.tags(.imageCapture))
+    func `JSON output warns when captured window is solid black`() async throws {
+        let appName = "BlankApp"
+        let window = ServiceWindowInfo(
+            windowID: 42,
+            title: "Blank",
+            bounds: CGRect(x: 20, y: 30, width: 120, height: 80)
+        )
+        let appInfo = ServiceApplicationInfo(
+            processIdentifier: 4242,
+            bundleIdentifier: "dev.blank",
+            name: appName,
+            windowCount: 1
+        )
+        let metadata = CaptureMetadata(
+            size: CGSize(width: 120, height: 80),
+            mode: .window,
+            applicationInfo: appInfo,
+            windowInfo: window
+        )
+        let captureService = StubScreenCaptureService(permissionGranted: true)
+        captureService.captureWindowByIdHandler = { _, _ in
+            try CaptureResult(
+                imageData: Self.solidPNG(width: 120, height: 80, color: .black),
+                metadata: metadata
+            )
+        }
+
+        let services = TestServicesFactory.makePeekabooServices(
+            applications: StubApplicationService(applications: [appInfo], windowsByApp: [appName: [window]]),
+            windows: StubWindowService(windowsByApp: [appName: [window]]),
+            screenCapture: captureService
+        )
+        let path = Self.makeTempCapturePath("solid-black.png")
+
+        let result = try await InProcessCommandRunner.run(
+            [
+                "image",
+                "--app", appName,
+                "--capture-focus", "background",
+                "--path", path,
+                "--json",
+            ],
+            services: services
+        )
+
+        #expect(result.exitStatus == 0)
+        let response = try JSONDecoder().decode(
+            CodableJSONResponse<ImageCaptureResult>.self,
+            from: Data(result.combinedOutput.utf8)
+        )
+        #expect(response.data.observations[0].warnings.contains {
+            $0.contains("solid black")
+        })
+        try? FileManager.default.removeItem(atPath: path)
+    }
+
+    private static func solidPNG(width: Int, height: Int, color: NSColor) throws -> Data {
+        let bitmap = NSBitmapImageRep(
+            bitmapDataPlanes: nil,
+            pixelsWide: width,
+            pixelsHigh: height,
+            bitsPerSample: 8,
+            samplesPerPixel: 4,
+            hasAlpha: true,
+            isPlanar: false,
+            colorSpaceName: .deviceRGB,
+            bytesPerRow: 0,
+            bitsPerPixel: 0
+        )!
+        NSGraphicsContext.saveGraphicsState()
+        NSGraphicsContext.current = NSGraphicsContext(bitmapImageRep: bitmap)
+        color.setFill()
+        NSBezierPath(rect: CGRect(x: 0, y: 0, width: width, height: height)).fill()
+        NSGraphicsContext.restoreGraphicsState()
+        return try #require(bitmap.representation(using: .png, properties: [:]))
     }
 }
 #endif

--- a/Apps/CLI/Tests/CoreCLITests/InteractionObservationContextTests.swift
+++ b/Apps/CLI/Tests/CoreCLITests/InteractionObservationContextTests.swift
@@ -47,6 +47,38 @@ struct InteractionObservationContextTests {
     }
 
     @Test
+    func `Explicit latest alias resolves to most recent snapshot`() async throws {
+        let snapshots = CoreSnapshotManagerStub()
+        let latest = try await snapshots.createSnapshot(id: "fresh-snapshot")
+
+        let context = await InteractionObservationContext.resolve(
+            explicitSnapshot: " latest ",
+            fallbackToLatest: true,
+            snapshots: snapshots
+        )
+
+        #expect(context.explicitSnapshotId == nil)
+        #expect(context.snapshotId == latest)
+        #expect(context.source == .latest)
+    }
+
+    @Test
+    func `Explicit latest alias does not force fallback when disabled`() async throws {
+        let snapshots = CoreSnapshotManagerStub()
+        _ = try await snapshots.createSnapshot(id: "fresh-snapshot")
+
+        let context = await InteractionObservationContext.resolve(
+            explicitSnapshot: "most-recent",
+            fallbackToLatest: false,
+            snapshots: snapshots
+        )
+
+        #expect(context.explicitSnapshotId == nil)
+        #expect(context.snapshotId == nil)
+        #expect(context.source == .none)
+    }
+
+    @Test
     func `Focus snapshot is skipped for latest snapshot with explicit target`() async throws {
         let snapshots = CoreSnapshotManagerStub()
         let latest = try await snapshots.createSnapshot()

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [3.2.3] - Unreleased
 
+### Added
+- `peekaboo image --json` now reports capture coordinate diagnostics and warns when window captures look blank or solid.
+
+### Fixed
+- Interaction commands now accept `--snapshot latest` explicitly and window/app capture failures list rejected capture candidates.
+
 ## [3.2.2] - 2026-05-22
 
 ### Added

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Observation/ObservationTargetResolver+WindowSelection.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Observation/ObservationTargetResolver+WindowSelection.swift
@@ -60,6 +60,24 @@ extension ObservationTargetResolver {
         self.filteredWindows(from: windows, mode: .capture)
     }
 
+    public nonisolated static func captureCandidateSummary(
+        from windows: [ServiceWindowInfo],
+        limit: Int = 5) -> String
+    {
+        guard !windows.isEmpty else {
+            return "no windows returned"
+        }
+
+        return windows.prefix(limit).map { window in
+            let title = window.title.trimmingCharacters(in: .whitespacesAndNewlines)
+            let label = title.isEmpty ? "<untitled>" : title
+            let reason = WindowFiltering.disqualificationReason(for: window, mode: .capture) ?? "capture candidate"
+            let size = "\(Int(window.bounds.width))x\(Int(window.bounds.height))"
+            return "#\(window.index) id=\(window.windowID) '\(label)' \(size) " +
+                "alpha=\(Self.format(window.alpha)) reason=\(reason)"
+        }.joined(separator: "; ")
+    }
+
     public nonisolated static func filteredWindows(
         from windows: [ServiceWindowInfo],
         mode: WindowFiltering.Mode) -> [ServiceWindowInfo]
@@ -97,6 +115,10 @@ extension ObservationTargetResolver {
         score += max(0, 600 - Double(window.index) * 40)
 
         return score
+    }
+
+    private nonisolated static func format(_ value: CGFloat) -> String {
+        String(format: "%.2f", Double(value))
     }
 
     private nonisolated static func deduplicate(_ windows: [ServiceWindowInfo]) -> [ServiceWindowInfo] {

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Observation/ObservationTargetResolver.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Observation/ObservationTargetResolver.swift
@@ -110,7 +110,9 @@ public final class ObservationTargetResolver: ObservationTargetResolving {
         let windows = try await self.applications.listWindows(for: lookupIdentifier, timeout: 2).data.windows
         let selectedWindow = try self.selectWindow(from: windows, selection: selection)
         if selection == .automatic, selectedWindow == nil, !windows.isEmpty {
-            throw DesktopObservationError.targetNotFound("shareable window for \(app.name)")
+            throw DesktopObservationError.targetNotFound(
+                "shareable window for \(app.name). Candidates: "
+                    + Self.captureCandidateSummary(from: windows))
         }
         let context = WindowContext(
             applicationName: app.name,

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Utilities/WindowFiltering.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Utilities/WindowFiltering.swift
@@ -7,7 +7,7 @@ public enum WindowFiltering {
         public let minHeight: CGFloat
         public let minAlpha: CGFloat
 
-        public static let `default` = Thresholds(minWidth: 120, minHeight: 90, minAlpha: 0.01)
+        public static let `default` = Thresholds(minWidth: 80, minHeight: 40, minAlpha: 0.01)
     }
 
     public enum Mode {

--- a/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/ObservationWindowSelectionTests.swift
+++ b/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/ObservationWindowSelectionTests.swift
@@ -47,6 +47,27 @@ final class ObservationWindowSelectionTests: XCTestCase {
         XCTAssertEqual(filtered.map(\.title), ["Editor"])
     }
 
+    func testCaptureCandidateSummaryIncludesRejectedReasons() {
+        let windows = [
+            Self.window(
+                id: 1,
+                title: "",
+                bounds: CGRect(x: 0, y: 0, width: 60, height: 30)),
+            Self.window(
+                id: 2,
+                title: "Overlay",
+                bounds: CGRect(x: 0, y: 0, width: 400, height: 400),
+                sharingState: .none),
+        ]
+
+        let summary = ObservationTargetResolver.captureCandidateSummary(from: windows)
+
+        XCTAssertTrue(summary.contains("#0 id=1 '<untitled>' 60x30"))
+        XCTAssertTrue(summary.contains("window too small"))
+        XCTAssertTrue(summary.contains("#0 id=2 'Overlay' 400x400"))
+        XCTAssertTrue(summary.contains("window marked non-shareable"))
+    }
+
     func testListFilteringKeepsMinimizedWindows() {
         let windows = [
             Self.window(


### PR DESCRIPTION
## Summary
- add `--snapshot latest` as an explicit alias for interaction commands and update help/error guidance
- add image JSON coordinate diagnostics plus blank/solid window-capture warnings
- make automatic app/window capture failures explain rejected candidate windows, while allowing smaller visible windows

## Verification
- `pnpm run format`
- `pnpm run lint`
- `pnpm run test:safe`
- `swift test --package-path Apps/CLI -Xswiftc -DPEEKABOO_SKIP_AUTOMATION --filter InteractionObservationContextTests --no-parallel`
- `swift test --package-path Core/PeekabooAutomationKit --filter ObservationWindowSelectionTests --no-parallel`
- `PEEKABOO_INCLUDE_AUTOMATION_TESTS=true swift test --package-path Apps/CLI --filter ImageCommandDiagnosticsTests --no-parallel`
- `pnpm run build:cli`
- live CLI: `image --mode screen --screen-index 0 --json --no-remote` wrote `/tmp/peekaboo-image-proof.png` and reported coordinate diagnostics
- live CLI: `list menubar --json --no-remote` returned 142 menu bar items
- live CLI: `see --mode screen --screen-index 0 --json --no-remote` created snapshot `B3BCA664-A8AA-4BBD-AF55-A46293742F71`
- live CLI: `click --snapshot latest --on Z999999 --json --no-remote` resolved latest snapshot and failed with `ELEMENT_NOT_FOUND`, not snapshot lookup failure

## Review
- `$autoreview` Codex and Claude engine runs both hung in their model subprocesses; I killed the stale runs and did an equivalent manual diff review before commit.
