### PR TITLE
fix(cli): support custom AI providers in agent command

### DIFF
--- a/Apps/CLI/Sources/PeekabooCLI/Commands/AI/AgentCommand+Execution.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/AI/AgentCommand+Execution.swift
@@ -27,9 +27,13 @@ extension AgentCommand {
 
         let hasCredential = await peekabooAgent.maskedApiKey != nil
         if !hasCredential {
-            self.emitAgentUnavailableMessage()
+            if !self.hasConfiguredAIProvider(configuration: self.services.configuration) {
+                self.emitAgentUnavailableMessage()
+            }
+            // If custom providers are configured, we have credentials — proceed
+            return self.hasConfiguredAIProvider(configuration: self.services.configuration)
         }
-        return hasCredential
+        return true
     }
 
     /// Render the agent execution result using either JSON output or a rich CLI transcript.

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/AI/AgentCommand+ModelParsing.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/AI/AgentCommand+ModelParsing.swift
@@ -6,9 +6,12 @@ import Tachikoma
 @available(macOS 14.0, *)
 extension AgentCommand {
     func parseModelString(_ modelString: String) -> LanguageModel? {
+        self.parseModelString(modelString, configuration: .shared)
+    }
+
+    func parseModelString(_ modelString: String, configuration: PeekabooCore.ConfigurationManager) -> LanguageModel? {
         let trimmed = modelString.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return nil }
-
         let explicitProvider = trimmed
             .split(separator: "/", maxSplits: 1)
             .first
@@ -45,6 +48,16 @@ extension AgentCommand {
             if let explicitProvider, Self.reservedProviderInputs.contains(explicitProvider) {
                 return nil
             }
+            // Check if this is a custom provider and resolve it
+            if let explicitProvider, configuration.listCustomProviders()[explicitProvider] != nil {
+                let aiService = PeekabooAIService(configuration: configuration)
+                return aiService.availableModels().first { model in
+                    if case .custom(let p) = model {
+                        return p.modelId.hasPrefix("\(explicitProvider)/")
+                    }
+                    return false
+                }
+            }
             return parsed.supportsTools ? parsed : nil
         default:
             break
@@ -53,9 +66,9 @@ extension AgentCommand {
         return nil
     }
 
-    func validatedModelSelection() throws -> LanguageModel? {
+    func validatedModelSelection(configuration: PeekabooCore.ConfigurationManager) throws -> LanguageModel? {
         guard let modelString = self.model else { return nil }
-        guard let parsed = self.parseModelString(modelString) else {
+        guard let parsed = self.parseModelString(modelString, configuration: configuration) else {
             throw PeekabooError.invalidInput(
                 "Unsupported model '\(modelString)'. Allowed values: \(Self.allowedModelList)"
             )
@@ -121,6 +134,7 @@ extension AgentCommand {
             "ollama/<model>",
             "lmstudio/<model>",
             "openrouter/<provider>/<model>",
+            "<custom-provider>/<model>",
         ])
         .sorted()
         .joined(separator: ", ")
@@ -144,6 +158,8 @@ extension AgentCommand {
             return configuration.getMiniMaxChinaAPIKey()?.isEmpty == false
         case .openRouter:
             return configuration.getOpenRouterAPIKey()?.isEmpty == false
+        case .custom(let customModel):
+            return customModel.apiKey?.isEmpty == false
         default:
             return false
         }
@@ -167,8 +183,10 @@ extension AgentCommand {
             "LM Studio"
         case .openRouter:
             "OpenRouter"
-        default:
-            "the selected provider"
+        case .custom(let customModel):
+            String(customModel.modelId.split(separator: "/").first ?? "custom")
+          default:
+              "the selected provider"
         }
     }
 
@@ -190,8 +208,10 @@ extension AgentCommand {
             "LM Studio local server URL"
         case .openRouter:
             "OPENROUTER_API_KEY"
-        default:
-            "provider API key"
+        case .custom(let customModel):
+            String(customModel.modelId.split(separator: "/").first ?? "custom").uppercased() + "_API_KEY"
+         default:
+             "provider API key"
         }
     }
 

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/AI/AgentCommand.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/AI/AgentCommand.swift
@@ -212,7 +212,7 @@ extension AgentCommand {
 
         let requestedModel: LanguageModel?
         do {
-            requestedModel = try self.validatedModelSelection()
+            requestedModel = try self.validatedModelSelection(configuration: services.configuration)
         } catch {
             self.printAgentExecutionError(error.localizedDescription)
             throw ExitCode.failure
@@ -223,9 +223,10 @@ extension AgentCommand {
             agentService = existing
         } else if let requestedModel {
             agentService = try PeekabooAgentService(services: services, defaultModel: requestedModel)
+        } else if let defaultModel = self.resolvedDefaultModel(from: services.configuration) {
+            agentService = try PeekabooAgentService(services: services, defaultModel: defaultModel)
         } else {
-            self.emitAgentUnavailableMessage()
-            return
+            agentService = try PeekabooAgentService(services: services)
         }
 
         let terminalCapabilities = TerminalDetector.detectCapabilities()
@@ -332,7 +333,7 @@ extension AgentCommand {
         }
     }
 
-    private func hasConfiguredAIProvider(configuration: PeekabooCore.ConfigurationManager) -> Bool {
+    func hasConfiguredAIProvider(configuration: PeekabooCore.ConfigurationManager) -> Bool {
         let hasOpenAI = configuration.hasOpenAIAuth()
         let hasAnthropic = configuration.hasAnthropicAuth()
         let hasGemini = configuration.getGeminiAPIKey()?.isEmpty == false
@@ -349,15 +350,22 @@ extension AgentCommand {
                     .lowercased()
                 return provider == "ollama" || provider == "lmstudio" || provider == "lm-studio"
             }
+        let customProviders = configuration.listCustomProviders()
+        let hasCustomProvider = !customProviders.isEmpty && customProviders.contains { $0.value.enabled }
         return hasOpenAI || hasAnthropic || hasGemini || hasMiniMax || hasMiniMaxChina || hasOpenRouter ||
-            hasLocalProvider
+            hasLocalProvider || hasCustomProvider
+    }
+
+    func resolvedDefaultModel(from configuration: PeekabooCore.ConfigurationManager) -> LanguageModel? {
+        let aiService = PeekabooAIService(configuration: configuration)
+        return aiService.availableModels().first
     }
 
     func emitAgentUnavailableMessage() {
         if self.jsonOutput {
             let message = "Agent service not available. Please set OPENAI_API_KEY, ANTHROPIC_API_KEY, " +
                 "GEMINI_API_KEY, MINIMAX_API_KEY, MINIMAX_CN_API_KEY, OPENROUTER_API_KEY, " +
-                "or configure ollama/<model> or lmstudio/<model>."
+                "configure ollama/<model>, lmstudio/<model>, or add a custom provider via 'peekaboo config add-provider'."
             let error = [
                 "success": false,
                 "error": message
@@ -373,7 +381,8 @@ extension AgentCommand {
                 "\(TerminalColor.red)Error: Agent service not available.",
                 " Please set OPENAI_API_KEY, ANTHROPIC_API_KEY, GEMINI_API_KEY, MINIMAX_API_KEY,",
                 " MINIMAX_CN_API_KEY, OPENROUTER_API_KEY,",
-                " or configure ollama/<model> or lmstudio/<model>."
+                " configure ollama/<model>, lmstudio/<model>,",
+                " or add a custom provider via 'peekaboo config add-provider'."
             ].joined()
             let errorMessageLine = [errorPrefix, "\(TerminalColor.reset)"].joined()
             print(errorMessageLine)

--- a/Apps/CLI/Tests/CoreCLITests/AgentCommandModelParsingTests.swift
+++ b/Apps/CLI/Tests/CoreCLITests/AgentCommandModelParsingTests.swift
@@ -1,4 +1,5 @@
 import PeekabooFoundation
+import PeekabooCore
 import Tachikoma
 import Testing
 @testable import PeekabooCLI
@@ -150,10 +151,10 @@ struct ModelSelectionIntegrationTests {
     @Test
     func `Validated model selection handles optional input`() throws {
         var command = try AgentCommand.parse([])
-        #expect(try command.validatedModelSelection() == nil)
+        #expect(try command.validatedModelSelection(configuration: .shared) == nil)
 
         command.model = "gpt-5.5"
-        let parsed = try command.validatedModelSelection()
+        let parsed = try command.validatedModelSelection(configuration: .shared)
         #expect(parsed == .openai(.gpt55))
     }
 
@@ -163,7 +164,7 @@ struct ModelSelectionIntegrationTests {
         command.model = "gpt-4o"
 
         let error = #expect(throws: PeekabooError.self) {
-            try command.validatedModelSelection()
+            try command.validatedModelSelection(configuration: .shared)
         }
 
         if case let .invalidInput(message) = error {


### PR DESCRIPTION
Closes #183

## Problem
Custom AI providers (registered via `peekaboo config add-provider`) are ignored by the `agent` command:

1. `hasConfiguredAIProvider` only checked built-in providers (OpenAI, Anthropic, Gemini, MiniMax, OpenRouter) and local providers (Ollama, LM Studio). Custom providers were invisible.
2. Agent creation fell through to `emitAgentUnavailableMessage()` when no `--model` was specified and no built-in API key was set, even when valid custom providers existed.
3. `parseModelString` mapped custom provider model strings (e.g. `amp/claude-sonnet-4-6`) to `.openRouter`, causing "Missing OPENROUTER_API_KEY" errors.
4. `hasCredentials`, `providerDisplayName`, and `providerEnvironmentVariable` had no `.custom` case handling.
5. `ensureAgentHasCredentials` checked only `maskedApiKey` (built-in providers), ignoring custom providers.

## Fix
- `hasConfiguredAIProvider`: check custom providers via `configuration.listCustomProviders()`
- Agent creation: resolve default model from `aiProviders` config when no `--model` flag is given
- `parseModelString`: detect custom providers and resolve via `PeekabooAIService`
- `hasCredentials` / `providerDisplayName` / `providerEnvironmentVariable`: handle `.custom` `LanguageModel` case
- `ensureAgentHasCredentials`: proceed when custom providers are configured even without a built-in provider key
- Error messages: mention custom providers (`peekaboo config add-provider`)
- Tests: updated for new `ConfigurationManager` parameter

## Verification
- All 12 existing unit tests pass
- Manually tested with Amp local proxy (`localhost:8317`) and DeepSeek API:
  ```bash
  # Default model from config
  peekaboo agent "say hello"                          # Uses first provider from aiProviders
  # Explicit custom provider model
  peekaboo agent "..." --model amp/claude-opus-4-8     # Works
  peekaboo agent "..." --model deepseek/deepseek-v4-flash  # Works
  ```