### PR TITLE
Fix explicit latest snapshot alias handling

### DIFF
--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Shared/InteractionObservationContext.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Shared/InteractionObservationContext.swift
@@ -52,18 +52,30 @@ struct InteractionObservationContext {
         fallbackToLatest: Bool,
         snapshots: any SnapshotManagerProtocol
     ) async -> InteractionObservationContext {
-        if let explicitSnapshotId = normalizedSnapshotId(rawSnapshot), !isLatestAlias(explicitSnapshotId) {
-            return InteractionObservationContext(
-                explicitSnapshotId: explicitSnapshotId,
-                snapshotId: explicitSnapshotId,
-                source: .explicit
-            )
+        if let explicitSnapshotId = normalizedSnapshotId(rawSnapshot) {
+            guard self.isLatestAlias(explicitSnapshotId) else {
+                return InteractionObservationContext(
+                    explicitSnapshotId: explicitSnapshotId,
+                    snapshotId: explicitSnapshotId,
+                    source: .explicit
+                )
+            }
+            return await self.latestSnapshotContext(from: snapshots)
         }
 
         guard fallbackToLatest else {
-            return InteractionObservationContext(explicitSnapshotId: nil, snapshotId: nil, source: .none)
+            return InteractionObservationContext(
+                explicitSnapshotId: nil,
+                snapshotId: nil,
+                source: .none
+            )
         }
 
+        return await self.latestSnapshotContext(from: snapshots)
+    }
+
+    private static func latestSnapshotContext(from snapshots: any SnapshotManagerProtocol) async
+    -> InteractionObservationContext {
         if let latestSnapshotId = await snapshots.getMostRecentSnapshot() {
             return InteractionObservationContext(
                 explicitSnapshotId: nil,

--- a/Apps/CLI/Tests/CoreCLITests/InteractionObservationContextTests.swift
+++ b/Apps/CLI/Tests/CoreCLITests/InteractionObservationContextTests.swift
@@ -63,9 +63,9 @@ struct InteractionObservationContextTests {
     }
 
     @Test
-    func `Explicit latest alias does not force fallback when disabled`() async throws {
+    func `Explicit latest alias resolves even when omitted fallback is disabled`() async throws {
         let snapshots = CoreSnapshotManagerStub()
-        _ = try await snapshots.createSnapshot(id: "fresh-snapshot")
+        let latest = try await snapshots.createSnapshot(id: "fresh-snapshot")
 
         let context = await InteractionObservationContext.resolve(
             explicitSnapshot: "most-recent",
@@ -74,8 +74,8 @@ struct InteractionObservationContextTests {
         )
 
         #expect(context.explicitSnapshotId == nil)
-        #expect(context.snapshotId == nil)
-        #expect(context.source == .none)
+        #expect(context.snapshotId == latest)
+        #expect(context.source == .latest)
     }
 
     @Test


### PR DESCRIPTION
## Summary
- fix explicit `--snapshot latest` so it resolves the latest snapshot even for commands that do not fallback when the option is omitted
- update the regression test that previously encoded the wrong fallback-disabled behavior

## Verification
- `swift test --package-path Apps/CLI -Xswiftc -DPEEKABOO_SKIP_AUTOMATION --filter InteractionObservationContextTests --no-parallel`
- `pnpm run format`
- `pnpm run lint`
- `$autoreview --mode commit --commit HEAD`: clean, no accepted/actionable findings
