### PR TITLE
fix(scroll): report unsupported targetless action scroll

### DIFF
--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/ScrollService.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/ScrollService.swift
@@ -109,7 +109,7 @@ public final class ScrollService {
         guard let target = request.target?.trimmingCharacters(in: .whitespacesAndNewlines),
               !target.isEmpty
         else {
-            throw ActionInputError.unsupported(.missingElement)
+            throw ActionInputError.unsupported(.actionUnsupported)
         }
         let pages = Self.actionScrollPages(amount: request.amount, strategy: strategy)
 

--- a/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/ScrollServiceTargetResolutionTests.swift
+++ b/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/ScrollServiceTargetResolutionTests.swift
@@ -105,6 +105,29 @@ struct ScrollServiceTargetResolutionTests {
         #expect(ScrollService.actionScrollPages(amount: -3, strategy: .actionOnly) == 3)
         #expect(ScrollService.actionScrollPages(amount: 0, strategy: .actionOnly) == 1)
     }
+
+    @Test
+    @MainActor
+    func `action-only scroll without target reports unsupported action`() async {
+        let service = ScrollService(
+            snapshotManager: InMemorySnapshotManager(),
+            inputPolicy: UIInputPolicy(defaultStrategy: .actionOnly))
+
+        do {
+            try await service.scroll(ScrollRequest(
+                direction: .down,
+                amount: 1,
+                target: "   ",
+                smooth: false,
+                delay: 0,
+                snapshotId: nil))
+            Issue.record("Expected unsupported action error for targetless action-only scroll.")
+        } catch let error as ActionInputError {
+            #expect(error == .unsupported(.actionUnsupported))
+        } catch {
+            Issue.record("Unexpected error: \(error)")
+        }
+    }
 }
 
 @MainActor


### PR DESCRIPTION
## Summary

Fixes #177.

Action-only scroll now reports an empty or whitespace-only target as `.unsupported(.actionUnsupported)` instead of `.missingElement`, since no action target was supplied for the action-only path to invoke.

## Verification

Run in `~/Desktop/peekaboo-pr-scroll-action` on June 5, 2026.

```console
$ swift test --package-path Core/PeekabooAutomationKit --no-parallel --filter ScrollServiceTargetResolutionTests
Suite ScrollServiceTargetResolutionTests passed
Test run with 6 tests in 1 suite passed

$ swiftlint lint --config .swiftlint.yml Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/ScrollService.swift Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/ScrollServiceTargetResolutionTests.swift
Done linting! Found 0 violations, 0 serious in 2 files.

$ swiftformat Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/ScrollService.swift Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/ScrollServiceTargetResolutionTests.swift
SwiftFormat completed in 0.04s.
0/2 files formatted.
```

Additional Tart VM runtime proof against this PR branch. The throwaway SwiftPM executable depends on the PR worktree's `Core/PeekabooAutomationKit` product and calls `ScrollService.scroll` with `UIInputPolicy(defaultStrategy: .actionOnly)` and a whitespace-only target.

```console
$ sw_vers
ProductName:     macOS
ProductVersion:  15.7.3
BuildVersion:    24G419

$ xcrun swift --version
swift-driver version: 1.148.6 Apple Swift version 6.3.1 (swiftlang-6.3.1.1.2 clang-2100.0.123.102)
Target: arm64-apple-macosx15.0

$ cd ~/peekaboo-proof-scroll && xcrun swift run ScrollProof
Build of product 'ScrollProof' complete! (0.16s)
scroll-action-only-proof=PASSED error=unsupported(PeekabooAutomationKit.ActionInputUnsupportedReason.actionUnsupported)
```
