### PR TITLE
Fix bridge permission error reporting

### DIFF
--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Base/CommandErrorHandling.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Base/CommandErrorHandling.swift
@@ -22,7 +22,11 @@ extension ErrorHandlingCommand {
             } else {
                 Logger.shared
             }
-            outputError(message: error.localizedDescription, code: errorCode, logger: logger)
+            outputError(
+                message: errorMessage(for: error),
+                code: errorCode,
+                details: errorDetails(for: error),
+                logger: logger)
         } else {
             let errorMessage: String = if let peekabooError = error as? PeekabooError {
                 peekabooError.errorDescription ?? String(describing: error)
@@ -220,6 +224,27 @@ extension ErrorHandlingCommand {
     }
 }
 
+func errorMessage(for error: any Error) -> String {
+    if let bridgeError = error as? PeekabooBridgeErrorEnvelope {
+        return bridgeError.message
+    }
+    return error.localizedDescription
+}
+
+func errorDetails(for error: any Error) -> String? {
+    guard let bridgeError = error as? PeekabooBridgeErrorEnvelope else {
+        return nil
+    }
+    var details: [String] = []
+    if let bridgeDetails = bridgeError.details, !bridgeDetails.isEmpty {
+        details.append(bridgeDetails)
+    }
+    if let permission = bridgeError.permission {
+        details.append("permission: \(permission.rawValue)")
+    }
+    return details.isEmpty ? nil : details.joined(separator: "\n")
+}
+
 func errorCode(for focusError: FocusError) -> ErrorCode {
     switch focusError {
     case .applicationNotRunning:
@@ -233,10 +258,29 @@ func errorCode(for focusError: FocusError) -> ErrorCode {
 
 func errorCode(for bridgeError: PeekabooBridgeErrorEnvelope) -> ErrorCode {
     switch bridgeError.code {
+    case .permissionDenied:
+        switch bridgeError.permission {
+        case .screenRecording:
+            .PERMISSION_ERROR_SCREEN_RECORDING
+        case .accessibility:
+            .PERMISSION_ERROR_ACCESSIBILITY
+        case .postEvent:
+            .PERMISSION_ERROR_EVENT_SYNTHESIZING
+        case .appleScript:
+            .PERMISSION_ERROR_APPLESCRIPT
+        case .none:
+            .PERMISSION_DENIED
+        }
     case .timeout:
         .TIMEOUT
-    default:
-        .INTERNAL_SWIFT_ERROR
+    case .invalidRequest:
+        .INVALID_ARGUMENT
+    case .operationNotSupported:
+        .VALIDATION_ERROR
+    case .notFound:
+        .UNKNOWN_ERROR
+    case .versionMismatch, .unauthorizedClient, .decodingFailed, .internalError, .serverBusy:
+        .UNKNOWN_ERROR
     }
 }
 

--- a/Apps/CLI/Tests/CoreCLITests/ErrorHandlingTests.swift
+++ b/Apps/CLI/Tests/CoreCLITests/ErrorHandlingTests.swift
@@ -42,6 +42,40 @@ struct FocusErrorMappingTests {
     }
 
     @Test
+    func `bridge screen recording permission maps to screen recording error`() {
+        let envelope = PeekabooBridgeErrorEnvelope(
+            code: .permissionDenied,
+            message: "Operation captureScreen is not allowed with current permissions",
+            permission: .screenRecording)
+
+        #expect(errorCode(for: envelope) == .PERMISSION_ERROR_SCREEN_RECORDING)
+    }
+
+    @Test
+    func `bridge envelope message uses actionable bridge message`() {
+        let envelope = PeekabooBridgeErrorEnvelope(
+            code: .permissionDenied,
+            message: "Operation captureArea is not allowed with current permissions",
+            permission: .screenRecording)
+
+        #expect(errorMessage(for: envelope) == "Operation captureArea is not allowed with current permissions")
+        #expect(!errorMessage(for: envelope).contains("PeekabooBridgeErrorEnvelope error"))
+    }
+
+    @Test
+    func `bridge envelope details preserve bridge details and permission`() {
+        let envelope = PeekabooBridgeErrorEnvelope(
+            code: .internalError,
+            message: "Bridge operation failed",
+            details: "Screen capture service rejected the request",
+            permission: .screenRecording)
+
+        let details = errorDetails(for: envelope)
+        #expect(details?.contains("Screen capture service rejected the request") == true)
+        #expect(details?.contains("permission: screenRecording") == true)
+    }
+
+    @Test
     func `POSIX timeout maps to TIMEOUT`() {
         let code = errorCode(for: POSIXError(.ETIMEDOUT))
         #expect(code == .TIMEOUT)


### PR DESCRIPTION
## Summary
- use `PeekabooBridgeErrorEnvelope.message` and `details` for JSON command errors instead of Swift localized envelope text
- map bridge permission-denied envelopes to the existing permission-specific CLI error codes
- add focused coverage for screen-recording bridge permission failures and bridge envelope message/details output

Fixes #170

## Testing
- `swift test --package-path Apps/CLI --filter ErrorHandlingTests`
- `swift build --package-path Apps/CLI`
- Fresh Tart guest validation: cloned upstream, applied this patch, initialized submodules, and reran the same focused test/build successfully on macOS 15.7.3.

Additional after-fix runtime proof from a real bridge-backed setup:

```bash
./Apps/CLI/.build/arm64-apple-macosx/debug/peekaboo bridge status --json
./Apps/CLI/.build/arm64-apple-macosx/debug/peekaboo app hide Finder --json
```

Bridge status was redacted to the relevant fields. The PR-built CLI selected the remote bridge, and this host had AppleScript denied while Screen Recording and Accessibility were granted:

```json
{
  "success": true,
  "source": "remote",
  "socketPath": "~/Library/Application Support/Peekaboo/bridge.sock",
  "hostKind": "inProcess",
  "build": "3.3.0 (3.3.0)",
  "permissions": {
    "screenRecording": true,
    "accessibility": true,
    "appleScript": false,
    "postEvent": true
  }
}
```

The after-fix bridge-backed permission failure now preserves the bridge envelope message/details and maps to the permission-specific CLI code instead of `INTERNAL_SWIFT_ERROR` or `PeekabooBridgeErrorEnvelope error 1`:

```json
{
  "debug_logs": [
    "[redacted] DEBUG: Runtime host: remote inProcess via ~/Library/Application Support/Peekaboo/bridge.sock (build 3.3.0 (3.3.0))"
  ],
  "success": false,
  "error": {
    "details": "permission: appleScript",
    "message": "Operation hideApplication is not allowed with current permissions",
    "code": "PERMISSION_ERROR_APPLESCRIPT"
  }
}
```

This live proof uses the AppleScript permission-denied bridge path because that is the denied permission available on this host. The screen-recording bridge permission mapping requested by #170 is covered by the focused regression test above: `bridge screen recording permission maps to screen recording error`.

During runtime probing, the source-built debug CLI also showed a broader Tart/source-build invocation hang, including simple subprocess-driven probes, so this PR stays scoped to the verified bridge-envelope reporting bug.
