### PR TITLE
fix(process): preserve generic interaction aliases

### DIFF
--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/System/ProcessService+ParameterParsing.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/System/ProcessService+ParameterParsing.swift
@@ -118,7 +118,7 @@ extension ProcessService {
         } else if let menu = dict["menu"], let item = dict["item"] {
             menuItems = [menu, dict["submenu"], item].compactMap(\.self)
         } else if let menu = dict["menu"] {
-            menuItems = [menu]
+            menuItems = menu.split(separator: ">").map { $0.trimmingCharacters(in: .whitespaces) }
         } else {
             return nil
         }

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/System/ProcessService+ParameterParsing.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/System/ProcessService+ParameterParsing.swift
@@ -81,8 +81,8 @@ extension ProcessService {
             text: text,
             app: dict["app"],
             field: dict["field"],
-            clearFirst: dict["clear-first"].flatMap { Bool($0) },
-            pressEnter: dict["press-enter"].flatMap { Bool($0) }))
+            clearFirst: self.boolValue(from: dict, keys: ["clear-first", "clearFirst", "clear_first"]),
+            pressEnter: self.boolValue(from: dict, keys: ["press-enter", "pressEnter", "press_enter"])))
     }
 
     private func typedScrollParameters(from dict: [String: String]) -> ProcessCommandParameters.ScrollParameters {
@@ -101,6 +101,9 @@ extension ProcessService {
         if dict["control"] == "true" || dict["ctrl"] == "true" { modifiers.append("control") }
         if dict["option"] == "true" || dict["alt"] == "true" { modifiers.append("option") }
         if dict["fn"] == "true" || dict["function"] == "true" { modifiers.append("function") }
+        if let modifierList = dict["modifiers"] {
+            modifiers.append(contentsOf: self.parseModifierList(modifierList))
+        }
 
         return .hotkey(ProcessCommandParameters.HotkeyParameters(
             key: key,
@@ -109,8 +112,16 @@ extension ProcessService {
     }
 
     private func typedMenuParameters(from dict: [String: String]) -> ProcessCommandParameters? {
-        guard let path = dict["path"] ?? dict["menu"] else { return nil }
-        let menuItems = path.split(separator: ">").map { $0.trimmingCharacters(in: .whitespaces) }
+        let menuItems: [String]
+        if let path = dict["path"] {
+            menuItems = path.split(separator: ">").map { $0.trimmingCharacters(in: .whitespaces) }
+        } else if let menu = dict["menu"], let item = dict["item"] {
+            menuItems = [menu, dict["submenu"], item].compactMap(\.self)
+        } else if let menu = dict["menu"] {
+            menuItems = [menu]
+        } else {
+            return nil
+        }
         return .menuClick(ProcessCommandParameters.MenuClickParameters(
             menuPath: menuItems,
             app: dict["app"]))
@@ -157,6 +168,9 @@ extension ProcessService {
         if dict["control"] == "true" || dict["ctrl"] == "true" { modifiers.append("control") }
         if dict["option"] == "true" || dict["alt"] == "true" { modifiers.append("option") }
         if dict["fn"] == "true" || dict["function"] == "true" { modifiers.append("function") }
+        if let modifierList = dict["modifiers"] {
+            modifiers.append(contentsOf: self.parseModifierList(modifierList))
+        }
 
         return .drag(ProcessCommandParameters.DragParameters(
             fromX: fromX,
@@ -170,6 +184,21 @@ extension ProcessService {
     private func typedSleepParameters(from dict: [String: String]) -> ProcessCommandParameters.SleepParameters {
         let duration = dict["duration"].flatMap { Double($0) } ?? 1.0
         return ProcessCommandParameters.SleepParameters(duration: duration)
+    }
+
+    private func parseModifierList(_ value: String) -> [String] {
+        value.split(separator: ",")
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+    }
+
+    private func boolValue(from dict: [String: String], keys: [String]) -> Bool? {
+        for key in keys {
+            if let value = dict[key].flatMap(Bool.init) {
+                return value
+            }
+        }
+        return nil
     }
 
     private func typedDockParameters(from dict: [String: String]) -> ProcessCommandParameters.DockParameters {

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/GestureService.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/GestureService.swift
@@ -1,4 +1,5 @@
 @preconcurrency import AXorcist
+import CoreGraphics
 import Foundation
 import os.log
 import PeekabooFoundation
@@ -7,6 +8,12 @@ import PeekabooFoundation
 @MainActor
 public final class GestureService {
     private let logger = Logger(subsystem: "boo.peekaboo.core", category: "GestureService")
+
+    struct HeldModifierKey: Equatable {
+        let name: String
+        let keyCode: CGKeyCode
+        let flag: CGEventFlags
+    }
 
     public init() {}
 
@@ -64,6 +71,13 @@ public final class GestureService {
             duration: request.duration,
             steps: request.steps,
             profile: request.profile)
+        let modifierKeys = Self.heldModifierKeys(for: request.modifiers)
+        let modifierEvents = try self.makeModifierEvents(for: modifierKeys)
+        modifierEvents.down.forEach { $0.post(tap: .cghidEventTap) }
+        defer {
+            modifierEvents.up.forEach { $0.post(tap: .cghidEventTap) }
+        }
+
         try await self.performDrag(path: path, start: request.from)
 
         self.logger.debug("Drag completed")
@@ -152,6 +166,65 @@ public final class GestureService {
         let steps = max(path.points.count, 2)
         let delay = Double(path.duration) / 1000.0 / Double(steps)
         try InputDriver.drag(from: start, to: endPoint, button: .left, steps: steps, interStepDelay: delay)
+    }
+
+    private func makeModifierEvents(for keys: [HeldModifierKey]) throws -> (down: [CGEvent], up: [CGEvent]) {
+        guard !keys.isEmpty else { return ([], []) }
+
+        let source = CGEventSource(stateID: .hidSystemState)
+        var activeFlags: CGEventFlags = []
+        let downEvents: [CGEvent] = try keys.map { key in
+            activeFlags.insert(key.flag)
+            return try Self.makeModifierEvent(source: source, key: key, keyDown: true, flags: activeFlags)
+        }
+
+        let upEvents: [CGEvent] = try keys.reversed().map { key in
+            activeFlags.remove(key.flag)
+            return try Self.makeModifierEvent(source: source, key: key, keyDown: false, flags: activeFlags)
+        }
+
+        return (downEvents, upEvents)
+    }
+
+    private static func makeModifierEvent(
+        source: CGEventSource?,
+        key: HeldModifierKey,
+        keyDown: Bool,
+        flags: CGEventFlags) throws -> CGEvent
+    {
+        guard let event = CGEvent(keyboardEventSource: source, virtualKey: key.keyCode, keyDown: keyDown) else {
+            throw PeekabooError.invalidInput("Could not create \(key.name) modifier event")
+        }
+        event.flags = flags
+        return event
+    }
+
+    static func heldModifierKeys(for modifiers: String?) -> [HeldModifierKey] {
+        guard let modifiers else { return [] }
+
+        var seen = Set<String>()
+        return modifiers
+            .split(separator: ",")
+            .compactMap { rawModifier -> HeldModifierKey? in
+                let rawName = rawModifier.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+                let key: HeldModifierKey? = switch rawName {
+                case "command", "cmd":
+                    HeldModifierKey(name: "command", keyCode: 0x37, flag: .maskCommand)
+                case "shift":
+                    HeldModifierKey(name: "shift", keyCode: 0x38, flag: .maskShift)
+                case "option", "alt":
+                    HeldModifierKey(name: "option", keyCode: 0x3A, flag: .maskAlternate)
+                case "control", "ctrl":
+                    HeldModifierKey(name: "control", keyCode: 0x3B, flag: .maskControl)
+                case "function", "fn":
+                    HeldModifierKey(name: "function", keyCode: 0x3F, flag: .maskSecondaryFn)
+                default:
+                    nil
+                }
+                guard let key, !seen.contains(key.name) else { return nil }
+                seen.insert(key.name)
+                return key
+            }
     }
 
     private func playPath(_ points: [CGPoint], duration: Int) async throws {

--- a/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/GestureServiceTests.swift
+++ b/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/GestureServiceTests.swift
@@ -1,0 +1,16 @@
+import CoreGraphics
+import XCTest
+@testable import PeekabooAutomationKit
+
+@MainActor
+final class GestureServiceTests: XCTestCase {
+    func testDragModifierKeysNormalizeAliasesAndIgnoreUnknownValues() {
+        let keys = GestureService.heldModifierKeys(for: " command, cmd, shift, alt, ctrl, fn, unknown ")
+
+        XCTAssertEqual(keys.map(\.name), ["command", "shift", "option", "control", "function"])
+        XCTAssertEqual(keys.map(\.keyCode), [0x37, 0x38, 0x3A, 0x3B, 0x3F])
+        XCTAssertEqual(
+            keys.map(\.flag),
+            [.maskCommand, .maskShift, .maskAlternate, .maskControl, .maskSecondaryFn])
+    }
+}

--- a/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/ProcessServiceInteractionScriptTests.swift
+++ b/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/ProcessServiceInteractionScriptTests.swift
@@ -33,6 +33,30 @@ final class ProcessServiceInteractionScriptTests: XCTestCase {
         ])
     }
 
+    func testMenuGenericParametersPreserveMenuPathWithoutItem() async throws {
+        let menuService = RecordingMenuService()
+        let processService = ProcessService(
+            applicationService: UnusedApplicationService(),
+            screenCaptureService: UnusedScreenCaptureService(),
+            snapshotManager: UnusedSnapshotManager(),
+            uiAutomationService: UnusedUIAutomationService(),
+            windowManagementService: UnusedWindowManagementService(),
+            menuService: menuService,
+            dockService: UnusedDockService(),
+            clipboardService: UnusedClipboardService())
+
+        _ = try await processService.executeStep(
+            ScriptStep(stepId: "menu", comment: nil, command: "menu", params: .generic([
+                "app": "Finder",
+                "menu": "File > New Finder Window",
+            ])),
+            snapshotId: nil)
+
+        XCTAssertEqual(menuService.clicks, [
+            RecordingMenuService.Click(app: "Finder", itemPath: "File > New Finder Window"),
+        ])
+    }
+
     func testHotkeyGenericParametersParseModifiersList() async throws {
         let automation = RecordingInteractionUIAutomationService()
         let processService = ProcessService(

--- a/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/ProcessServiceInteractionScriptTests.swift
+++ b/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/ProcessServiceInteractionScriptTests.swift
@@ -8,8 +8,86 @@ import XCTest
 @available(macOS 14.0, *)
 @MainActor
 final class ProcessServiceInteractionScriptTests: XCTestCase {
+    func testMenuGenericParametersCombineMenuAndItemPath() async throws {
+        let menuService = RecordingMenuService()
+        let processService = ProcessService(
+            applicationService: UnusedApplicationService(),
+            screenCaptureService: UnusedScreenCaptureService(),
+            snapshotManager: UnusedSnapshotManager(),
+            uiAutomationService: UnusedUIAutomationService(),
+            windowManagementService: UnusedWindowManagementService(),
+            menuService: menuService,
+            dockService: UnusedDockService(),
+            clipboardService: UnusedClipboardService())
+
+        _ = try await processService.executeStep(
+            ScriptStep(stepId: "menu", comment: nil, command: "menu", params: .generic([
+                "app": "Finder",
+                "menu": "File",
+                "item": "New Finder Window",
+            ])),
+            snapshotId: nil)
+
+        XCTAssertEqual(menuService.clicks, [
+            RecordingMenuService.Click(app: "Finder", itemPath: "File > New Finder Window"),
+        ])
+    }
+
+    func testHotkeyGenericParametersParseModifiersList() async throws {
+        let automation = RecordingInteractionUIAutomationService()
+        let processService = ProcessService(
+            applicationService: UnusedApplicationService(),
+            screenCaptureService: UnusedScreenCaptureService(),
+            snapshotManager: UnusedSnapshotManager(),
+            uiAutomationService: automation,
+            windowManagementService: UnusedWindowManagementService(),
+            menuService: UnusedMenuService(),
+            dockService: UnusedDockService(),
+            clipboardService: UnusedClipboardService())
+
+        _ = try await processService.executeStep(
+            ScriptStep(stepId: "hotkey", comment: nil, command: "hotkey", params: .generic([
+                "key": "p",
+                "modifiers": "command,shift",
+            ])),
+            snapshotId: nil)
+
+        XCTAssertEqual(automation.hotkeys, ["cmd,shift,p"])
+    }
+
+    func testTypeGenericParametersParseCamelCaseControlFlags() async throws {
+        let automation = RecordingInteractionUIAutomationService()
+        let processService = ProcessService(
+            applicationService: UnusedApplicationService(),
+            screenCaptureService: UnusedScreenCaptureService(),
+            snapshotManager: UnusedSnapshotManager(),
+            uiAutomationService: automation,
+            windowManagementService: UnusedWindowManagementService(),
+            menuService: UnusedMenuService(),
+            dockService: UnusedDockService(),
+            clipboardService: UnusedClipboardService())
+
+        _ = try await processService.executeStep(
+            ScriptStep(stepId: "type", comment: nil, command: "type", params: .generic([
+                "text": "hello",
+                "field": "Search",
+                "clearFirst": "true",
+                "pressEnter": "true",
+            ])),
+            snapshotId: "snapshot-1")
+
+        XCTAssertEqual(automation.typedText, [
+            RecordingInteractionUIAutomationService.TypeCall(
+                text: "hello",
+                target: "Search",
+                clearExisting: true,
+                snapshotId: "snapshot-1"),
+        ])
+        XCTAssertEqual(automation.typeActionCounts, [1])
+    }
+
     func testSwipeWithoutExplicitStartUsesPrimaryScreenServiceCenter() async throws {
-        let automation = RecordingSwipeUIAutomationService()
+        let automation = RecordingInteractionUIAutomationService()
         let processService = ProcessService(
             applicationService: UnusedApplicationService(),
             screenCaptureService: UnusedScreenCaptureService(),
@@ -33,6 +111,91 @@ final class ProcessServiceInteractionScriptTests: XCTestCase {
         XCTAssertEqual(automation.swipes[0].from, CGPoint(x: 400, y: 250))
         XCTAssertEqual(automation.swipes[0].to, CGPoint(x: 360, y: 250))
         XCTAssertEqual(automation.swipes[0].duration, 250)
+    }
+
+    func testDragGenericParametersParseModifiersList() async throws {
+        let automation = RecordingInteractionUIAutomationService()
+        let processService = ProcessService(
+            applicationService: UnusedApplicationService(),
+            screenCaptureService: UnusedScreenCaptureService(),
+            snapshotManager: UnusedSnapshotManager(),
+            uiAutomationService: automation,
+            windowManagementService: UnusedWindowManagementService(),
+            menuService: UnusedMenuService(),
+            dockService: UnusedDockService(),
+            clipboardService: UnusedClipboardService())
+
+        _ = try await processService.executeStep(
+            ScriptStep(stepId: "drag", comment: nil, command: "drag", params: .generic([
+                "from-x": "10",
+                "from-y": "20",
+                "to-x": "30",
+                "to-y": "40",
+                "modifiers": "command,shift",
+            ])),
+            snapshotId: nil)
+
+        XCTAssertEqual(automation.drags, [
+            RecordingInteractionUIAutomationService.DragCall(
+                from: CGPoint(x: 10, y: 20),
+                to: CGPoint(x: 30, y: 40),
+                modifiers: "cmd,shift"),
+        ])
+    }
+}
+
+@available(macOS 14.0, *)
+@MainActor
+private final class RecordingMenuService: MenuServiceProtocol {
+    struct Click: Equatable {
+        let app: String
+        let itemPath: String
+    }
+
+    var clicks: [Click] = []
+
+    func clickMenuItem(app: String, itemPath: String) async throws {
+        self.clicks.append(Click(app: app, itemPath: itemPath))
+    }
+
+    func listMenus(for _: String) async throws -> MenuStructure {
+        fatalError("unused")
+    }
+
+    func listFrontmostMenus() async throws -> MenuStructure {
+        fatalError("unused")
+    }
+
+    func clickMenuItemByName(app _: String, itemName _: String) async throws {
+        fatalError("unused")
+    }
+
+    func clickMenuExtra(title _: String) async throws {
+        fatalError("unused")
+    }
+
+    func isMenuExtraMenuOpen(title _: String, ownerPID _: pid_t?) async throws -> Bool {
+        fatalError("unused")
+    }
+
+    func menuExtraOpenMenuFrame(title _: String, ownerPID _: pid_t?) async throws -> CGRect? {
+        fatalError("unused")
+    }
+
+    func listMenuExtras() async throws -> [MenuExtraInfo] {
+        fatalError("unused")
+    }
+
+    func listMenuBarItems(includeRaw _: Bool) async throws -> [MenuBarItemInfo] {
+        fatalError("unused")
+    }
+
+    func clickMenuBarItem(named _: String) async throws -> ClickResult {
+        fatalError("unused")
+    }
+
+    func clickMenuBarItem(at _: Int) async throws -> ClickResult {
+        fatalError("unused")
     }
 }
 
@@ -95,7 +258,7 @@ private final class StaticScreenService: ScreenServiceProtocol {
 
 @available(macOS 14.0, *)
 @MainActor
-private final class RecordingSwipeUIAutomationService: UIAutomationServiceProtocol {
+private final class RecordingInteractionUIAutomationService: UIAutomationServiceProtocol {
     struct SwipeCall {
         let from: CGPoint
         let to: CGPoint
@@ -103,6 +266,46 @@ private final class RecordingSwipeUIAutomationService: UIAutomationServiceProtoc
     }
 
     var swipes: [SwipeCall] = []
+    var hotkeys: [String] = []
+    var typedText: [TypeCall] = []
+    var typeActionCounts: [Int] = []
+    var drags: [DragCall] = []
+
+    struct TypeCall: Equatable {
+        let text: String
+        let target: String?
+        let clearExisting: Bool
+        let snapshotId: String?
+    }
+
+    struct DragCall: Equatable {
+        let from: CGPoint
+        let to: CGPoint
+        let modifiers: String?
+    }
+
+    func hotkey(keys: String, holdDuration _: Int) async throws {
+        self.hotkeys.append(keys)
+    }
+
+    func type(text: String, target: String?, clearExisting: Bool, typingDelay _: Int, snapshotId: String?)
+        async throws
+    {
+        self.typedText.append(TypeCall(
+            text: text,
+            target: target,
+            clearExisting: clearExisting,
+            snapshotId: snapshotId))
+    }
+
+    func typeActions(
+        _ actions: [TypeAction],
+        cadence _: TypingCadence,
+        snapshotId _: String?) async throws -> TypeResult
+    {
+        self.typeActionCounts.append(actions.count)
+        return TypeResult(totalCharacters: 0, keyPresses: actions.count)
+    }
 
     func swipe(from: CGPoint, to: CGPoint, duration: Int, steps _: Int, profile _: MouseMovementProfile) async throws {
         self.swipes.append(SwipeCall(from: from, to: to, duration: duration))
@@ -118,21 +321,7 @@ private final class RecordingSwipeUIAutomationService: UIAutomationServiceProtoc
         fatalError("unused")
     }
 
-    func type(text _: String, target _: String?, clearExisting _: Bool, typingDelay _: Int, snapshotId _: String?)
-        async throws
-    {
-        fatalError("unused")
-    }
-
-    func typeActions(_: [TypeAction], cadence _: TypingCadence, snapshotId _: String?) async throws -> TypeResult {
-        fatalError("unused")
-    }
-
     func scroll(_: ScrollRequest) async throws {
-        fatalError("unused")
-    }
-
-    func hotkey(keys _: String, holdDuration _: Int) async throws {
         fatalError("unused")
     }
 
@@ -146,8 +335,11 @@ private final class RecordingSwipeUIAutomationService: UIAutomationServiceProtoc
         fatalError("unused")
     }
 
-    func drag(_: DragOperationRequest) async throws {
-        fatalError("unused")
+    func drag(_ request: DragOperationRequest) async throws {
+        self.drags.append(DragCall(
+            from: request.from,
+            to: request.to,
+            modifiers: request.modifiers))
     }
 
     func moveMouse(to _: CGPoint, duration _: Int, steps _: Int, profile _: MouseMovementProfile) async throws {


### PR DESCRIPTION
## Summary

Fixes #175.

Generic process-step normalization now preserves the aliases that the lower-level parser already understands:

- `menu` + optional `submenu` + `item` becomes the intended menu path.
- existing `menu: "File > Item"` path behavior is preserved when `item` is absent.
- comma-separated `modifiers` are parsed for `hotkey` and `drag`.
- `clearFirst` / `clear_first` and `pressEnter` / `press_enter` are accepted for type steps.

Follow-up from ClawSweeper: drag modifiers are now applied in the production `GestureService.drag` path by holding the requested modifier keys around the low-level drag operation. A later compatibility follow-up preserves the old `menu`-as-path behavior and adds a regression test for `menu: "File > New Finder Window"`.

## Verification

Run in `~/Desktop/peekaboo-pr-process-params` on June 5, 2026.

```console
$ swift test --package-path Core/PeekabooAutomationKit --no-parallel --filter ProcessServiceInteractionScriptTests
Test Suite 'ProcessServiceInteractionScriptTests' passed
Executed 6 tests, with 0 failures (0 unexpected)

$ swiftformat Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/System/ProcessService+ParameterParsing.swift Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/ProcessServiceInteractionScriptTests.swift
SwiftFormat completed in 0.04s.
0/2 files formatted.

$ swiftlint lint --config .swiftlint.yml Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/System/ProcessService+ParameterParsing.swift Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/ProcessServiceInteractionScriptTests.swift
Done linting! Found 0 violations, 0 serious in 2 files.

$ swift test --package-path Core/PeekabooAutomationKit --no-parallel --filter 'ProcessServiceInteractionScriptTests|GestureServiceTests'
Test Suite 'GestureServiceTests' passed
Test Suite 'ProcessServiceInteractionScriptTests' passed
Executed 7 tests, with 0 failures (0 unexpected)
```

Additional Tart VM process-runtime proof against this PR branch from before the menu-path compatibility follow-up. The throwaway SwiftPM executable depends on the PR worktree's `Core/PeekabooAutomationKit` and calls production `ProcessService.executeStep` with `.generic` process steps. Recording implementations of the public service protocols capture the calls emitted by the production normalization and dispatch path; this is not an XCTest run.

```console
$ sw_vers
ProductName:     macOS
ProductVersion:  15.7.3
BuildVersion:    24G419

$ xcrun swift --version
swift-driver version: 1.148.6 Apple Swift version 6.3.1 (swiftlang-6.3.1.1.2 clang-2100.0.123.102)
Target: arm64-apple-macosx15.0

$ cd ~/peekaboo-proof-process && xcrun swift run ProcessAliasProof
Build of product 'ProcessAliasProof' complete! (0.16s)
process-menu-alias-proof=PASSED clicks=[(app: Finder, itemPath: File > New Finder Window)]
process-hotkey-modifiers-proof=PASSED hotkeys=["cmd,shift,p"]
process-type-camelcase-proof=PASSED typed=[(text: hello, target: Search, clearExisting: true, snapshotId: snapshot-1)] enterActions=[1]
process-drag-modifiers-proof=PASSED drags=[(from: (10.0, 20.0), to: (30.0, 40.0), modifiers: cmd,shift)]
```
