### PR TITLE
fix(cli): default clicks to background delivery

### DIFF
--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Base/CommanderBinder.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Base/CommanderBinder.swift
@@ -279,7 +279,9 @@ extension CommanderBindableValues {
         options.noAutoFocus = self.flag("noAutoFocus")
         options.spaceSwitch = self.flag("spaceSwitch")
         options.bringToCurrentSpace = self.flag("bringToCurrentSpace")
-        options.focusBackground = includeBackgroundDelivery && self.flag("focusBackground")
+        if includeBackgroundDelivery && self.flag("focusBackground") {
+            options.focusBackground = true
+        }
         if let timeout: TimeInterval = try decodeOption("focusTimeoutSeconds", as: TimeInterval.self) {
             options.focusTimeoutSeconds = timeout
         }

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Core/LearnCommand.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Core/LearnCommand.swift
@@ -126,7 +126,7 @@ struct LearnCommand {
         5. Recover from errors by trying alternative interactions (menus, hotkeys).
         6. Common workflows:
            - Screenshot: `image` with `--app` or `--mode screen`.
-           - Typing: `click` the field, then `type` the text.
+           - Typing: `click --foreground` the field, then `type` the text.
            - Menus: `menu click --path ...`.
            - Keyboard shortcuts: `hotkey`.
         """, to: &output)

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Interaction/ClickCommand+CommanderMetadata.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Interaction/ClickCommand+CommanderMetadata.swift
@@ -31,6 +31,7 @@ extension ClickCommand: CommanderBindableCommand {
         }
         self.double = values.flag("double")
         self.right = values.flag("right")
+        self.foreground = values.flag("foreground")
         self.focusOptions = try values.makeFocusOptions(includeBackgroundDelivery: true)
     }
 }
@@ -82,6 +83,11 @@ extension ClickCommand: CommanderSignatureProviding {
                     "right",
                     help: "Right-click (secondary click)",
                     long: "right"
+                ),
+                .commandFlag(
+                    "foreground",
+                    help: "Focus target and send a foreground mouse click",
+                    long: "foreground"
                 ),
                 .commandFlag(
                     "globalCoords",

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Interaction/ClickCommand+Output.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Interaction/ClickCommand+Output.swift
@@ -14,6 +14,7 @@ struct ClickResult: Codable {
     let inputCoordinates: [String: Double]?
     let screenCoordinates: [String: Double]?
     let targetPoint: InteractionTargetPointDiagnostics?
+    let deliveryMode: String?
 
     init(
         success: Bool,
@@ -27,7 +28,8 @@ struct ClickResult: Codable {
         coordinateSpace: String? = nil,
         inputCoordinates: CGPoint? = nil,
         screenCoordinates: CGPoint? = nil,
-        targetPoint: InteractionTargetPointDiagnostics? = nil
+        targetPoint: InteractionTargetPointDiagnostics? = nil,
+        deliveryMode: String? = nil
     ) {
         self.success = success
         self.clickedElement = clickedElement
@@ -41,5 +43,6 @@ struct ClickResult: Codable {
         self.inputCoordinates = inputCoordinates.map { ["x": $0.x, "y": $0.y] }
         self.screenCoordinates = screenCoordinates.map { ["x": $0.x, "y": $0.y] }
         self.targetPoint = targetPoint
+        self.deliveryMode = deliveryMode
     }
 }

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Interaction/ClickCommand+Validation.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Interaction/ClickCommand+Validation.swift
@@ -25,6 +25,15 @@ extension ClickCommand {
         if self.globalCoords && self.coords == nil {
             throw ValidationError("--global-coords requires --coords")
         }
+
+        if self.foreground && self.focusOptions.backgroundDeliveryExplicitlyRequested {
+            throw ValidationError("--foreground cannot be combined with --focus-background")
+        }
+
+        if self.focusOptions.backgroundDeliveryExplicitlyRequested &&
+            self.focusOptions.hasForegroundFocusOverrides {
+            throw ValidationError("--focus-background cannot be combined with focus options")
+        }
     }
 
     func formatElementInfo(_ element: DetectedElement) -> String {

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Interaction/ClickCommand.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Interaction/ClickCommand.swift
@@ -37,6 +37,9 @@ struct ClickCommand: ErrorHandlingCommand, OutputFormattable, RuntimeOptionsConf
     @Flag(help: "Right-click (secondary click)")
     var right = false
 
+    @Flag(help: "Focus target and send a foreground mouse click")
+    var foreground = false
+
     @OptionGroup var focusOptions: FocusCommandOptions
 
     @RuntimeStorage private var runtime: CommandRuntime?
@@ -63,6 +66,20 @@ struct ClickCommand: ErrorHandlingCommand, OutputFormattable, RuntimeOptionsConf
 
     var jsonOutput: Bool {
         self.runtime?.configuration.jsonOutput ?? self.runtimeOptions.jsonOutput
+    }
+
+    private var deliveryMode: ClickDeliveryMode {
+        if self.focusOptions.backgroundDeliveryExplicitlyRequested {
+            return .background
+        }
+        if self.foreground || self.focusOptions.hasForegroundFocusOverrides {
+            return .foreground
+        }
+        return .background
+    }
+
+    private var usesBackgroundDelivery: Bool {
+        self.deliveryMode == .background
     }
 
     @MainActor
@@ -106,7 +123,7 @@ struct ClickCommand: ErrorHandlingCommand, OutputFormattable, RuntimeOptionsConf
                 // InputDriver.click() sends a CGEvent at screen-absolute coordinates,
                 // so if the target window is not frontmost, the click will land on
                 // whatever window is at that position (see #90).
-                if !self.focusOptions.focusBackground {
+                if !self.usesBackgroundDelivery {
                     try await self.verifyFocusForCoordinateClick(coordinateResolution: resolvedCoordinates)
                 }
 
@@ -126,7 +143,7 @@ struct ClickCommand: ErrorHandlingCommand, OutputFormattable, RuntimeOptionsConf
                 let elementId = self.on ?? self.id
 
                 if let elementId {
-                    if !self.focusOptions.focusBackground {
+                    if !self.usesBackgroundDelivery {
                         observation = try await InteractionObservationRefresher.refreshForMissingElementsIfNeeded(
                             observation,
                             elementIds: [elementId],
@@ -139,7 +156,7 @@ struct ClickCommand: ErrorHandlingCommand, OutputFormattable, RuntimeOptionsConf
                     activeSnapshotId = observation.snapshotId ?? ""
 
                     clickTarget = .elementId(elementId)
-                    if self.focusOptions.focusBackground {
+                    if self.usesBackgroundDelivery {
                         let element = try await self.cachedElementById(elementId, observation: observation)
                         waitResult = WaitForElementResult(found: true, element: element, waitTime: 0)
                     } else {
@@ -157,13 +174,13 @@ struct ClickCommand: ErrorHandlingCommand, OutputFormattable, RuntimeOptionsConf
                     }
 
                 } else if let searchQuery = query {
-                    if !self.focusOptions.focusBackground {
+                    if !self.usesBackgroundDelivery {
                         observation = try await self.refreshObservationIfQueryMissing(observation, query: searchQuery)
                     }
                     observationForInvalidation = observation
                     activeSnapshotId = observation.snapshotId ?? ""
 
-                    if self.focusOptions.focusBackground {
+                    if self.usesBackgroundDelivery {
                         let element = try await self.cachedElementMatching(searchQuery, observation: observation)
                         clickTarget = .elementId(element.id)
                         waitResult = WaitForElementResult(found: true, element: element, waitTime: 0)
@@ -194,7 +211,12 @@ struct ClickCommand: ErrorHandlingCommand, OutputFormattable, RuntimeOptionsConf
 
             // Determine click type
             let clickType: ClickType = self.right ? .right : (self.double ? .double : .single)
-            try await self.performClick(clickTarget, clickType: clickType, snapshotId: activeSnapshotId)
+            try await self.performClick(
+                clickTarget,
+                clickType: clickType,
+                snapshotId: activeSnapshotId,
+                coordinateResolution: coordinateResolution
+            )
 
             // Brief delay to ensure click is processed
             try await Task.sleep(nanoseconds: 20_000_000) // 0.02 seconds
@@ -224,7 +246,8 @@ struct ClickCommand: ErrorHandlingCommand, OutputFormattable, RuntimeOptionsConf
                 coordinateSpace: coordinateResolution?.coordinateSpace.rawValue,
                 inputCoordinates: coordinateResolution?.inputPoint,
                 screenCoordinates: coordinateResolution?.screenPoint,
-                targetPoint: details.targetPointDiagnostics
+                targetPoint: details.targetPointDiagnostics,
+                deliveryMode: self.deliveryMode.rawValue
             )
 
             if let observationForInvalidation {
@@ -312,7 +335,7 @@ struct ClickCommand: ErrorHandlingCommand, OutputFormattable, RuntimeOptionsConf
             return "window \(windowID)"
         }
 
-        guard self.focusOptions.focusBackground else {
+        guard self.usesBackgroundDelivery else {
             return await self.frontmostApplicationName()
         }
 
@@ -329,6 +352,14 @@ struct ClickCommand: ErrorHandlingCommand, OutputFormattable, RuntimeOptionsConf
         guard !snapshotId.isEmpty,
               let snapshot = try? await self.services.snapshots.getUIAutomationSnapshot(snapshotId: snapshotId)
         else {
+            if let detectionResult = try? await self.services.snapshots.getDetectionResult(snapshotId: snapshotId) {
+                if let applicationName = detectionResult.metadata.windowContext?.applicationName {
+                    return applicationName
+                }
+                if let processId = detectionResult.metadata.windowContext?.applicationProcessId {
+                    return await self.applicationName(processIdentifier: processId) ?? "PID \(processId)"
+                }
+            }
             return await self.frontmostApplicationName()
         }
 
@@ -354,8 +385,8 @@ struct ClickCommand: ErrorHandlingCommand, OutputFormattable, RuntimeOptionsConf
         output(result) {
             print("✅ Click successful")
             print("🎯 App: \(result.targetApp)")
-            if self.focusOptions.focusBackground {
-                print("🎯 Mode: background")
+            if let deliveryMode = result.deliveryMode {
+                print("🎯 Mode: \(deliveryMode)")
             }
             if let coordinateSpace = result.coordinateSpace {
                 print("🎯 Coordinate space: \(coordinateSpace)")
@@ -456,15 +487,23 @@ struct ClickCommand: ErrorHandlingCommand, OutputFormattable, RuntimeOptionsConf
         return score
     }
 
-    private func performClick(_ target: ClickTarget, clickType: ClickType, snapshotId: String) async throws {
+    private func performClick(
+        _ target: ClickTarget,
+        clickType: ClickType,
+        snapshotId: String,
+        coordinateResolution: InteractionCoordinateResolution?
+    ) async throws {
         let effectiveSnapshotId: String? = if case .coordinates = target {
             nil
         } else {
             snapshotId.isEmpty ? nil : snapshotId
         }
 
-        if self.focusOptions.focusBackground {
-            let pid = try await self.resolveBackgroundClickProcessIdentifier(snapshotId: effectiveSnapshotId)
+        if self.usesBackgroundDelivery {
+            let pid = try await self.resolveBackgroundClickProcessIdentifier(
+                snapshotId: effectiveSnapshotId,
+                coordinateResolution: coordinateResolution
+            )
             try await AutomationServiceBridge.click(
                 automation: self.services.automation,
                 target: target,
@@ -486,7 +525,7 @@ struct ClickCommand: ErrorHandlingCommand, OutputFormattable, RuntimeOptionsConf
         snapshotId: String?,
         coordinateResolution: InteractionCoordinateResolution? = nil
     ) async throws {
-        if self.focusOptions.focusBackground {
+        if self.usesBackgroundDelivery {
             try self.validateBackgroundClickOptions()
             return
         }
@@ -523,17 +562,22 @@ struct ClickCommand: ErrorHandlingCommand, OutputFormattable, RuntimeOptionsConf
     }
 
     private func validateBackgroundClickOptions() throws {
-        if self.focusOptions.focusTimeoutSeconds != nil ||
-            self.focusOptions.focusRetryCount != nil ||
-            self.focusOptions.spaceSwitch ||
-            self.focusOptions.bringToCurrentSpace {
+        if self.foreground, self.focusOptions.backgroundDeliveryExplicitlyRequested {
+            throw ValidationError("--foreground cannot be combined with --focus-background")
+        }
+
+        if self.focusOptions.backgroundDeliveryExplicitlyRequested &&
+            self.focusOptions.hasForegroundFocusOverrides {
             throw ValidationError("--focus-background cannot be combined with focus options")
         }
     }
 
-    private func resolveBackgroundClickProcessIdentifier(snapshotId: String?) async throws -> pid_t {
+    private func resolveBackgroundClickProcessIdentifier(
+        snapshotId: String?,
+        coordinateResolution: InteractionCoordinateResolution?
+    ) async throws -> pid_t {
         if self.target.pid != nil, self.target.app != nil {
-            throw ValidationError("--focus-background accepts one process target: use --app or --pid")
+            throw ValidationError("Background click accepts one process target: use --app or --pid")
         }
 
         if let pid = self.target.pid {
@@ -549,14 +593,32 @@ struct ClickCommand: ErrorHandlingCommand, OutputFormattable, RuntimeOptionsConf
             return pid_t(app.processIdentifier)
         }
 
+        if let processId = coordinateResolution?.targetProcessIdentifier {
+            return pid_t(processId)
+        }
+
         if let snapshotId,
            let snapshot = try? await self.services.snapshots.getUIAutomationSnapshot(snapshotId: snapshotId),
            let processId = snapshot.applicationProcessId {
             return pid_t(processId)
         }
 
-        throw ValidationError("--focus-background requires --app, --pid, or a snapshot with process metadata")
+        if let snapshotId,
+           let detectionResult = try? await self.services.snapshots.getDetectionResult(snapshotId: snapshotId),
+           let processId = detectionResult.metadata.windowContext?.applicationProcessId {
+            return pid_t(processId)
+        }
+
+        throw ValidationError(
+            "Background click requires --app, --pid, --window-id, or a snapshot with process metadata; " +
+                "use --foreground for foreground screen clicks"
+        )
     }
 
     // Error handling is provided by ErrorHandlingCommand protocol
+}
+
+private enum ClickDeliveryMode: String {
+    case background
+    case foreground
 }

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Shared/FocusCommandOptions+CommanderMetadata.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Shared/FocusCommandOptions+CommanderMetadata.swift
@@ -28,7 +28,7 @@ extension FocusCommandOptions {
         if includeBackgroundDelivery {
             flags.append(.commandFlag(
                 "focusBackground",
-                help: "Send input to the target process without focusing it",
+                help: "Send input to the target process without focusing it (default for click)",
                 long: "focus-background"
             ))
         }

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Shared/FocusCommandOptions.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Shared/FocusCommandOptions.swift
@@ -26,6 +26,18 @@ struct FocusCommandOptions: CommanderParsable, FocusOptionsProtocol {
         set { self.focusBackgroundStorage = newValue }
     }
 
+    var backgroundDeliveryExplicitlyRequested: Bool {
+        self.focusBackgroundStorage == true
+    }
+
+    var hasForegroundFocusOverrides: Bool {
+        self.noAutoFocus ||
+            self.focusTimeoutSeconds != nil ||
+            self.focusRetryCount != nil ||
+            self.spaceSwitch ||
+            self.bringToCurrentSpace
+    }
+
     init() {}
 
     // MARK: FocusOptionsProtocol

--- a/Apps/CLI/Tests/CLIAutomationTests/ClickCommandFocusTests.swift
+++ b/Apps/CLI/Tests/CLIAutomationTests/ClickCommandFocusTests.swift
@@ -21,6 +21,7 @@ struct ClickCommandFocusTests {
         let result = try await self.runPeekabooCommand(["click", "--help"])
         let output = result.combinedOutput
 
+        #expect(output.contains("--foreground"))
         #expect(output.contains("--no-auto-focus"))
         #expect(output.contains("--focus-timeout-seconds"))
         #expect(output.contains("--focus-retry-count"))

--- a/Apps/CLI/Tests/CLIAutomationTests/ClickCommandTests.swift
+++ b/Apps/CLI/Tests/CLIAutomationTests/ClickCommandTests.swift
@@ -20,7 +20,7 @@ struct ClickCommandTests {
     func `Click command  parses coordinates correctly`() async throws {
         let context = await self.makeContext()
         let result = try await InProcessCommandRunner.run(
-            ["click", "--coords", "100,200", "--json"],
+            ["click", "--coords", "100,200", "--foreground", "--json"],
             services: context.services
         )
 
@@ -43,10 +43,10 @@ struct ClickCommandTests {
     }
 
     @Test
-    func `Click command supports background coordinate clicks`() async throws {
+    func `Click command defaults to background coordinate clicks when pid is supplied`() async throws {
         let context = await self.makeContext()
         let result = try await InProcessCommandRunner.run(
-            ["click", "--coords", "100,200", "--pid", "12345", "--focus-background", "--global-coords", "--json"],
+            ["click", "--coords", "100,200", "--pid", "12345", "--global-coords", "--json"],
             services: context.services
         )
 
@@ -62,7 +62,7 @@ struct ClickCommandTests {
     }
 
     @Test
-    func `Click command background element click uses cached snapshot without waiting`() async throws {
+    func `Click command default element click uses cached snapshot without waiting`() async throws {
         let context = await self.makeContext()
         let element = DetectedElement(
             id: "B1",
@@ -73,7 +73,7 @@ struct ClickCommandTests {
         let snapshotId = try await self.storeSnapshot(element: element, in: context.snapshots)
 
         let result = try await InProcessCommandRunner.run(
-            ["click", "--on", "B1", "--snapshot", snapshotId, "--pid", "12345", "--focus-background", "--json"],
+            ["click", "--on", "B1", "--snapshot", snapshotId, "--json"],
             services: context.services
         )
 
@@ -92,7 +92,7 @@ struct ClickCommandTests {
     }
 
     @Test
-    func `Click command background query click resolves cached snapshot without waiting`() async throws {
+    func `Click command default query click resolves cached snapshot without waiting`() async throws {
         let context = await self.makeContext()
         let element = DetectedElement(
             id: "B1",
@@ -103,7 +103,7 @@ struct ClickCommandTests {
         let snapshotId = try await self.storeSnapshot(element: element, in: context.snapshots)
 
         let result = try await InProcessCommandRunner.run(
-            ["click", "Save", "--snapshot", snapshotId, "--pid", "12345", "--focus-background", "--json"],
+            ["click", "Save", "--snapshot", snapshotId, "--json"],
             services: context.services
         )
 
@@ -162,7 +162,16 @@ struct ClickCommandTests {
             snapshotId: snapshotId,
             screenshotPath: "/tmp/screenshot.png",
             elements: DetectedElements(buttons: [element]),
-            metadata: DetectionMetadata(detectionTime: 0, elementCount: 1, method: "stub")
+            metadata: DetectionMetadata(
+                detectionTime: 0,
+                elementCount: 1,
+                method: "stub",
+                windowContext: WindowContext(
+                    applicationName: "TestApp",
+                    applicationBundleId: "com.example.test",
+                    applicationProcessId: 12345
+                )
+            )
         )
         try await snapshots.storeDetectionResult(snapshotId: snapshotId, result: detection)
         return snapshotId

--- a/Apps/CLI/Tests/peekabooTests/ClickCommandAdvancedTests.swift
+++ b/Apps/CLI/Tests/peekabooTests/ClickCommandAdvancedTests.swift
@@ -36,6 +36,12 @@ struct ClickCommandAdvancedTests {
     }
 
     @Test
+    func `Parse foreground option`() throws {
+        let command = try ClickCommand.parse(["--on", "B1", "--foreground"])
+        #expect(command.foreground == true)
+    }
+
+    @Test
     func `Parse wait-for option`() throws {
         let command = try ClickCommand.parse(["--on", "B1", "--wait-for", "3000"])
         #expect(command.waitFor == 3000)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 ### Added
 - `peekaboo agent` now supports MiniMax China via `minimax-cn/...` models and `MINIMAX_CN_API_KEY`, while preserving the existing international MiniMax endpoint. Thanks @LLuke for #161.
 
+### Changed
+- `peekaboo click` now uses background delivery by default and adds `--foreground` for focused foreground mouse clicks.
+
 ### Fixed
 - Visualizer settings and capture-engine docs now reference `peekaboo capture live` instead of stale top-level `peekaboo watch`/`peekaboo capture` command forms. Thanks @coygeek for #166 and #167.
 

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/Agent/Tools/AgentSystemPrompt.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/Agent/Tools/AgentSystemPrompt.swift
@@ -156,7 +156,7 @@ public struct AgentSystemPrompt {
         **Common Patterns**
         - Menus → the `menu` tool with action "click" and the full path.
         - Keyboard shortcuts → `hotkey` with modifiers.
-        - Text entry → click the field, then `type`.
+        - Text entry → click the field with `foreground: true`, then `type`.
         - Scrolling → `scroll` with direction and amount.
         """
     }

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/ClickTool.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/ClickTool.swift
@@ -16,7 +16,7 @@ public struct ClickTool: MCPTool {
         """
         Clicks on UI elements or coordinates.
         Supports element queries, specific IDs from `see` or `inspect_ui`, or raw coordinates.
-        Includes smart waiting for elements to become actionable.
+        Background delivery is the default. Set `foreground` to true when the next step needs keyboard focus.
         \(PeekabooMCPVersion.banner) using openai/gpt-5.5, anthropic/claude-opus-4-7
         """
     }
@@ -51,9 +51,12 @@ public struct ClickTool: MCPTool {
                 "right": SchemaBuilder.boolean(
                     description: "Optional. Right-click (secondary click) instead of left-click.",
                     default: false),
-                "background": SchemaBuilder.boolean(
-                    description: "Optional. Deliver the click to the target process without focusing it.",
+                "foreground": SchemaBuilder.boolean(
+                    description: "Optional. Use foreground/global click delivery. Background delivery is the default.",
                     default: false),
+                "background": SchemaBuilder.boolean(
+                    description: "Optional legacy alias. Defaults to true; set foreground=true for foreground clicks.",
+                    default: true),
                 "pid": SchemaBuilder.number(
                     description: "Optional. Target process ID for background coordinate clicks."),
             ],
@@ -84,7 +87,7 @@ public struct ClickTool: MCPTool {
                 target: resolution.automationTarget,
                 snapshotId: resolution.snapshotId,
                 intent: request.intent,
-                background: request.background,
+                deliveryMode: request.deliveryMode,
                 targetProcessIdentifier: effectiveTargetProcessIdentifier)
 
             let invalidatedSnapshotId = await UISnapshotManager.shared
@@ -154,10 +157,10 @@ public struct ClickTool: MCPTool {
         target: ClickTarget,
         snapshotId: String?,
         intent: ClickIntent,
-        background: Bool,
+        deliveryMode: ClickToolDeliveryMode,
         targetProcessIdentifier: pid_t?) async throws
     {
-        if background {
+        if deliveryMode == .background {
             guard let targetProcessIdentifier else {
                 throw ClickToolError("Background click requires a snapshot target process or explicit pid.")
             }
@@ -181,7 +184,7 @@ public struct ClickTool: MCPTool {
         request: ClickRequest,
         resolution: ClickResolution) throws -> pid_t?
     {
-        guard request.background else { return nil }
+        guard request.deliveryMode == .background else { return nil }
         if let pid = request.pid {
             guard pid > 0 else {
                 throw ClickToolError("pid must be greater than 0.")
@@ -213,6 +216,7 @@ public struct ClickTool: MCPTool {
             ]),
             "execution_time": .double(executionTime),
             "clicked_element": resolution.elementDescription.map(Value.string) ?? .null,
+            "delivery_mode": .string(effectiveTargetProcessIdentifier == nil ? "foreground" : "background"),
         ]
         if let invalidatedSnapshotId {
             metaDict["invalidated_snapshot"] = .string(invalidatedSnapshotId)
@@ -288,7 +292,7 @@ private struct ClickRequest {
     let target: ClickRequestTarget
     let snapshotId: String?
     let intent: ClickIntent
-    let background: Bool
+    let deliveryMode: ClickToolDeliveryMode
     let pid: Int32?
 
     init(arguments: ToolArguments) throws {
@@ -306,7 +310,12 @@ private struct ClickRequest {
         let isDouble = arguments.getBool("double") ?? false
         let isRight = arguments.getBool("right") ?? false
         self.intent = ClickIntent(double: isDouble, right: isRight)
-        self.background = arguments.getBool("background") ?? false
+        let foreground = arguments.getBool("foreground") ?? false
+        self.deliveryMode = if foreground || arguments.getBool("background") == false {
+            .foreground
+        } else {
+            .background
+        }
         if let rawPID = arguments.getNumber("pid") {
             guard let pid = Int32(exactly: rawPID) else {
                 throw ClickToolError("pid is outside the supported Int32 range.")
@@ -322,6 +331,11 @@ private enum ClickRequestTarget {
     case coordinates(String)
     case elementId(String)
     case query(String)
+}
+
+private enum ClickToolDeliveryMode {
+    case background
+    case foreground
 }
 
 private struct ClickResolution {

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/ToolRegistry/ToolDefinitions.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/ToolRegistry/ToolDefinitions.swift
@@ -64,6 +64,7 @@ public enum UIAutomationToolDefinitions {
         Clicks on UI elements or coordinates. Supports element queries,
         specific IDs from `see` or `inspect_ui`, or coordinates. CLI coordinate
         clicks are target-window-relative when app/window target flags are supplied.
+        Background delivery is the default; pass `--foreground` for focused foreground clicks.
         """,
         category: .ui,
         parameters: [
@@ -113,9 +114,9 @@ public enum UIAutomationToolDefinitions {
                 description: "Bring window to current Space instead of switching",
                 required: false),
             ParameterDefinition(
-                name: "autoFocus",
+                name: "foreground",
                 type: .boolean,
-                description: "Automatically focus application before clicking",
+                description: "Focus target and send a foreground click",
                 required: false),
             ParameterDefinition(
                 name: "jsonOutput",

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/ToolRegistry/ToolRegistry.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/ToolRegistry/ToolRegistry.swift
@@ -48,7 +48,8 @@ public enum ToolRegistry {
             abstract: "High-precision UI clicking with fuzzy matching and snapshot-aware targeting.",
             discussion: """
             Clicks on UI elements or coordinates. Supports IDs from `see` or `inspect_ui`,
-            fuzzy text queries, or raw coordinates.
+            fuzzy text queries, or raw coordinates. Clicks use background delivery by default;
+            pass `--foreground` only when the target must receive a foreground mouse event.
 
             ELEMENT MATCHING
             - Fuzzy matching on element titles and labels
@@ -56,8 +57,8 @@ public enum ToolRegistry {
             - Snapshot-aware IDs avoid ambiguity when multiple matches exist
 
             EXAMPLE
-            peekaboo click --wait-for 1500 --double \"Submit\"
-            peekaboo click --on B2 --space-switch
+            peekaboo click --foreground --wait-for 1500 --double \"Submit\"
+            peekaboo click --on B2 --foreground --space-switch
 
             TROUBLESHOOTING
             If the element isn't found, refresh the snapshot with a fresh observation (`peekaboo see`
@@ -65,10 +66,10 @@ public enum ToolRegistry {
             """,
             examples: [
                 "peekaboo click \"Submit\"",
-                "peekaboo click --wait-for 2000 --double \"Save\"",
+                "peekaboo click --foreground --wait-for 2000 --double \"Save\"",
             ],
-            agentGuidance: "Prefer ID-based clicks when possible. If fuzzy text fails, capture " +
-                "again and reference the new element id."),
+            agentGuidance: "Prefer ID-based clicks when possible. Use `--foreground` before typing into a field. " +
+                "If fuzzy text fails, capture again and reference the new element id."),
         "type": ToolOverride(
             category: .automation,
             abstract: "Types text or key sequences, including escape characters and modifiers.",

--- a/Core/PeekabooCore/Tests/PeekabooTests/MCP/MCPToolExecutionTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/MCP/MCPToolExecutionTests.swift
@@ -10,6 +10,7 @@ import Testing
 @testable import PeekabooCore
 @testable import PeekabooVisualizer
 
+@Suite(.serialized)
 struct MCPToolExecutionTests {
     // MARK: - Sleep Tool Tests
 
@@ -453,6 +454,15 @@ struct MCPToolExecutionTests {
         let context = await MCPToolTestHelpers.makeContext(automation: automation)
         let snapshot = await UISnapshotManager.shared.createSnapshot()
         let snapshotId = await snapshot.id
+        await snapshot.setScreenshot(
+            path: "/tmp/screenshot.png",
+            metadata: CaptureMetadata(
+                size: CGSize(width: 200, height: 100),
+                mode: .window,
+                applicationInfo: ServiceApplicationInfo(
+                    processIdentifier: 111,
+                    bundleIdentifier: "com.example.snapshot",
+                    name: "SnapshotApp")))
         await snapshot.setUIElements([
             UIElement(
                 id: "B1",
@@ -476,9 +486,10 @@ struct MCPToolExecutionTests {
         ]))
 
         #expect(response.isError == false)
-        let calls = await MainActor.run { automation.clickCalls }
+        let calls = await MainActor.run { automation.targetedClickCalls }
         #expect(calls.count == 1)
         #expect(calls.first?.snapshotId == snapshotId)
+        #expect(calls.first?.targetProcessIdentifier == 111)
         if case let .elementId(id) = calls.first?.target {
             #expect(id == "B1")
         } else {
@@ -496,6 +507,15 @@ struct MCPToolExecutionTests {
         let context = await MCPToolTestHelpers.makeContext(automation: automation)
         let snapshot = await UISnapshotManager.shared.createSnapshot()
         let snapshotId = await snapshot.id
+        await snapshot.setScreenshot(
+            path: "/tmp/screenshot.png",
+            metadata: CaptureMetadata(
+                size: CGSize(width: 200, height: 100),
+                mode: .window,
+                applicationInfo: ServiceApplicationInfo(
+                    processIdentifier: 111,
+                    bundleIdentifier: "com.example.snapshot",
+                    name: "SnapshotApp")))
         await snapshot.setUIElements([
             UIElement(
                 id: "B1",
@@ -516,8 +536,9 @@ struct MCPToolExecutionTests {
         let response = try await tool.execute(arguments: ToolArguments(raw: ["on": "B1"]))
 
         #expect(response.isError == false)
-        let calls = await MainActor.run { automation.clickCalls }
+        let calls = await MainActor.run { automation.targetedClickCalls }
         #expect(calls.first?.snapshotId == snapshotId)
+        #expect(calls.first?.targetProcessIdentifier == 111)
         let invalidated = await UISnapshotManager.shared.getSnapshot(id: snapshotId)
         #expect(invalidated == nil)
         #expect(MCPResponseMeta.requiresFreshObservation(response))
@@ -530,6 +551,15 @@ struct MCPToolExecutionTests {
         let context = await MCPToolTestHelpers.makeContext(automation: automation)
         let snapshot = await UISnapshotManager.shared.createSnapshot()
         let snapshotId = await snapshot.id
+        await snapshot.setScreenshot(
+            path: "/tmp/screenshot.png",
+            metadata: CaptureMetadata(
+                size: CGSize(width: 200, height: 100),
+                mode: .window,
+                applicationInfo: ServiceApplicationInfo(
+                    processIdentifier: 111,
+                    bundleIdentifier: "com.example.snapshot",
+                    name: "SnapshotApp")))
         await snapshot.setUIElements([
             UIElement(
                 id: "B1",
@@ -566,9 +596,10 @@ struct MCPToolExecutionTests {
         ]))
 
         #expect(response.isError == false)
-        let calls = await MainActor.run { automation.clickCalls }
+        let calls = await MainActor.run { automation.targetedClickCalls }
         #expect(calls.count == 1)
         #expect(calls.first?.snapshotId == snapshotId)
+        #expect(calls.first?.targetProcessIdentifier == 111)
         if case let .elementId(id) = calls.first?.target {
             #expect(id == "B2")
         } else {
@@ -632,7 +663,10 @@ struct MCPToolExecutionTests {
         let snapshotId = await snapshot.id
 
         let tool = ClickTool(context: context)
-        let response = try await tool.execute(arguments: ToolArguments(raw: ["coords": "40,50"]))
+        let response = try await tool.execute(arguments: ToolArguments(raw: [
+            "coords": "40,50",
+            "foreground": true,
+        ]))
 
         #expect(response.isError == false)
         let calls = await MainActor.run { automation.clickCalls }
@@ -655,6 +689,7 @@ struct MCPToolExecutionTests {
         let response = try await tool.execute(arguments: ToolArguments(raw: [
             "coords": "40,50",
             "snapshot": explicitSnapshotId,
+            "foreground": true,
         ]))
 
         #expect(response.isError == false)

--- a/docs/automation.md
+++ b/docs/automation.md
@@ -80,6 +80,7 @@ Three primitives, four lines. The agent does the same thing under the hood — i
 - Always run [`peekaboo see`](commands/see.md) when an element is unreachable. The AX tree refreshes after focus changes; capture again if a click fails.
 - Use [focus](focus.md) and [application-resolving](application-resolving.md) for tricky cases (multiple windows, helper apps, processes that hide on activation).
 - Wrap risky sequences with `peekaboo sleep 0.2` — humans don't fire ten clicks in a single frame, and neither should you.
+- `peekaboo click` defaults to background delivery; add `--foreground` before click-then-type flows that need keyboard focus.
 - Prefer [`hotkey --focus-background`](commands/hotkey.md) when you need to drive an app without stealing focus from the user.
 
 ## Going further

--- a/docs/commands/click.md
+++ b/docs/commands/click.md
@@ -7,7 +7,7 @@ read_when:
 
 # `peekaboo click`
 
-`click` is the primary interaction command. It accepts element IDs, fuzzy text queries, or literal coordinates and then drives `AutomationServiceBridge.click` with built-in focus handling and wait logic.
+`click` is the primary interaction command. It accepts element IDs, fuzzy text queries, or literal coordinates and then drives `AutomationServiceBridge.click`. Background delivery is the default so target apps do not need to become frontmost; pass `--foreground` for old foreground mouse behavior.
 
 ## Key options
 | Flag | Description |
@@ -20,15 +20,17 @@ read_when:
 | Target flags | `--app <name>`, `--pid <pid>`, `--window-id <id>`, `--window-title <title>`, `--window-index <n>` — focus a specific app/window before clicking. (`--window-title`/`--window-index` require `--app` or `--pid`; `--window-id` does not.) |
 | `--wait-for <ms>` | Millisecond timeout while waiting for the element to appear (default 5000). |
 | `--double` / `--right` | Perform double-click or secondary-click instead of the default single click. |
-| Focus flags | `--no-auto-focus`, `--focus-timeout-seconds`, `--focus-retry-count`, `--space-switch`, `--bring-to-current-space` (see `FocusCommandOptions`). |
-| `--focus-background` | Send the click to a target process without focusing it. Use `--app`, `--pid`, or a snapshot with process metadata. |
+| `--foreground` | Focus target and send a foreground mouse click. Focus flags also imply foreground delivery. |
+| Focus flags | `--no-auto-focus`, `--focus-timeout-seconds`, `--focus-retry-count`, `--space-switch`, `--bring-to-current-space` (foreground mode only; see `FocusCommandOptions`). |
+| `--focus-background` | Legacy alias for the default background delivery. Use `--app`, `--pid`, `--window-id`, or a snapshot with process metadata. |
 
 ## Implementation notes
 - Validation makes sure you only provide one targeting strategy (ID/query vs. `--coords`) and that coordinate strings parse cleanly into doubles. Target-relative coordinate clicks fail if the point is outside the resolved window.
 - When no `--snapshot` is provided, the command grabs the most recent snapshot ID (if any) before waiting for elements. Coordinate clicks skip snapshot usage entirely to avoid stale caches, but targeted coordinate clicks resolve the target window before synthesizing the final screen point.
-- Element-based clicks call `AutomationServiceBridge.waitForElement` with the supplied timeout so you don’t have to insert manual sleeps. Helpful hints are printed when timeouts expire.
-- Focus is enforced just before the click by `ensureFocused`; by default it will hop Spaces if necessary unless you pass `--no-auto-focus`.
-- `--focus-background` uses process-targeted CoreGraphics mouse events and skips foreground focus. It requires Event Synthesizing access and a resolvable target process. Coordinate clicks need explicit `--app` or `--pid`; element clicks can reuse snapshot process metadata.
+- Background element/query clicks use cached snapshot geometry and skip foreground focus. Run `peekaboo see` first when you need fresh element IDs or target process metadata.
+- Foreground element-based clicks call `AutomationServiceBridge.waitForElement` with the supplied timeout so you don’t have to insert manual sleeps. Helpful hints are printed when timeouts expire.
+- `--foreground` enforces focus just before the click by `ensureFocused`; it will hop Spaces if necessary unless you pass `--no-auto-focus`.
+- Background delivery uses process-targeted CoreGraphics mouse events and skips foreground focus. It requires Event Synthesizing access and a resolvable target process. Coordinate clicks need explicit `--app`, `--pid`, `--window-id`, or `--foreground`; element clicks can reuse snapshot process metadata.
 - JSON output reports `clickedElement`, input coordinates, resolved screen coordinates, coordinate space, target window metadata, wait time, execution time, and `targetPoint` diagnostics. Element/query `targetPoint` includes the original snapshot midpoint, the final resolved point, the snapshot ID, and whether a moved-window adjustment was applied.
 
 ## Examples
@@ -36,20 +38,20 @@ read_when:
 # Click the "Send" button (ID from a previous `see` run)
 peekaboo click --on B12
 
-# Fuzzy search + extra wait for a slow dialog
-peekaboo click "Allow" --wait-for 8000 --space-switch
+# Fuzzy search + extra wait for a slow dialog using foreground delivery
+peekaboo click "Allow" --foreground --wait-for 8000 --space-switch
 
 # Issue a right-click at global screen coordinates
-peekaboo click --coords 1024,88 --right --no-auto-focus
+peekaboo click --coords 1024,88 --right --foreground --no-auto-focus
 
 # Click 20,40 inside a resolved app window
 peekaboo click --app Safari --coords 20,40
 
 # Force global screen coordinates while still focusing a target first
-peekaboo click --window-id 59620 --coords 1024,88 --global-coords
+peekaboo click --window-id 59620 --coords 1024,88 --global-coords --foreground
 
 # Click Safari coordinates without activating Safari
-peekaboo click --coords 420,180 --app Safari --focus-background --global-coords
+peekaboo click --coords 420,180 --app Safari --global-coords
 ```
 
 ## Troubleshooting

--- a/docs/commands/paste.md
+++ b/docs/commands/paste.md
@@ -20,7 +20,7 @@ This reduces drift by collapsing multiple CLI steps into one command.
 | `--also-text` | Optional plain-text companion when pasting binary. |
 | `--restore-delay-ms` | Delay before restoring the previous clipboard (default 150ms). |
 | Target flags | `--app <name>`, `--pid <pid>`, `--window-id <id>`, `--window-title <title>`, `--window-index <n>` — focus a specific app/window before pasting. |
-| Focus flags | Same as `click`/`type` (`--space-switch`, `--no-auto-focus`, etc.). |
+| Focus flags | Foreground focus controls (`--space-switch`, `--no-auto-focus`, etc.). |
 
 ## Examples
 ```bash

--- a/docs/commands/permissions.md
+++ b/docs/commands/permissions.md
@@ -14,7 +14,7 @@ read_when:
 | --- | --- |
 | `status` (default) | Fetches the current permission set and prints each entry (`granted`, `denied`, etc.). Honors `--json` so agents can block proactively. Add `--all-sources` to compare Bridge and local CLI permissions side by side. |
 | `grant` | Reuses the same snapshot but focuses on remediation: when in text mode it prints the exact System Settings pane/location for each missing entitlement. |
-| `request-event-synthesizing` | Triggers the macOS Event Synthesizing prompt needed by background input such as `hotkey --focus-background` and `click --focus-background`. With the default remote runtime it requests the permission for the selected bridge host; use `--no-remote` to request it for the local CLI process. |
+| `request-event-synthesizing` | Triggers the macOS Event Synthesizing prompt needed by background input such as `hotkey --focus-background` and default `click` delivery. With the default remote runtime it requests the permission for the selected bridge host; use `--no-remote` to request it for the local CLI process. |
 
 ## Implementation notes
 - All subcommands conform to `RuntimeOptionsConfigurable`, so they inherit global `--json`/`--verbose` flags even when invoked from compound commands like `peekaboo learn`.

--- a/docs/commands/type.md
+++ b/docs/commands/type.md
@@ -20,7 +20,7 @@ read_when:
 | `--clear` | Issue Cmd+A, Delete before typing any new text. |
 | `--return`, `--tab <count>`, `--escape`, `--delete` | Append those keypresses after (or without) the text payload. |
 | Target flags | `--app <name>`, `--pid <pid>`, `--window-id <id>`, `--window-title <title>`, `--window-index <n>` — focus a specific app/window before typing. (`--window-title`/`--window-index` require `--app` or `--pid`; `--window-id` does not.) |
-| Focus flags | Same as `click` (`--no-auto-focus`, `--space-switch`, etc.). |
+| Focus flags | Foreground focus controls (`--no-auto-focus`, `--space-switch`, etc.). |
 
 ## Implementation notes
 - You can omit the text entirely and rely on the key flags (e.g., just `--tab 2 --return`). Validation only requires *some* action to be specified.

--- a/docs/focus.md
+++ b/docs/focus.md
@@ -48,7 +48,7 @@ When you use the `see` command, Peekaboo stores the window's CGWindowID in the s
 
 ### Focus Flow
 
-When you execute an interaction command (click, type, etc.), Peekaboo:
+When you execute a foreground interaction command (`type`, `click --foreground`, etc.), Peekaboo:
 
 1. **Retrieves window info** from the current snapshot
 2. **Checks if window still exists** (handles closed windows gracefully)
@@ -60,11 +60,11 @@ When you execute an interaction command (click, type, etc.), Peekaboo:
 
 ## Automatic Focus Management
 
-All interaction commands automatically handle focus:
+Foreground interaction commands automatically handle focus:
 
 ```bash
 # These commands all include automatic focus management:
-peekaboo click "Submit"
+peekaboo click "Submit" --foreground
 peekaboo type "Hello world"
 peekaboo scroll --direction down
 peekaboo menu click --app Safari --item "New Tab"
@@ -83,13 +83,13 @@ By default, Peekaboo will:
 
 ## Focus Options
 
-All interaction commands support these focus-related options:
+Interaction commands that use foreground delivery support these focus-related options. `click` defaults to background delivery; pass `--foreground` when you want focus behavior.
 
 ### `--no-auto-focus`
 Disables automatic focus management (not recommended).
 
 ```bash
-peekaboo click "Submit" --no-auto-focus
+peekaboo click "Submit" --foreground --no-auto-focus
 ```
 
 Use cases:
@@ -98,11 +98,11 @@ Use cases:
 - Testing or debugging focus issues
 
 ### `--focus-background`
-Uses command-supported background delivery instead of activating the target app.
+Uses command-supported background delivery instead of activating the target app. For `click`, this is now the default and the flag is only a legacy alias.
 
 ```bash
 peekaboo hotkey "cmd,l" --app Safari --focus-background
-peekaboo click --coords 420,180 --app Safari --focus-background
+peekaboo click --coords 420,180 --app Safari
 ```
 
 Use cases:
@@ -110,7 +110,7 @@ Use cases:
 - Clicking app-local coordinates without activating the target app
 - Keeping a long-running foreground workflow uninterrupted
 
-Currently, `hotkey` and `click` expose this mode. `hotkey` requires exactly one process target: `--app` or `--pid`. `click` requires `--app`, `--pid`, or snapshot process metadata.
+Currently, `hotkey` exposes this mode via `--focus-background`; `click` uses it by default. `hotkey` requires exactly one process target: `--app` or `--pid`. `click` requires `--app`, `--pid`, `--window-id`, or snapshot process metadata. Use `click --foreground` for focused foreground clicks.
 
 `--focus-background` is a delivery mode, not a focus mode. It cannot be combined with foreground focus timeout, retry, or Space-switching flags. `hotkey` also rejects `--snapshot` and `--no-auto-focus`; `click` can use snapshot metadata to resolve the target process. It requires Event Synthesizing access for the process that sends the event; `peekaboo permissions request-event-synthesizing` requests it for the selected bridge host by default, or for the local CLI when used with `--no-remote`. macOS does not acknowledge whether the target app handled a process-targeted event; Peekaboo reports that the event was sent to a live process after event-posting permission preflight.
 
@@ -130,7 +130,7 @@ Use cases:
 Sets how many times to retry focus operations (default: 3).
 
 ```bash
-peekaboo click "Save" --focus-retry-count 5
+peekaboo click "Save" --foreground --focus-retry-count 5
 ```
 
 Use cases:
@@ -142,7 +142,7 @@ Use cases:
 Forces Space switching even if window appears to be on current Space.
 
 ```bash
-peekaboo click "Login" --space-switch
+peekaboo click "Login" --foreground --space-switch
 ```
 
 Use cases:
@@ -256,11 +256,11 @@ Always start with `see` to establish a snapshot:
 ```bash
 # Good: Establishes snapshot with window tracking
 peekaboo see --app Safari
-peekaboo click "Login"
+peekaboo click "Login" --foreground
 peekaboo type "username"
 
 # Less reliable: No window tracking
-peekaboo click "Login" --coords 100,200
+peekaboo click "Login" --coords 100,200 --foreground
 ```
 
 ### 2. Let Peekaboo Handle Focus
@@ -273,7 +273,7 @@ peekaboo window focus --app Safari
 peekaboo click "Submit"
 
 # Do this instead (automatic focus):
-peekaboo click "Submit"
+peekaboo click "Submit" --foreground
 ```
 
 ### 3. Handle Space Switches Gracefully
@@ -282,7 +282,7 @@ Be aware that Space switching takes time:
 
 ```bash
 # For critical operations, increase timeout
-peekaboo click "Save" --focus-timeout-seconds 10
+peekaboo click "Save" --foreground --focus-timeout-seconds 10
 
 # Or move windows to avoid switching
 peekaboo type "Important data" --bring-to-current-space
@@ -296,7 +296,7 @@ Test your automation across different Space configurations:
 # Test with window on different Space
 peekaboo space move-window --app YourApp --to 2
 peekaboo see --app YourApp  # Should auto-switch
-peekaboo click "Test Button"
+peekaboo click "Test Button" --foreground
 ```
 
 ## Troubleshooting
@@ -307,14 +307,14 @@ This occurs when Space switching is disabled:
 
 ```bash
 # Solution 1: Allow Space switching (default)
-peekaboo click "Button"  # Will auto-switch
+peekaboo click "Button" --foreground  # Will auto-switch
 
 # Solution 2: Move window to current Space
-peekaboo click "Button" --bring-to-current-space
+peekaboo click "Button" --foreground --bring-to-current-space
 
 # Solution 3: Manually switch first
 peekaboo space switch --to 2
-peekaboo click "Button"
+peekaboo click "Button" --foreground
 ```
 
 ### "Window not found" Error
@@ -327,7 +327,7 @@ peekaboo list windows --app YourApp
 
 # For minimized windows, restore first
 peekaboo window restore --app YourApp
-peekaboo click "Button"
+peekaboo click "Button" --foreground
 ```
 
 ### "Focus timeout" Error
@@ -336,10 +336,10 @@ The window is taking too long to focus:
 
 ```bash
 # Increase timeout
-peekaboo click "Button" --focus-timeout-seconds 10
+peekaboo click "Button" --foreground --focus-timeout-seconds 10
 
 # Or increase retry count
-peekaboo click "Button" --focus-retry-count 5
+peekaboo click "Button" --foreground --focus-retry-count 5
 ```
 
 ### Focus Not Working
@@ -354,7 +354,7 @@ peekaboo window focus --app YourApp --verbose
 peekaboo list permissions
 
 # Try without focus (for testing)
-peekaboo click "Button" --no-auto-focus
+peekaboo click "Button" --foreground --no-auto-focus
 ```
 
 ## Implementation notes (internal)

--- a/docs/permissions.md
+++ b/docs/permissions.md
@@ -12,7 +12,7 @@ read_when:
 - **macOS 15.0+ (Sequoia)** – core automation APIs depend on Sequoia.
 - **Screen Recording (required)** – enables CGWindow capture and multi-app automation.
 - **Accessibility (recommended)** – improves window focus, menu interaction, and dialog control.
-- **Event Synthesizing (optional)** – enables background input delivery such as `hotkey --focus-background` and `click --focus-background` to post events to a target process without activating it.
+- **Event Synthesizing (optional)** – enables background input delivery such as `hotkey --focus-background` and default `click` delivery to post events to a target process without activating it.
 
 For build and runtime version details, see [platform-support.md](platform-support.md).
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -54,11 +54,11 @@ Each element has `id`, `role`, `label`, `frame`, and `actions`. Pass an `id` to 
 ## 4. Click and type
 
 ```bash
-peekaboo click "Address and search bar" --app Safari
+peekaboo click "Address and search bar" --app Safari --foreground
 peekaboo type "github.com/openclaw/Peekaboo" --return
 ```
 
-Coordinates also work: `peekaboo click --coords 480,120`. With app/window target flags, click coordinates are target-window-relative; add `--global-coords` for screen coordinates. See [automation.md](automation.md) for the full input vocabulary.
+Coordinates also work: `peekaboo click --coords 480,120 --foreground`. With app/window target flags, click coordinates are target-window-relative; add `--global-coords` for screen coordinates. See [automation.md](automation.md) for the full input vocabulary.
 
 ## 5. Run an agent
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -56,7 +56,7 @@ If you disable the `clipboard` tool via allow/deny filters, the injected DESKTOP
   - Any audio capture path (`AudioInputService`, voice command helpers) that transcribes speech through `PeekabooAIService`.  
   Disable by clearing `PEEKABOO_AI_PROVIDERS`, removing API keys, or adding these names to your deny list when running offline.
 - **Medium risk** – can manipulate apps or data  
-  - `click`, `type`, `press`, `scroll`, `swipe`, `drag`, `move`: can trigger actions in foreground apps. `click --focus-background` can send process-targeted mouse events to a background app.
+  - `click`, `type`, `press`, `scroll`, `swipe`, `drag`, `move`: can trigger actions in foreground apps. `click` now sends process-targeted mouse events by default when it can resolve a target process; use `click --foreground` for foreground mouse delivery.
   - `hotkey`: can trigger actions in foreground apps, or send process-targeted keyboard events to a background app when used with `--focus-background`. Background delivery still requires macOS event-posting access and does not prove the target app handled the event.
   - `window`, `app`, `menu_click`, `dock_launch`, `space`: can close apps, move windows, switch spaces.  
   - `permissions`: can prompt/alter macOS permissions flow; disable for locked-down sessions.  

--- a/docs/testing/tools.md
+++ b/docs/testing/tools.md
@@ -254,7 +254,7 @@ The following subsections spell out the concrete steps, required Playground surf
 - **Test cases**:
   1. Query-based click: `polter peekaboo -- click "Single Click"` (expect `Click` log + counter increment).
   2. ID-based click: `polter peekaboo -- click --on B1 --snapshot <id>` targeting `single-click-button`.
-  3. Coordinate click: `polter peekaboo -- click --coords 400,400` hitting the nested area.
+  3. Coordinate click: `polter peekaboo -- click --coords 400,400 --foreground` hitting the nested area.
   4. Coordinate validation: `polter peekaboo -- click --coords , --json-output` should fail with `VALIDATION_ERROR` (no crash).
   5. Error path: attempt to click disabled button and confirm descriptive `elementNotFound` guidance.
 - **Verification**: Playground counter increments, log file shows `[Click] Single click...` entries.


### PR DESCRIPTION
## Summary
- make `peekaboo click` default to background UIAutomation delivery for app/PID/window targets
- add `--foreground` for the previous global foreground click path and report `deliveryMode` in JSON
- update MCP `click` defaults/docs/tests so agents opt into foreground clicks only when needed

## Validation
- `autoreview --mode local` clean, no actionable findings
- `pnpm run lint`
- `pnpm run format`
- `pnpm run test:safe`
- `swift test --package-path Core/PeekabooCore --filter "Click tool"`
- `git diff --check`
- `swift build --package-path Apps/Playground`
- `xcodebuild -workspace Apps/Peekaboo.xcworkspace -scheme Playground -configuration Debug -destination 'platform=macOS,arch=arm64' -derivedDataPath /tmp/peekaboo-playground-dd build`

## Live Playground Check
- launched `/tmp/peekaboo-playground-dd/Build/Products/Debug/Playground.app`
- default `click --pid <playground-pid> --coords 975,210 --global-coords --json --no-remote` stayed background: frontmost app remained Ghostty
- local host TCC denies Screen Recording, Accessibility, and Event Synthesizing for the debug CLI, so the background path reached the expected Event Synthesizing permission gate instead of delivering the click
