### PR TITLE
docs(cli): clarify peekaboo tools lists MCP/agent catalog not CLI commands

### DIFF
--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Core/ToolsCommand.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Core/ToolsCommand.swift
@@ -6,14 +6,17 @@ import TachikomaMCP
 
 @MainActor
 struct ToolsCommand: OutputFormattable, RuntimeOptionsConfigurable {
-    private static let abstractText = "List available tools with filtering and display options"
-    private static let descriptionText = "Tools command for listing and filtering available tools"
+    private static let abstractText = "List the MCP/agent tool catalog (not CLI commands)"
+    private static let descriptionText = "Tools command for listing the MCP/agent tool catalog"
 
     static let commandDescription = CommandDescription(
         commandName: "tools",
         abstract: Self.abstractText,
         discussion: """
-        Display all available Peekaboo tools exposed to agents and the MCP server.
+        Display the Peekaboo MCP/agent tool catalog. These tools are exposed to agents
+        and `peekaboo mcp` clients (e.g. Codex, Claude Code, Cursor); they are not
+        runnable as top-level CLI subcommands. Run `peekaboo --help` for the CLI
+        command list.
 
         Examples:
           peekaboo tools                    # Show all tools

--- a/Apps/CLI/Tests/CoreCLITests/ToolsCommandTests.swift
+++ b/Apps/CLI/Tests/CoreCLITests/ToolsCommandTests.swift
@@ -10,7 +10,7 @@ struct ToolsCommandTests {
         let config = ToolsCommand.commandDescription
 
         #expect(config.commandName == "tools")
-        #expect(config.abstract == "List available tools with filtering and display options")
+        #expect(config.abstract == "List the MCP/agent tool catalog (not CLI commands)")
         #expect(config.discussion != nil)
         let discussion = config.discussion ?? ""
         #expect(discussion.contains("Examples:"))
@@ -55,7 +55,7 @@ struct ToolsCommandTests {
     @Test
     func `ToolsCommand description property`() throws {
         let command = try ToolsCommand.parse([])
-        #expect(command.description == "Tools command for listing and filtering available tools")
+        #expect(command.description == "Tools command for listing the MCP/agent tool catalog")
     }
 }
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 ### Changed
 - Documented background vs. foreground input delivery across the README, automation guide, quickstart, permissions, and interaction command docs.
-- Clarified that `peekaboo tools` lists the MCP/agent tool catalog (which is not the same as the CLI command set) in the command help, CLI reference, and tools docs page.
 
 ## [3.3.0] - 2026-06-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Changed
 - Documented background vs. foreground input delivery across the README, automation guide, quickstart, permissions, and interaction command docs.
+- Clarified that `peekaboo tools` lists the MCP/agent tool catalog (which is not the same as the CLI command set) in the command help, CLI reference, and tools docs page.
 
 ## [3.3.0] - 2026-06-01
 

--- a/docs/cli-command-reference.md
+++ b/docs/cli-command-reference.md
@@ -7,7 +7,7 @@ read_when:
 
 # CLI Command Reference
 
-Peekaboo’s CLI mirrors everything the agent can do. Commands share the same snapshot cache and most support `--json` (alias: `--json-output`) for scripting. Run `peekaboo` with no arguments to print the root help menu, and `peekaboo --version` at any time to see the embedded build/commit metadata that Poltergeist stamped into the binary.
+Peekaboo’s CLI covers most of what agents can do; a few capabilities (notably `browser` and `inspect_ui`) are currently exposed only as MCP/agent tools via `peekaboo mcp` and have no top-level CLI command. Run `peekaboo tools` to see the MCP/agent catalog and `peekaboo --help` for the CLI command list. Commands share the same snapshot cache and most support `--json` (alias: `--json-output`) for scripting. Run `peekaboo` with no arguments to print the root help menu, and `peekaboo --version` at any time to see the embedded build/commit metadata that Poltergeist stamped into the binary.
 
 Use `peekaboo <command> --help` for inline flag descriptions; this page links to the authoritative docs in `docs/commands/`.
 
@@ -17,7 +17,7 @@ Use `peekaboo <command> --help` for inline flag descriptions; this page links to
 - [`image`](commands/image.md) – Save raw PNG/JPG captures of screens, windows, or menu bar regions; supports `--analyze` prompts.
 - `capture` – Long-running capture. `capture live` (adaptive PNG frames) replaces watch; `capture video` ingests a video and samples frames. Outputs frames, contact sheet, metadata, optional MP4.
 - [`list`](commands/list.md) – Subcommands: `apps`, `windows`, `screens`, `menubar`, `permissions`.
-- [`tools`](commands/tools.md) – Filter native vs MCP tools; group by server or emit JSON summaries.
+- [`tools`](commands/tools.md) – List the MCP/agent tool catalog (not CLI commands); supports `--verbose` and `--json`.
 - [`completions`](commands/completions.md) – Generate shell-native completions for zsh, bash, and fish from Commander metadata.
 - [`run`](commands/run.md) – Execute `.peekaboo.json` scripts (`--output`, `--no-fail-fast`).
 - [`sleep`](commands/sleep.md) – Millisecond pauses between steps.

--- a/docs/commands/tools.md
+++ b/docs/commands/tools.md
@@ -1,5 +1,5 @@
 ---
-summary: 'Inspect native tooling via peekaboo tools'
+summary: 'List the MCP/agent tool catalog via peekaboo tools'
 read_when:
   - 'deciding which automation tool to call from agents or scripts'
   - 'debugging missing tool registrations'
@@ -7,17 +7,18 @@ read_when:
 
 # `peekaboo tools`
 
-`peekaboo tools` prints the authoritative native MCP tool catalog that `peekaboo mcp` exposes. The command hydrates the same native MCP tool set (Image, See, Click, Window, etc.) so you can audit what MCP clients will see without attaching a debugger.
+`peekaboo tools` prints the MCP/agent tool catalog that `peekaboo mcp` exposes (Image, See, Click, Window, Browser, Inspect UI, etc.). These names are the tools available to agents and MCP clients — they are **not** the same as top-level CLI subcommands. Run `peekaboo --help` for the CLI command list, or invoke MCP-only tools through `peekaboo mcp` / an attached MCP client.
 
 ## Key options
 | Flag | Description |
 | --- | --- |
 | `--no-sort` | Preserve registration order instead of alphabetizing every tool. |
+| `--verbose` | Include each tool's description alongside its name. |
 | `--json` | Emit `{tools:[…], count:n}` for machine parsing. |
 
 ## Implementation notes
 - The command and MCP server both use `MCPToolCatalog`, so tool additions only need to be registered once.
-- Filtering happens before formatting (`ToolFiltering.apply`), so allow/deny rules match MCP server behavior.
+- Allow/deny filtering happens before formatting (`ToolFiltering.apply`), so the output matches MCP server behavior.
 - Input-strategy availability filtering also runs before formatting, so action-only tools are hidden when the current policy cannot support them.
 - The command runs locally by default because it only reports the static native catalog; pass `--bridge-socket <path>` only when you need to inspect a specific bridge host.
 - Because the command implements `RuntimeOptionsConfigurable`, it respects global `--json`/`--verbose` flags even when invoked from other commands (e.g., `peekaboo learn` can embed the summaries verbatim).


### PR DESCRIPTION
Closes #172.

## Summary

`peekaboo tools` lists the MCP/agent tool catalog (e.g. `browser`, `inspect_ui`), not top-level CLI subcommands. The current command help and CLI reference docs describe filtering / mirroring that doesn't match real behavior, so users following the docs land on `peekaboo browser status --json` and hit `Unknown command 'browser'`. This PR makes the wording match what the command actually does.

## Changes

- `ToolsCommand` — abstract claimed "filtering and display options" but the only flag is `--no-sort`; replaced with a description that names the catalog and disambiguates it from the CLI command set. Discussion now explicitly directs readers to `peekaboo --help` for CLI commands.
- `docs/cli-command-reference.md` — "Peekaboo's CLI mirrors everything the agent can do" was load-bearing for the bug in #172; rewritten to flag the MCP-only tools (`browser`, `inspect_ui`) and point readers at the right entry points. The `tools` row also no longer advertises a non-existent "Filter native vs MCP tools" capability.
- `docs/commands/tools.md` — overview clarifies MCP/agent framing, names a couple of MCP-only tools explicitly, and the Key options table now lists `--verbose` (already supported via `RuntimeOptionsConfigurable`).
- `ToolsCommandTests` — updated abstract/description assertions to match the new strings.

## Why

Filed by @coygeek in #172 with source-level repro (matching `ToolsCommand` / `MCPToolCatalog` / `CommandRegistry` against actual CLI behavior). The behavior is consistent — the docs and command-help text were misleading. This is the minimum surface change to make the boundary between "MCP/agent tools" and "CLI commands" legible.

## Validation

- `swift build --package-path Apps/CLI -c debug` ✅ (36.66s)
- `swift test --package-path Apps/CLI --filter ToolsCommand` ✅ (9 tests, including the updated abstract/description assertions)
- `swiftlint lint Apps/CLI/Sources/PeekabooCLI/Commands/Core/ToolsCommand.swift` ✅ (clean; only version-mismatch warning vs `.swiftlint.yml`)
- `swiftformat` not run locally — tool not installed on this box; the touched files are within the existing 4-space / 120-col conventions.

No functional change. Output of `peekaboo tools` (and its `--json` payload) is unchanged.
