### PR TITLE
fix(clipboard): validate alternate text payloads

### DIFF
--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/System/ClipboardService.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/System/ClipboardService.swift
@@ -155,15 +155,14 @@ public final class ClipboardService: ClipboardServiceProtocol {
             throw ClipboardServiceError.writeFailed("No representations provided.")
         }
 
-        let totalSize = request.representations.reduce(0) { $0 + $1.data.count }
+        let totalSize = request.representations.reduce(0) { $0 + $1.data.count } +
+            (request.alsoText?.utf8.count ?? 0)
         if !request.allowLarge, totalSize > self.sizeLimit {
             throw ClipboardServiceError.sizeExceeded(current: totalSize, limit: self.sizeLimit)
         }
 
         var types = request.representations.map { NSPasteboard.PasteboardType($0.utiIdentifier) }
-        let includesTextType = request.representations.contains(where: {
-            $0.utiIdentifier == UTType.plainText.identifier || $0.utiIdentifier == UTType.utf8PlainText.identifier
-        })
+        let includesTextType = request.representations.contains(where: Self.isPlainTextRepresentation)
         if request.alsoText != nil || includesTextType {
             if !types.contains(.string) {
                 types.append(.string)
@@ -180,10 +179,8 @@ public final class ClipboardService: ClipboardServiceProtocol {
 
         if let alsoText = request.alsoText {
             self.pasteboard.setString(alsoText, forType: .string)
-        } else if let representation = request.representations.first(where: {
-            $0.utiIdentifier == UTType.plainText.identifier || $0.utiIdentifier == UTType.utf8PlainText.identifier
-        }),
-            let fallbackText = String(data: representation.data, encoding: .utf8)
+        } else if let representation = request.representations.first(where: Self.isPlainTextRepresentation),
+                  let fallbackText = String(data: representation.data, encoding: .utf8)
         {
             self.pasteboard.setString(fallbackText, forType: .string)
         }
@@ -191,7 +188,7 @@ public final class ClipboardService: ClipboardServiceProtocol {
         let primary = request.representations.first!
         let preview: String? = if let text = request.alsoText {
             Self.makePreview(text)
-        } else if primary.utiIdentifier == UTType.plainText.identifier,
+        } else if Self.isPlainTextRepresentation(primary),
                   let string = String(data: primary.data, encoding: .utf8)
         {
             Self.makePreview(string)
@@ -289,6 +286,11 @@ public final class ClipboardService: ClipboardServiceProtocol {
         }
 
         return reps
+    }
+
+    private static func isPlainTextRepresentation(_ representation: ClipboardRepresentation) -> Bool {
+        representation.utiIdentifier == UTType.plainText.identifier ||
+            representation.utiIdentifier == UTType.utf8PlainText.identifier
     }
 
     private static func makePreview(_ text: String) -> String {

--- a/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/ClipboardWriteRequestTests.swift
+++ b/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/ClipboardWriteRequestTests.swift
@@ -14,4 +14,33 @@ final class ClipboardWriteRequestTests: XCTestCase {
         XCTAssertTrue(types.contains(NSPasteboard.PasteboardType.string.rawValue))
         XCTAssertEqual(Set(types).count, types.count)
     }
+
+    func testSetReturnsPreviewForUTF8PlainTextRepresentation() throws {
+        let pasteboard = NSPasteboard.withUniqueName()
+        let clipboard = ClipboardService(pasteboard: pasteboard)
+        let request = ClipboardWriteRequest(representations: [
+            ClipboardRepresentation(utiIdentifier: UTType.utf8PlainText.identifier, data: Data("hello".utf8)),
+        ])
+
+        let result = try clipboard.set(request)
+
+        XCTAssertEqual(result.textPreview, "hello")
+    }
+
+    func testSetCountsAlsoTextAgainstLargePayloadLimit() throws {
+        let pasteboard = NSPasteboard.withUniqueName()
+        let clipboard = ClipboardService(pasteboard: pasteboard, sizeLimit: 4)
+        let request = ClipboardWriteRequest(
+            representations: [
+                ClipboardRepresentation(utiIdentifier: "com.example.payload", data: Data([0x01])),
+            ],
+            alsoText: "oversized")
+
+        XCTAssertThrowsError(try clipboard.set(request)) { error in
+            guard case let ClipboardServiceError.sizeExceeded(current, limit) = error else {
+                return XCTFail("Expected sizeExceeded, got \(error)")
+            }
+            XCTAssertGreaterThan(current, limit)
+        }
+    }
 }

--- a/docs/clipboard.md
+++ b/docs/clipboard.md
@@ -16,7 +16,7 @@ Goal: add a single `clipboard` tool (CLI + MCP) that handles text, images, files
 - Files: accept a file path; write as `public.file-url`.
 - Raw: accept `--data-base64` plus `--uti` to write arbitrary pasteboard types.
 - Slots: `save`/`restore` snapshot the current pasteboard (default slot `0`; allow named slots).
-- Size guard: warn and block writes over 10 MB unless `--allow-large` is set.
+- Size guard: warn and block writes over 10 MB unless `--allow-large` is set; count every representation plus any `--also-text` companion text.
 - Safety: never set Trimmy’s marker type; only requested UTIs.
 
 ## CLI syntax (`peekaboo clipboard …`)

--- a/docs/commands/clipboard.md
+++ b/docs/commands/clipboard.md
@@ -55,7 +55,7 @@ peekaboo clipboard restore --slot original
 - File paths for `--file-path`, `--image-path`, and `--output` accept `~/...`.
 - Slot saves are stored in a dedicated named pasteboard so they work across separate `peekaboo clipboard` invocations.
 - `restore` removes the saved slot after applying it to avoid leaving clipboard snapshots around indefinitely.
-- Size guard: writes larger than 10 MB require `--allow-large`.
+- Size guard: writes larger than 10 MB require `--allow-large`; the guard counts all representations plus any `--also-text` companion text.
 - `--text` writes both `public.plain-text` and `.string` (`public.utf8-plain-text`) for compatibility.
 - `--verify` reads back each representation written and compares payloads (text is normalized for line endings).
 


### PR DESCRIPTION
## Summary

Fixes #176.

`ClipboardService.set(_:)` now:

- includes `alsoText` bytes in the large-payload guard.
- treats `public.utf8-plain-text` as a plain-text representation for `.string` fallback and result preview.

## Verification

Run in `~/Desktop/peekaboo-pr-clipboard` on June 5, 2026.

```console
$ swift test --package-path Core/PeekabooAutomationKit --no-parallel --filter ClipboardWriteRequestTests
Test Suite 'ClipboardWriteRequestTests' passed
Executed 3 tests, with 0 failures (0 unexpected)

$ swiftlint lint --config .swiftlint.yml Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/System/ClipboardService.swift Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/ClipboardWriteRequestTests.swift
Done linting! Found 0 violations, 0 serious in 2 files.

$ swiftformat Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/System/ClipboardService.swift Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/ClipboardWriteRequestTests.swift
SwiftFormat completed in 0.04s.
0/2 files formatted.
```

Additional Tart VM pasteboard/API proof against this PR branch. The throwaway SwiftPM executable depends on the PR worktree's `Core/PeekabooAutomationKit` product and uses a real AppKit `NSPasteboard` instance through `ClipboardService`.

```console
$ sw_vers
ProductName:     macOS
ProductVersion:  15.7.3
BuildVersion:    24G419

$ xcrun swift --version
swift-driver version: 1.148.6 Apple Swift version 6.3.1 (swiftlang-6.3.1.1.2 clang-2100.0.123.102)
Target: arm64-apple-macosx15.0

$ cd ~/peekaboo-proof-clipboard && xcrun swift run ClipboardProof
Build of product 'ClipboardProof' complete! (0.08s)
alsoText-size-proof=PASSED sizeExceeded current=10 limit=4
utf8-preview-proof=PASSED preview=hello pasteboardString=hello
```


## Maintainer decision and verification

Maintainer decision: accept the stricter default clipboard size contract. The large-write guard should count the effective pasteboard payload, including `alsoText`, so callers that intentionally write large companion text must opt in with `allowLarge` / `--allow-large`.

Maintainer follow-up on head `1369c2a9` documents that contract in `docs/commands/clipboard.md` and `docs/clipboard.md`.

Run from `/Users/steipete/Projects/Peekaboo` on June 6, 2026:

```console
$ swift test --package-path Core/PeekabooAutomationKit --no-parallel --filter ClipboardWriteRequestTests
Test Suite 'ClipboardWriteRequestTests' passed
Executed 3 tests, with 0 failures (0 unexpected)

$ swiftlint lint --config .swiftlint.yml Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/System/ClipboardService.swift Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/ClipboardWriteRequestTests.swift
Done linting! Found 0 violations, 0 serious in 2 files.
```
