### PR TITLE
fix(bridge): enforce exclusive socket ownership

### DIFF
--- a/Apps/CLI/CHANGELOG.md
+++ b/Apps/CLI/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to Peekaboo CLI will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+- Bridge hosts now use atomic lease-backed socket ownership and bounded nonblocking transport, keep Peekaboo.app and the reusable daemon on distinct paths, preserve lifecycle settings while migrating legacy daemons, prevent MCP from hosting a bridge listener, safely recover stale sockets, and release abandoned client connections instead of wedging. Thanks @Artifact-LV for #184.
+
 ## [3.4.2] - 2026-06-12
 
 ### Added

--- a/Apps/CLI/CHANGELOG.md
+++ b/Apps/CLI/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 ### Fixed
-- Bridge hosts now use atomic lease-backed socket ownership and bounded nonblocking transport, keep Peekaboo.app and the reusable daemon on distinct paths, preserve lifecycle settings while migrating legacy daemons, prevent MCP from hosting a bridge listener, safely recover stale sockets, and release abandoned client connections instead of wedging. Thanks @Artifact-LV for #184.
+- Bridge hosts now use atomic lease-backed socket ownership and bounded nonblocking transport, keep Peekaboo.app and the reusable daemon on distinct paths while preserving the healthy app's TCC-backed fallback, preserve lifecycle settings while migrating legacy daemons, prevent MCP from hosting a bridge listener, safely recover stale sockets, and release abandoned client connections instead of wedging. Thanks @Artifact-LV for #184.
 
 ## [3.4.2] - 2026-06-12
 

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Base/Runtime/DaemonLaunchPolicy.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Base/Runtime/DaemonLaunchPolicy.swift
@@ -3,6 +3,21 @@ import Foundation
 import PeekabooBridge
 
 enum DaemonLaunchPolicy {
+    struct LaunchResult {
+        let status: PeekabooDaemonStatus
+        let processID: pid_t
+
+        var ownsObservedDaemon: Bool {
+            self.status.pid == self.processID
+        }
+    }
+
+    enum SocketAvailability: Equatable {
+        case available
+        case reusableDaemon
+        case timedOut
+    }
+
     static func shouldAutoStartDaemon(
         options: CommandRuntimeOptions,
         environment: [String: String]
@@ -16,7 +31,7 @@ enum DaemonLaunchPolicy {
            !socket.isEmpty {
             return socket
         }
-        return PeekabooBridgeConstants.peekabooSocketPath
+        return PeekabooBridgeConstants.daemonSocketPath
     }
 
     static func daemonIdleTimeoutSeconds(environment: [String: String]) -> TimeInterval {
@@ -29,20 +44,66 @@ enum DaemonLaunchPolicy {
         return value
     }
 
+    static func shouldMigrateLegacyDaemon(targetSocketPath: String) -> Bool {
+        let target = (targetSocketPath as NSString).expandingTildeInPath
+        let standard = (PeekabooBridgeConstants.daemonSocketPath as NSString).expandingTildeInPath
+        return (target as NSString).standardizingPath == (standard as NSString).standardizingPath
+    }
+
     static func onDemandDaemonArguments(socketPath: String, idleTimeoutSeconds: TimeInterval) -> [String] {
-        [
+        self.daemonArguments(
+            socketPath: socketPath,
+            mode: .auto,
+            idleTimeoutSeconds: idleTimeoutSeconds
+        )
+    }
+
+    static func daemonArguments(
+        socketPath: String,
+        mode: PeekabooDaemonMode,
+        pollIntervalMs: Int? = nil,
+        idleTimeoutSeconds: TimeInterval
+    ) -> [String] {
+        var arguments = [
             "daemon",
             "run",
             "--mode",
-            "auto",
+            mode.rawValue,
             "--bridge-socket",
             socketPath,
-            "--idle-timeout-seconds",
-            String(format: "%.3f", idleTimeoutSeconds),
         ]
+        if let pollIntervalMs, pollIntervalMs > 0 {
+            arguments.append(contentsOf: [
+                "--poll-interval-ms",
+                "\(pollIntervalMs)",
+            ])
+        }
+        if mode == .auto {
+            arguments.append(contentsOf: [
+                "--idle-timeout-seconds",
+                String(format: "%.3f", idleTimeoutSeconds),
+            ])
+        }
+        return arguments
     }
 
-    static func startOnDemandDaemon(socketPath: String, environment: [String: String]) async -> Bool {
+    static func migratedDaemonArguments(
+        socketPath: String,
+        status: PeekabooDaemonStatus,
+        fallbackIdleTimeoutSeconds: TimeInterval
+    ) -> [String]? {
+        guard let mode = DaemonControlClient.migrationMode(for: status) else { return nil }
+        let idleTimeoutSeconds = status.activity?.idleTimeoutSeconds.flatMap { $0 > 0 ? $0 : nil }
+            ?? fallbackIdleTimeoutSeconds
+        return self.daemonArguments(
+            socketPath: socketPath,
+            mode: mode,
+            pollIntervalMs: status.windowTracker?.cgPollIntervalMs,
+            idleTimeoutSeconds: idleTimeoutSeconds
+        )
+    }
+
+    static func startOnDemandDaemon(socketPath: String, environment: [String: String]) async -> String? {
         let client = DaemonControlClient(socketPath: socketPath)
         let lockHandle = DaemonPaths.openDaemonStartupLock()
         if let fileDescriptor = lockHandle?.fileDescriptor {
@@ -55,17 +116,133 @@ enum DaemonLaunchPolicy {
             try? lockHandle?.close()
         }
 
-        if await client.fetchStatus() != nil {
-            return true
+        if await client.fetchReusableDaemonStatus() != nil {
+            return socketPath
         }
 
+        switch await self.waitForDaemonSocketAvailability(
+            socketPath: socketPath,
+            client: client,
+            timeout: TimeInterval(DaemonControlClient.defaultShutdownWaitSeconds)
+        ) {
+        case .available:
+            break
+        case .reusableDaemon:
+            return socketPath
+        case .timedOut:
+            return nil
+        }
+
+        let fallbackIdleTimeoutSeconds = self.daemonIdleTimeoutSeconds(environment: environment)
+        var launchArguments = self.daemonArguments(
+            socketPath: socketPath,
+            mode: .auto,
+            idleTimeoutSeconds: fallbackIdleTimeoutSeconds
+        )
+        let legacyClient = DaemonControlClient(socketPath: PeekabooBridgeConstants.peekabooSocketPath)
+        if self.shouldMigrateLegacyDaemon(targetSocketPath: socketPath),
+           let legacyStatus = await legacyClient.fetchReusableDaemonStatus(),
+           let migrationArguments = self.migratedDaemonArguments(
+               socketPath: socketPath,
+               status: legacyStatus,
+               fallbackIdleTimeoutSeconds: fallbackIdleTimeoutSeconds
+           ) {
+            guard DaemonControlClient.supportsSafeMigration(legacyStatus),
+                  DaemonControlClient.isIdleForMigration(legacyStatus)
+            else {
+                return PeekabooBridgeConstants.peekabooSocketPath
+            }
+            launchArguments = migrationArguments
+
+            guard let replacement = await self.launchDaemon(
+                socketPath: socketPath,
+                arguments: launchArguments
+            )
+            else {
+                return await legacyClient.fetchReusableDaemonStatus() != nil
+                    ? PeekabooBridgeConstants.peekabooSocketPath
+                    : nil
+            }
+
+            do {
+                let stopped = try await legacyClient.stopAndWait(
+                    waitSeconds: DaemonControlClient.defaultShutdownWaitSeconds,
+                    expectedPID: legacyStatus.pid,
+                    requireIdentityMatch: true
+                )
+                if !stopped {
+                    if await legacyClient.fetchReusableDaemonStatus() != nil {
+                        let cleanedUp = await self.stopReplacement(
+                            client: client,
+                            replacement: replacement
+                        )
+                        return cleanedUp ? PeekabooBridgeConstants.peekabooSocketPath : nil
+                    }
+                }
+            } catch {
+                if await legacyClient.fetchReusableDaemonStatus() != nil {
+                    let cleanedUp = await self.stopReplacement(
+                        client: client,
+                        replacement: replacement
+                    )
+                    return cleanedUp ? PeekabooBridgeConstants.peekabooSocketPath : nil
+                }
+            }
+            return await client.fetchReusableDaemonStatus() != nil ? socketPath : nil
+        }
+
+        return await self.launchDaemon(
+            socketPath: socketPath,
+            arguments: launchArguments
+        ) != nil ? socketPath : nil
+    }
+
+    static func waitForDaemonSocketAvailability(
+        socketPath: String,
+        client: DaemonControlClient,
+        timeout: TimeInterval
+    ) async -> SocketAvailability {
+        guard self.bridgeLeaseIsHeld(socketPath: socketPath) else {
+            return .available
+        }
+
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            if await client.fetchReusableDaemonStatus() != nil {
+                return .reusableDaemon
+            }
+            if !self.bridgeLeaseIsHeld(socketPath: socketPath) {
+                return .available
+            }
+            try? await Task.sleep(nanoseconds: 100_000_000)
+        }
+        return self.bridgeLeaseIsHeld(socketPath: socketPath) ? .timedOut : .available
+    }
+
+    private static func bridgeLeaseIsHeld(socketPath: String) -> Bool {
+        let fd = open(
+            "\(socketPath).lock",
+            O_RDWR | O_CLOEXEC | O_NOFOLLOW
+        )
+        guard fd >= 0 else { return false }
+        defer { close(fd) }
+
+        if flock(fd, LOCK_EX | LOCK_NB) == 0 {
+            flock(fd, LOCK_UN)
+            return false
+        }
+        return errno == EWOULDBLOCK || errno == EAGAIN
+    }
+
+    static func launchDaemon(
+        socketPath: String,
+        arguments: [String],
+        timeout: TimeInterval = 3
+    ) async -> LaunchResult? {
         let executable = CommandLine.arguments.first ?? "/usr/local/bin/peekaboo"
         let process = Process()
         process.executableURL = URL(fileURLWithPath: executable)
-        process.arguments = self.onDemandDaemonArguments(
-            socketPath: socketPath,
-            idleTimeoutSeconds: self.daemonIdleTimeoutSeconds(environment: environment)
-        )
+        process.arguments = arguments
         let logHandle = DaemonPaths.openDaemonLogForAppend() ?? FileHandle.nullDevice
         process.standardOutput = logHandle
         process.standardError = logHandle
@@ -74,16 +251,47 @@ enum DaemonLaunchPolicy {
         do {
             try process.run()
         } catch {
-            return false
+            return nil
         }
 
-        let deadline = Date().addingTimeInterval(3)
+        let deadline = Date().addingTimeInterval(timeout)
+        let client = DaemonControlClient(socketPath: socketPath)
         while Date() < deadline {
-            if await client.fetchStatus() != nil {
-                return true
+            if let status = await client.fetchReusableDaemonStatus() {
+                let processID = process.processIdentifier
+                if status.pid != processID, process.isRunning {
+                    process.terminate()
+                }
+                return LaunchResult(status: status, processID: processID)
             }
             try? await Task.sleep(nanoseconds: 100_000_000)
         }
-        return false
+        if process.isRunning {
+            process.terminate()
+        }
+        return nil
+    }
+
+    static func stopReplacement(
+        client: DaemonControlClient,
+        replacement: LaunchResult
+    ) async -> Bool {
+        guard replacement.ownsObservedDaemon else { return true }
+        let expectedPID = replacement.processID
+        let deadline = Date().addingTimeInterval(
+            TimeInterval(DaemonControlClient.defaultShutdownWaitSeconds)
+        )
+
+        while Date() < deadline {
+            guard let status = await client.fetchControllableDaemonStatus(),
+                  status.pid == expectedPID
+            else {
+                return true
+            }
+            _ = try? await client.stopDaemon(expectedPID: expectedPID)
+            try? await Task.sleep(nanoseconds: 200_000_000)
+        }
+
+        return await client.fetchControllableDaemonStatus()?.pid != expectedPID
     }
 }

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Base/Runtime/DaemonLaunchPolicy.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Base/Runtime/DaemonLaunchPolicy.swift
@@ -3,6 +3,11 @@ import Foundation
 import PeekabooBridge
 
 enum DaemonLaunchPolicy {
+    enum ImplicitRuntimeCandidateRole: Equatable {
+        case reusableDaemon
+        case defaultAppFallback
+    }
+
     struct LaunchResult {
         let status: PeekabooDaemonStatus
         let processID: pid_t
@@ -45,9 +50,37 @@ enum DaemonLaunchPolicy {
     }
 
     static func shouldMigrateLegacyDaemon(targetSocketPath: String) -> Bool {
-        let target = (targetSocketPath as NSString).expandingTildeInPath
-        let standard = (PeekabooBridgeConstants.daemonSocketPath as NSString).expandingTildeInPath
-        return (target as NSString).standardizingPath == (standard as NSString).standardizingPath
+        self.standardizedSocketPath(targetSocketPath) ==
+            self.standardizedSocketPath(PeekabooBridgeConstants.daemonSocketPath)
+    }
+
+    static func implicitRuntimeCandidateRole(
+        socketPath: String,
+        daemonSocketPath: String
+    ) -> ImplicitRuntimeCandidateRole? {
+        let candidate = self.standardizedSocketPath(socketPath)
+        if candidate == self.standardizedSocketPath(daemonSocketPath) {
+            return .reusableDaemon
+        }
+        if self.shouldMigrateLegacyDaemon(targetSocketPath: daemonSocketPath),
+           candidate == self.standardizedSocketPath(PeekabooBridgeConstants.peekabooSocketPath) {
+            return .defaultAppFallback
+        }
+        return nil
+    }
+
+    static func isSelectableImplicitRuntimeCandidate(
+        role: ImplicitRuntimeCandidateRole,
+        handshake: PeekabooBridgeHandshakeResponse,
+        daemonStatus: PeekabooDaemonStatus?
+    ) -> Bool {
+        switch role {
+        case .reusableDaemon:
+            daemonStatus.map(DaemonControlClient.isReusableDaemonStatus) == true
+        case .defaultAppFallback:
+            handshake.hostKind == .gui ||
+                daemonStatus.map(DaemonControlClient.isReusableDaemonStatus) == true
+        }
     }
 
     static func onDemandDaemonArguments(socketPath: String, idleTimeoutSeconds: TimeInterval) -> [String] {
@@ -293,5 +326,10 @@ enum DaemonLaunchPolicy {
         }
 
         return await client.fetchControllableDaemonStatus()?.pid != expectedPID
+    }
+
+    private static func standardizedSocketPath(_ path: String) -> String {
+        let expanded = (path as NSString).expandingTildeInPath
+        return (expanded as NSString).standardizingPath
     }
 }

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Base/Runtime/RuntimeHostResolver.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Base/Runtime/RuntimeHostResolver.swift
@@ -43,13 +43,25 @@ enum RuntimeHostResolver {
             ) {
                 return resolved
             }
-        } else if let resolved = await self.resolveRemoteServices(
-            candidates: [daemonSocketPath],
-            identity: identity,
-            options: options,
-            requireReusableDaemon: true
-        ) {
-            return resolved
+        } else {
+            if let resolved = await self.resolveRemoteServices(
+                candidates: [daemonSocketPath],
+                identity: identity,
+                options: options,
+                requireReusableDaemon: true
+            ) {
+                return resolved
+            }
+            if DaemonLaunchPolicy.shouldMigrateLegacyDaemon(targetSocketPath: daemonSocketPath),
+               let resolved = await self.resolveRemoteServices(
+                   candidates: [PeekabooBridgeConstants.peekabooSocketPath],
+                   identity: identity,
+                   options: options,
+                   requireReusableDaemon: false,
+                   requiredHostKind: .gui
+               ) {
+                return resolved
+            }
         }
 
         if options.autoStartDaemon,
@@ -77,13 +89,17 @@ enum RuntimeHostResolver {
         candidates: [String],
         identity: PeekabooBridgeClientIdentity,
         options: CommandRuntimeOptions,
-        requireReusableDaemon: Bool
+        requireReusableDaemon: Bool,
+        requiredHostKind: PeekabooBridgeHostKind? = nil
     )
     async -> (services: any PeekabooServiceProviding, hostDescription: String)? {
         for socketPath in candidates {
             let client = PeekabooBridgeClient(socketPath: socketPath)
             do {
                 let handshake = try await client.handshake(client: identity, requestedHost: nil)
+                guard requiredHostKind == nil || handshake.hostKind == requiredHostKind else {
+                    continue
+                }
                 guard BridgeCapabilityPolicy.supportsRemoteRequirements(for: handshake, options: options) else {
                     continue
                 }

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Base/Runtime/RuntimeHostResolver.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Base/Runtime/RuntimeHostResolver.swift
@@ -27,12 +27,6 @@ enum RuntimeHostResolver {
         let explicitSocket = BridgeSocketResolver.explicitBridgeSocket(options: options, environment: environment)
 
         let daemonSocketPath = DaemonLaunchPolicy.daemonSocketPath(environment: environment)
-        let candidates: [String] = if let explicitSocket, !explicitSocket.isEmpty {
-            [explicitSocket]
-        } else {
-            [daemonSocketPath]
-        }
-
         let identity = PeekabooBridgeClientIdentity(
             bundleIdentifier: Bundle.main.bundleIdentifier,
             teamIdentifier: nil,
@@ -40,21 +34,35 @@ enum RuntimeHostResolver {
             hostname: Host.current().name
         )
 
-        if let resolved = await self.resolveRemoteServices(
-            candidates: candidates,
+        if let explicitSocket, !explicitSocket.isEmpty {
+            if let resolved = await self.resolveRemoteServices(
+                candidates: [explicitSocket],
+                identity: identity,
+                options: options,
+                requireReusableDaemon: false
+            ) {
+                return resolved
+            }
+        } else if let resolved = await self.resolveRemoteServices(
+            candidates: [daemonSocketPath],
             identity: identity,
-            options: options
+            options: options,
+            requireReusableDaemon: true
         ) {
             return resolved
         }
 
         if options.autoStartDaemon,
            DaemonLaunchPolicy.shouldAutoStartDaemon(options: options, environment: environment),
-           await DaemonLaunchPolicy.startOnDemandDaemon(socketPath: daemonSocketPath, environment: environment),
+           let resolvedDaemonSocket = await DaemonLaunchPolicy.startOnDemandDaemon(
+               socketPath: daemonSocketPath,
+               environment: environment
+           ),
            let resolved = await self.resolveRemoteServices(
-               candidates: [daemonSocketPath],
+               candidates: [resolvedDaemonSocket],
                identity: identity,
-               options: options
+               options: options,
+               requireReusableDaemon: true
            ) {
             return resolved
         }
@@ -68,7 +76,8 @@ enum RuntimeHostResolver {
     private static func resolveRemoteServices(
         candidates: [String],
         identity: PeekabooBridgeClientIdentity,
-        options: CommandRuntimeOptions
+        options: CommandRuntimeOptions,
+        requireReusableDaemon: Bool
     )
     async -> (services: any PeekabooServiceProviding, hostDescription: String)? {
         for socketPath in candidates {
@@ -76,6 +85,10 @@ enum RuntimeHostResolver {
             do {
                 let handshake = try await client.handshake(client: identity, requestedHost: nil)
                 guard BridgeCapabilityPolicy.supportsRemoteRequirements(for: handshake, options: options) else {
+                    continue
+                }
+                if requireReusableDaemon,
+                   await DaemonControlClient(socketPath: socketPath).fetchReusableDaemonStatus() == nil {
                     continue
                 }
 

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Core/BridgeCommand+Diagnostics.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Core/BridgeCommand+Diagnostics.swift
@@ -11,7 +11,8 @@ struct BridgeDiagnostics {
 
     @MainActor
     func run(runtimeOptions: CommandRuntimeOptions) async -> BridgeStatusReport {
-        let envNoRemote = ProcessInfo.processInfo.environment["PEEKABOO_NO_REMOTE"]
+        let environment = ProcessInfo.processInfo.environment
+        let envNoRemote = environment["PEEKABOO_NO_REMOTE"]
         let shouldSkipRemote = !runtimeOptions.preferRemote || envNoRemote != nil
         let remoteSkipReason = shouldSkipRemote
             ? (!runtimeOptions.preferRemote ? "--no-remote" : "PEEKABOO_NO_REMOTE")
@@ -24,7 +25,15 @@ struct BridgeDiagnostics {
             hostname: Host.current().name
         )
 
-        let candidates = self.candidateSocketPaths(runtimeOptions: runtimeOptions)
+        let runtimeCandidates = Self.runtimeCandidateSocketPaths(
+            runtimeOptions: runtimeOptions,
+            environment: environment
+        )
+        let candidates = Self.diagnosticSocketPaths(
+            runtimeOptions: runtimeOptions,
+            environment: environment
+        )
+        let selectablePaths = Set(runtimeCandidates)
         if shouldSkipRemote {
             self.logger.debug("Bridge status: remote skipped (\(remoteSkipReason ?? "unknown reason"))")
             return BridgeStatusReport(
@@ -51,7 +60,21 @@ struct BridgeDiagnostics {
                 results.append(.init(socketPath: socketPath, result: .success(report)))
 
                 let enabledOps = handshake.enabledOperations ?? handshake.supportedOperations
-                if selected == nil, enabledOps.contains(.captureScreen) {
+                let isImplicitDaemonCandidate =
+                    BridgeSocketResolver.explicitBridgeSocket(
+                        options: runtimeOptions,
+                        environment: environment
+                    ) == nil &&
+                    selectablePaths.contains(socketPath)
+                let isSelectableDaemon: Bool = if isImplicitDaemonCandidate {
+                    await DaemonControlClient(socketPath: socketPath).fetchReusableDaemonStatus() != nil
+                } else {
+                    true
+                }
+                if selected == nil,
+                   selectablePaths.contains(socketPath),
+                   isSelectableDaemon,
+                   enabledOps.contains(.captureScreen) {
                     selected = .remote(socketPath: socketPath, handshake: report)
                 }
             } catch let envelope as PeekabooBridgeErrorEnvelope {
@@ -78,21 +101,45 @@ struct BridgeDiagnostics {
         )
     }
 
-    private func candidateSocketPaths(runtimeOptions: CommandRuntimeOptions) -> [String] {
-        let envSocket = ProcessInfo.processInfo.environment["PEEKABOO_BRIDGE_SOCKET"]
-        let explicitSocket = runtimeOptions.bridgeSocketPath ?? envSocket
-
-        let rawCandidates: [String] = if let explicitSocket, !explicitSocket.isEmpty {
-            [explicitSocket]
-        } else {
-            [
-                PeekabooBridgeConstants.peekabooSocketPath,
-                PeekabooBridgeConstants.claudeSocketPath,
-                PeekabooBridgeConstants.clawdbotSocketPath,
-            ]
+    static func runtimeCandidateSocketPaths(
+        runtimeOptions: CommandRuntimeOptions,
+        environment: [String: String]
+    ) -> [String] {
+        if let explicitPath = BridgeSocketResolver.explicitBridgeSocket(
+            options: runtimeOptions,
+            environment: environment
+        ) {
+            return [NSString(string: explicitPath).expandingTildeInPath]
         }
 
-        return rawCandidates.map { NSString(string: $0).expandingTildeInPath }
+        let daemonPath = NSString(
+            string: DaemonLaunchPolicy.daemonSocketPath(environment: environment)
+        ).expandingTildeInPath
+        guard DaemonLaunchPolicy.shouldMigrateLegacyDaemon(targetSocketPath: daemonPath) else {
+            return [daemonPath]
+        }
+        let legacyPath = NSString(string: PeekabooBridgeConstants.peekabooSocketPath).expandingTildeInPath
+        return [daemonPath, legacyPath]
+    }
+
+    static func diagnosticSocketPaths(
+        runtimeOptions: CommandRuntimeOptions,
+        environment: [String: String]
+    ) -> [String] {
+        let runtimePaths = self.runtimeCandidateSocketPaths(
+            runtimeOptions: runtimeOptions,
+            environment: environment
+        )
+        if BridgeSocketResolver.explicitBridgeSocket(options: runtimeOptions, environment: environment) != nil {
+            return runtimePaths
+        }
+
+        let additionalPaths = [
+            PeekabooBridgeConstants.peekabooSocketPath,
+            PeekabooBridgeConstants.claudeSocketPath,
+            PeekabooBridgeConstants.clawdbotSocketPath,
+        ].map { NSString(string: $0).expandingTildeInPath }
+        return runtimePaths + additionalPaths.filter { !runtimePaths.contains($0) }
     }
 
     private static func currentTeamIdentifier() -> String? {

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Core/BridgeCommand+Diagnostics.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Core/BridgeCommand+Diagnostics.swift
@@ -60,20 +60,34 @@ struct BridgeDiagnostics {
                 results.append(.init(socketPath: socketPath, result: .success(report)))
 
                 let enabledOps = handshake.enabledOperations ?? handshake.supportedOperations
-                let isImplicitDaemonCandidate =
+                let isImplicitRuntimeCandidate =
                     BridgeSocketResolver.explicitBridgeSocket(
                         options: runtimeOptions,
                         environment: environment
                     ) == nil &&
                     selectablePaths.contains(socketPath)
-                let isSelectableDaemon: Bool = if isImplicitDaemonCandidate {
-                    await DaemonControlClient(socketPath: socketPath).fetchReusableDaemonStatus() != nil
+                let isSelectableRuntime: Bool
+                if isImplicitRuntimeCandidate,
+                   let role = DaemonLaunchPolicy.implicitRuntimeCandidateRole(
+                       socketPath: socketPath,
+                       daemonSocketPath: DaemonLaunchPolicy.daemonSocketPath(
+                           environment: environment
+                       )
+                   ) {
+                    let daemonStatus = handshake.hostKind == .gui
+                        ? nil
+                        : await DaemonControlClient(socketPath: socketPath).fetchStatus()
+                    isSelectableRuntime = DaemonLaunchPolicy.isSelectableImplicitRuntimeCandidate(
+                        role: role,
+                        handshake: handshake,
+                        daemonStatus: daemonStatus
+                    )
                 } else {
-                    true
+                    isSelectableRuntime = true
                 }
                 if selected == nil,
                    selectablePaths.contains(socketPath),
-                   isSelectableDaemon,
+                   isSelectableRuntime,
                    enabledOps.contains(.captureScreen) {
                     selected = .remote(socketPath: socketPath, handshake: report)
                 }

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Core/BridgeCommand.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Core/BridgeCommand.swift
@@ -9,11 +9,8 @@ struct BridgeCommand: ParsableCommand {
         Peekaboo Bridge lets the CLI run permission-bound operations (Screen Recording, Accessibility,
         AppleScript) via a host app that already has the needed TCC grants.
 
-        By default, Peekaboo prefers a remote host when available:
-          1) Peekaboo.app
-          2) Claude.app
-          3) ClawdBot.app
-          4) Local in-process fallback (caller needs permissions)
+        By default, automation commands use the dedicated Peekaboo daemon and fall back to local execution.
+        Peekaboo.app, Claude.app, and ClawdBot.app sockets are shown for diagnostics and can be selected explicitly.
 
         Examples:
           peekaboo bridge status

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/MCP/MCPCommand+Serve.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/MCP/MCPCommand+Serve.swift
@@ -36,6 +36,7 @@ extension MCPCommand {
 
         @MainActor
         mutating func run(using runtime: CommandRuntime) async throws {
+            var localDaemon: PeekabooDaemon?
             do {
                 guard let transportType = Self.transportType(named: self.transport) else {
                     runtime.logger.setJsonOutputMode(runtime.configuration.jsonOutput)
@@ -51,18 +52,27 @@ extension MCPCommand {
                 if runtime.services is RemotePeekabooServices {
                     runtime.logger.debug("MCP: using remote Bridge host; skipping local daemon startup")
                 } else {
-                    let daemon = PeekabooDaemon(configuration: .mcp())
-                    await daemon.start()
+                    let daemon = PeekabooDaemon(configuration: .embeddedMCP())
+                    localDaemon = daemon
+                    try await daemon.startChecked()
                 }
 
                 let server = try await PeekabooMCPServer()
                 try await server.serve(transport: transportType, port: self.port)
+                await Self.stopLocalDaemon(localDaemon)
             } catch let exitCode as ExitCode {
+                await Self.stopLocalDaemon(localDaemon)
                 throw exitCode
             } catch {
+                await Self.stopLocalDaemon(localDaemon)
                 runtime.logger.error("Failed to start MCP server: \(error)")
                 throw ExitCode.failure
             }
+        }
+
+        private static func stopLocalDaemon(_ daemon: PeekabooDaemon?) async {
+            guard let daemon, await daemon.requestStop() else { return }
+            await daemon.waitUntilStopped()
         }
 
         static func transportType(named name: String) -> PeekabooCore.TransportType? {

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/System/DaemonCommand+Run.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/System/DaemonCommand+Run.swift
@@ -15,7 +15,7 @@ extension DaemonCommand {
             }
         }
 
-        @Option(name: .long, help: "Daemon mode (manual, mcp)")
+        @Option(name: .long, help: "Daemon mode (manual, auto)")
         var mode: String = "manual"
 
         @Option(name: .long, help: "Override bridge socket path")
@@ -33,23 +33,41 @@ extension DaemonCommand {
         mutating func run(using runtime: CommandRuntime) async throws {
             self.runtime = runtime
             let pollInterval = TimeInterval(Double(self.pollIntervalMs ?? 1000) / 1000.0)
-            let socketPath = self.bridgeSocket ?? PeekabooBridgeConstants.peekabooSocketPath
-
-            let normalizedMode = self.mode.lowercased()
-            let config: PeekabooDaemon.Configuration = if normalizedMode == "auto" {
-                .auto(
-                    bridgeSocketPath: socketPath,
-                    windowPollInterval: pollInterval,
-                    idleTimeout: self.idleTimeoutSeconds ?? CommandRuntime.defaultDaemonIdleTimeoutSeconds
-                )
-            } else if normalizedMode == "mcp" {
-                .mcp(bridgeSocketPath: socketPath, windowPollInterval: pollInterval)
-            } else {
-                .manual(bridgeSocketPath: socketPath, windowPollInterval: pollInterval)
-            }
+            let config = try Self.configuration(
+                mode: self.mode,
+                bridgeSocket: self.bridgeSocket,
+                pollInterval: pollInterval,
+                idleTimeoutSeconds: self.idleTimeoutSeconds
+            )
 
             let daemon = PeekabooDaemon(configuration: config)
-            await daemon.runUntilStop()
+            try await daemon.runUntilStopChecked()
+        }
+
+        static func configuration(
+            mode: String,
+            bridgeSocket: String?,
+            pollInterval: TimeInterval,
+            idleTimeoutSeconds: Double?
+        ) throws -> PeekabooDaemon.Configuration {
+            let normalizedMode = mode.lowercased()
+            if normalizedMode == "mcp" {
+                throw ValidationError(
+                    "Standalone MCP daemon mode is unavailable; use `peekaboo mcp` so the MCP transport owns its lifecycle."
+                )
+            }
+            return if normalizedMode == "auto" {
+                .auto(
+                    bridgeSocketPath: bridgeSocket ?? PeekabooBridgeConstants.daemonSocketPath,
+                    windowPollInterval: pollInterval,
+                    idleTimeout: idleTimeoutSeconds ?? CommandRuntime.defaultDaemonIdleTimeoutSeconds
+                )
+            } else {
+                .manual(
+                    bridgeSocketPath: bridgeSocket ?? PeekabooBridgeConstants.daemonSocketPath,
+                    windowPollInterval: pollInterval
+                )
+            }
         }
 
         mutating func applyCommanderValues(_ values: CommanderBindableValues) throws {

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/System/DaemonCommand+Start.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/System/DaemonCommand+Start.swift
@@ -1,4 +1,5 @@
 import Commander
+import Darwin
 import Foundation
 import PeekabooBridge
 import PeekabooFoundation
@@ -48,54 +49,108 @@ extension DaemonCommand {
 
         mutating func run(using runtime: CommandRuntime) async throws {
             self.runtime = runtime
-            let socketPath = self.bridgeSocket ?? PeekabooBridgeConstants.peekabooSocketPath
+            let socketPath = self.bridgeSocket ?? PeekabooBridgeConstants.daemonSocketPath
             let client = DaemonControlClient(socketPath: socketPath)
+            let lockHandle = DaemonPaths.openDaemonStartupLock()
+            if let fileDescriptor = lockHandle?.fileDescriptor {
+                flock(fileDescriptor, LOCK_EX)
+            }
+            defer {
+                if let fileDescriptor = lockHandle?.fileDescriptor {
+                    flock(fileDescriptor, LOCK_UN)
+                }
+                try? lockHandle?.close()
+            }
 
-            if let status = await client.fetchStatus() {
+            let targets = await DaemonControlResolver.targets(explicitSocket: self.bridgeSocket)
+            if let target = targets.first(where: { !$0.isLegacyDefault }) {
+                let status = target.status
                 self.output(status) {
                     DaemonStatusPrinter.render(status: status)
                 }
                 return
             }
 
-            let executable = Self.resolveExecutablePath()
-            let process = Process()
-            process.executableURL = URL(fileURLWithPath: executable)
-            var args = ["daemon", "run", "--mode", "manual"]
-            if let bridgeSocket {
-                args.append(contentsOf: ["--bridge-socket", bridgeSocket])
+            let legacyTarget = targets.first {
+                $0.isLegacyDefault && DaemonControlClient.isReusableDaemonStatus($0.status)
             }
-            if let pollIntervalMs {
-                args.append(contentsOf: ["--poll-interval-ms", "\(pollIntervalMs)"])
+            if let legacyTarget {
+                guard DaemonControlClient.supportsSafeMigration(legacyTarget.status) else {
+                    throw PeekabooError.operationError(
+                        message: "Legacy daemon predates safe migration; run `peekaboo daemon stop`, then retry start"
+                    )
+                }
+                guard DaemonControlClient.isIdleForMigration(legacyTarget.status) else {
+                    throw PeekabooError.operationError(
+                        message: "Legacy daemon has active requests; retry start after they finish"
+                    )
+                }
             }
-            process.arguments = args
 
-            let logHandle = DaemonPaths.openDaemonLogForAppend() ?? FileHandle.nullDevice
-            process.standardOutput = logHandle
-            process.standardError = logHandle
-            process.standardInput = FileHandle.nullDevice
-
-            try process.run()
-
-            let deadline = Date().addingTimeInterval(TimeInterval(self.waitSeconds))
-            while Date() < deadline {
-                if let status = await client.fetchStatus() {
+            switch await DaemonLaunchPolicy.waitForDaemonSocketAvailability(
+                socketPath: socketPath,
+                client: client,
+                timeout: TimeInterval(max(self.waitSeconds, DaemonControlClient.defaultShutdownWaitSeconds))
+            ) {
+            case .available:
+                break
+            case .reusableDaemon:
+                if let status = await client.fetchReusableDaemonStatus() {
                     self.output(status) {
                         DaemonStatusPrinter.render(status: status)
                     }
                     return
                 }
-                try await Task.sleep(nanoseconds: 200_000_000)
+            case .timedOut:
+                throw PeekabooError.operationError(message: "Daemon socket is still shutting down")
             }
 
-            throw PeekabooError.operationError(message: "Daemon did not start within \(self.waitSeconds)s")
-        }
-
-        private static func resolveExecutablePath() -> String {
-            if let path = CommandLine.arguments.first {
-                return path
+            let arguments = DaemonLaunchPolicy.daemonArguments(
+                socketPath: socketPath,
+                mode: .manual,
+                pollIntervalMs: self.pollIntervalMs ?? legacyTarget?.status.windowTracker?.cgPollIntervalMs,
+                idleTimeoutSeconds: CommandRuntime.defaultDaemonIdleTimeoutSeconds
+            )
+            guard let replacement = await DaemonLaunchPolicy.launchDaemon(
+                socketPath: socketPath,
+                arguments: arguments,
+                timeout: TimeInterval(self.waitSeconds)
+            )
+            else {
+                throw PeekabooError.operationError(message: "Daemon did not start within \(self.waitSeconds)s")
             }
-            return "/usr/local/bin/peekaboo"
+
+            if let legacyTarget {
+                do {
+                    let stopped = try await legacyTarget.client.stopAndWait(
+                        waitSeconds: max(self.waitSeconds, DaemonControlClient.defaultShutdownWaitSeconds),
+                        expectedPID: legacyTarget.status.pid,
+                        requireIdentityMatch: true
+                    )
+                    if !stopped,
+                       await legacyTarget.client.fetchReusableDaemonStatus() != nil {
+                        throw PeekabooError.operationError(message: "Legacy daemon refused migration stop request")
+                    }
+                } catch {
+                    if await legacyTarget.client.fetchReusableDaemonStatus() != nil {
+                        let cleanedUp = await DaemonLaunchPolicy.stopReplacement(
+                            client: client,
+                            replacement: replacement
+                        )
+                        if !cleanedUp {
+                            throw PeekabooError.operationError(
+                                message: "Legacy migration failed and replacement cleanup timed out"
+                            )
+                        }
+                        throw error
+                    }
+                }
+            }
+
+            let status = replacement.status
+            self.output(status) {
+                DaemonStatusPrinter.render(status: status)
+            }
         }
     }
 }

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/System/DaemonCommand+Status.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/System/DaemonCommand+Status.swift
@@ -40,10 +40,9 @@ extension DaemonCommand {
 
         mutating func run(using runtime: CommandRuntime) async throws {
             self.runtime = runtime
-            let socketPath = self.bridgeSocket ?? PeekabooBridgeConstants.peekabooSocketPath
-            let client = DaemonControlClient(socketPath: socketPath)
+            let targets = await DaemonControlResolver.targets(explicitSocket: self.bridgeSocket)
 
-            if let status = await client.fetchStatus() {
+            if let status = targets.first?.status {
                 self.output(status) {
                     DaemonStatusPrinter.render(status: status)
                 }

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/System/DaemonCommand+Stop.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/System/DaemonCommand+Stop.swift
@@ -18,8 +18,8 @@ extension DaemonCommand {
         @Option(name: .long, help: "Override bridge socket path")
         var bridgeSocket: String?
 
-        @Option(name: .long, help: "Seconds to wait for daemon shutdown (default 3)")
-        var waitSeconds: Int = 3
+        @Option(name: .long, help: "Seconds to wait for daemon shutdown (default 12)")
+        var waitSeconds: Int = DaemonControlClient.defaultShutdownWaitSeconds
 
         @RuntimeStorage private var runtime: CommandRuntime?
         var runtimeOptions = CommandRuntimeOptions()
@@ -45,10 +45,9 @@ extension DaemonCommand {
 
         mutating func run(using runtime: CommandRuntime) async throws {
             self.runtime = runtime
-            let socketPath = self.bridgeSocket ?? PeekabooBridgeConstants.peekabooSocketPath
-            let client = DaemonControlClient(socketPath: socketPath)
+            let targets = await DaemonControlResolver.targets(explicitSocket: self.bridgeSocket)
 
-            guard let status = await client.fetchStatus() else {
+            guard !targets.isEmpty else {
                 let stopped = PeekabooDaemonStatus(running: false)
                 self.output(stopped) {
                     DaemonStatusPrinter.render(status: stopped)
@@ -56,28 +55,25 @@ extension DaemonCommand {
                 return
             }
 
-            if status.mode == nil {
+            if targets.contains(where: { $0.status.mode == nil }) {
                 throw PeekabooError.operationError(message: "Connected host does not support daemon stop")
             }
 
-            let stopped = try await client.stopDaemon()
-            guard stopped else {
-                throw PeekabooError.operationError(message: "Daemon refused stop request")
-            }
-
-            let deadline = Date().addingTimeInterval(TimeInterval(self.waitSeconds))
-            while Date() < deadline {
-                if await client.fetchStatus() == nil {
-                    let stopped = PeekabooDaemonStatus(running: false)
-                    self.output(stopped) {
-                        DaemonStatusPrinter.render(status: stopped)
-                    }
-                    return
+            for target in targets {
+                guard try await target.client.stopAndWait(
+                    waitSeconds: self.waitSeconds,
+                    expectedPID: target.status.pid,
+                    requireIdentityMatch: DaemonControlClient.supportsSafeMigration(target.status)
+                )
+                else {
+                    throw PeekabooError.operationError(message: "Daemon refused stop request")
                 }
-                try await Task.sleep(nanoseconds: 200_000_000)
             }
 
-            throw PeekabooError.operationError(message: "Daemon did not stop within \(self.waitSeconds)s")
+            let stopped = PeekabooDaemonStatus(running: false)
+            self.output(stopped) {
+                DaemonStatusPrinter.render(status: stopped)
+            }
         }
     }
 }

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/System/DaemonCommand.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/System/DaemonCommand.swift
@@ -1,4 +1,5 @@
 import Commander
+import Darwin
 import Foundation
 import PeekabooBridge
 
@@ -23,6 +24,9 @@ struct DaemonCommand: ParsableCommand {
 }
 
 struct DaemonControlClient {
+    static let defaultShutdownWaitSeconds =
+        Int(ceil(PeekabooBridgeConstants.defaultRequestTimeoutSeconds)) + 2
+
     let socketPath: String
 
     func fetchStatus() async -> PeekabooDaemonStatus? {
@@ -39,9 +43,94 @@ struct DaemonControlClient {
         }
     }
 
-    func stopDaemon() async throws -> Bool {
+    func stopDaemon(expectedPID: pid_t? = nil) async throws -> Bool {
         let client = PeekabooBridgeClient(socketPath: self.socketPath)
+        if let expectedPID {
+            return try await client.daemonStop(expectedPID: expectedPID)
+        }
         return try await client.daemonStop()
+    }
+
+    func fetchControllableDaemonStatus() async -> PeekabooDaemonStatus? {
+        guard let status = await self.fetchStatus(),
+              Self.isControllableDaemonStatus(status)
+        else {
+            return nil
+        }
+        return status
+    }
+
+    func fetchReusableDaemonStatus() async -> PeekabooDaemonStatus? {
+        guard let status = await self.fetchStatus(),
+              Self.isReusableDaemonStatus(status)
+        else {
+            return nil
+        }
+        return status
+    }
+
+    static func isControllableDaemonStatus(_ status: PeekabooDaemonStatus) -> Bool {
+        status.mode != nil
+    }
+
+    static func isReusableDaemonStatus(_ status: PeekabooDaemonStatus) -> Bool {
+        status.mode == .auto || status.mode == .manual
+    }
+
+    static func migrationMode(for status: PeekabooDaemonStatus) -> PeekabooDaemonMode? {
+        self.isReusableDaemonStatus(status) ? status.mode : nil
+    }
+
+    static func isIdleForMigration(_ status: PeekabooDaemonStatus) -> Bool {
+        status.activity?.activeRequests ?? 0 == 0
+    }
+
+    static func supportsSafeMigration(_ status: PeekabooDaemonStatus) -> Bool {
+        status.supportsConditionalStop == true
+    }
+
+    func stopAndWait(
+        waitSeconds: Int,
+        expectedPID: pid_t?,
+        requireIdentityMatch: Bool = false
+    ) async throws -> Bool {
+        var requestError: (any Error)?
+        var accepted = false
+        do {
+            accepted = try await self.stopDaemon(
+                expectedPID: requireIdentityMatch ? expectedPID : nil
+            )
+        } catch {
+            requestError = error
+        }
+
+        if !accepted, requestError == nil {
+            return false
+        }
+
+        let deadline = Date().addingTimeInterval(TimeInterval(waitSeconds))
+        while Date() < deadline {
+            if await self.fetchControllableDaemonStatus() == nil {
+                if let expectedPID {
+                    if !Self.isProcessAlive(expectedPID) {
+                        return true
+                    }
+                } else if requestError == nil {
+                    return true
+                }
+            }
+            try await Task.sleep(nanoseconds: 200_000_000)
+        }
+
+        if let requestError {
+            throw requestError
+        }
+        return false
+    }
+
+    private static func isProcessAlive(_ pid: pid_t) -> Bool {
+        if kill(pid, 0) == 0 { return true }
+        return errno != ESRCH
     }
 
     private func fallbackHandshake(client: PeekabooBridgeClient) async -> PeekabooDaemonStatus? {
@@ -71,6 +160,42 @@ struct DaemonControlClient {
         } catch {
             return nil
         }
+    }
+}
+
+struct DaemonControlTarget {
+    let client: DaemonControlClient
+    let status: PeekabooDaemonStatus
+    let isLegacyDefault: Bool
+}
+
+enum DaemonControlResolver {
+    static func targets(explicitSocket: String?) async -> [DaemonControlTarget] {
+        if let explicitSocket {
+            let client = DaemonControlClient(socketPath: explicitSocket)
+            guard let status = await client.fetchStatus() else { return [] }
+            return [DaemonControlTarget(client: client, status: status, isLegacyDefault: false)]
+        }
+
+        var targets: [DaemonControlTarget] = []
+        let dedicatedClient = DaemonControlClient(socketPath: PeekabooBridgeConstants.daemonSocketPath)
+        if let status = await dedicatedClient.fetchControllableDaemonStatus() {
+            targets.append(DaemonControlTarget(
+                client: dedicatedClient,
+                status: status,
+                isLegacyDefault: false
+            ))
+        }
+
+        let legacyClient = DaemonControlClient(socketPath: PeekabooBridgeConstants.peekabooSocketPath)
+        if let status = await legacyClient.fetchControllableDaemonStatus() {
+            targets.append(DaemonControlTarget(
+                client: legacyClient,
+                status: status,
+                isLegacyDefault: true
+            ))
+        }
+        return targets
     }
 }
 

--- a/Apps/CLI/Sources/PeekabooCLI/Helpers/PermissionHelpers.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Helpers/PermissionHelpers.swift
@@ -44,19 +44,24 @@ enum PermissionHelpers {
 
     /// Try to fetch permissions from a remote Peekaboo Bridge host; falls back to local services on failure.
     @MainActor
-    private static func remotePermissionsStatus(socketPath override: String? = nil) async -> PermissionsStatus? {
-        let envSocket = ProcessInfo.processInfo.environment["PEEKABOO_BRIDGE_SOCKET"]
+    private static func remotePermissionsStatus(
+        services: any PeekabooServiceProviding,
+        socketPath override: String? = nil
+    ) async -> PermissionsStatus? {
+        let environment = ProcessInfo.processInfo.environment
+        let envSocket = environment["PEEKABOO_BRIDGE_SOCKET"]
         let resolvedOverride = override ?? envSocket
 
-        let candidates: [String] = if let explicit = resolvedOverride, !explicit.isEmpty {
-            [explicit]
-        } else {
-            [
-                PeekabooBridgeConstants.peekabooSocketPath,
-                PeekabooBridgeConstants.claudeSocketPath,
-                PeekabooBridgeConstants.clawdbotSocketPath,
-            ]
+        if resolvedOverride == nil,
+           let remoteServices = services as? RemotePeekabooServices,
+           let status = try? await remoteServices.permissionsStatus() {
+            return status
         }
+
+        let candidates = self.remotePermissionSocketPaths(
+            explicitSocket: resolvedOverride,
+            environment: environment
+        )
 
         let identity = PeekabooBridgeClientIdentity(
             bundleIdentifier: Bundle.main.bundleIdentifier,
@@ -68,6 +73,10 @@ enum PermissionHelpers {
         for socketPath in candidates {
             let client = PeekabooBridgeClient(socketPath: socketPath)
             do {
+                if resolvedOverride == nil,
+                   await DaemonControlClient(socketPath: socketPath).fetchReusableDaemonStatus() == nil {
+                    continue
+                }
                 let handshake = try await client.handshake(client: identity, requestedHost: nil)
                 guard handshake.supportedOperations.contains(.permissionsStatus) else { continue }
                 return try await client.permissionsStatus()
@@ -76,6 +85,20 @@ enum PermissionHelpers {
             }
         }
         return nil
+    }
+
+    static func remotePermissionSocketPaths(
+        explicitSocket: String?,
+        environment: [String: String] = ProcessInfo.processInfo.environment
+    ) -> [String] {
+        if let explicitSocket, !explicitSocket.isEmpty {
+            return [explicitSocket]
+        }
+        let daemonPath = DaemonLaunchPolicy.daemonSocketPath(environment: environment)
+        guard DaemonLaunchPolicy.shouldMigrateLegacyDaemon(targetSocketPath: daemonPath) else {
+            return [daemonPath]
+        }
+        return [daemonPath, PeekabooBridgeConstants.peekabooSocketPath]
     }
 
     /// Get current permission status for all Peekaboo permissions
@@ -100,7 +123,7 @@ enum PermissionHelpers {
     ) async -> PermissionStatusResponse {
         // Prefer remote host when available so sandboxes can reuse existing TCC grants.
         let remoteStatus = allowRemote
-            ? await self.remotePermissionsStatus(socketPath: socketPath)
+            ? await self.remotePermissionsStatus(services: services, socketPath: socketPath)
             : nil
 
         let status: PermissionsStatus
@@ -121,7 +144,7 @@ enum PermissionHelpers {
         socketPath: String? = nil
     ) async -> PermissionSourcesResponse {
         let remoteStatus = allowRemote
-            ? await self.remotePermissionsStatus(socketPath: socketPath)
+            ? await self.remotePermissionsStatus(services: services, socketPath: socketPath)
             : nil
         let localStatus = await self.localPermissionsStatus(services: services)
         let selectedSource = remoteStatus != nil ? "bridge" : "local"
@@ -148,9 +171,12 @@ enum PermissionHelpers {
 
     private static func localPermissionsStatus(services: any PeekabooServiceProviding) async -> PermissionsStatus {
         await Task { @MainActor in
-            let screenRecording = await services.screenCapture.hasScreenRecordingPermission()
-            let accessibility = await services.automation.hasAccessibilityPermission()
-            let postEvent = services.permissions.checkPostEventPermission()
+            let localServices: any PeekabooServiceProviding = services is RemotePeekabooServices
+                ? PeekabooServices()
+                : services
+            let screenRecording = await localServices.screenCapture.hasScreenRecordingPermission()
+            let accessibility = await localServices.automation.hasAccessibilityPermission()
+            let postEvent = localServices.permissions.checkPostEventPermission()
             return PermissionsStatus(
                 screenRecording: screenRecording,
                 accessibility: accessibility,

--- a/Apps/CLI/Sources/PeekabooCLI/Helpers/PermissionHelpers.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Helpers/PermissionHelpers.swift
@@ -73,11 +73,25 @@ enum PermissionHelpers {
         for socketPath in candidates {
             let client = PeekabooBridgeClient(socketPath: socketPath)
             do {
-                if resolvedOverride == nil,
-                   await DaemonControlClient(socketPath: socketPath).fetchReusableDaemonStatus() == nil {
-                    continue
-                }
                 let handshake = try await client.handshake(client: identity, requestedHost: nil)
+                if resolvedOverride == nil {
+                    guard let role = DaemonLaunchPolicy.implicitRuntimeCandidateRole(
+                        socketPath: socketPath,
+                        daemonSocketPath: DaemonLaunchPolicy.daemonSocketPath(environment: environment)
+                    ) else {
+                        continue
+                    }
+                    let daemonStatus = handshake.hostKind == .gui
+                        ? nil
+                        : await DaemonControlClient(socketPath: socketPath).fetchStatus()
+                    guard DaemonLaunchPolicy.isSelectableImplicitRuntimeCandidate(
+                        role: role,
+                        handshake: handshake,
+                        daemonStatus: daemonStatus
+                    ) else {
+                        continue
+                    }
+                }
                 guard handshake.supportedOperations.contains(.permissionsStatus) else { continue }
                 return try await client.permissionsStatus()
             } catch {

--- a/Apps/CLI/Tests/CLIRuntimeTests/CommandRuntimeInjectionTests.swift
+++ b/Apps/CLI/Tests/CLIRuntimeTests/CommandRuntimeInjectionTests.swift
@@ -1,3 +1,4 @@
+import Darwin
 import Foundation
 import PeekabooAgentRuntime
 import PeekabooAutomationKit
@@ -349,6 +350,59 @@ struct CommandRuntimeInjectionTests {
     }
 
     @Test
+    func `daemon defaults to its dedicated socket`() {
+        #expect(CommandRuntime.daemonSocketPath(environment: [:]) == PeekabooBridgeConstants.daemonSocketPath)
+        #expect(CommandRuntime.daemonSocketPath(environment: [:]) != PeekabooBridgeConstants.peekabooSocketPath)
+        #expect(DaemonLaunchPolicy.shouldMigrateLegacyDaemon(
+            targetSocketPath: PeekabooBridgeConstants.daemonSocketPath
+        ))
+        #expect(!DaemonLaunchPolicy.shouldMigrateLegacyDaemon(targetSocketPath: "/tmp/custom-daemon.sock"))
+    }
+
+    @Test
+    func `bridge diagnostics select only runtime-routed sockets`() {
+        let options = CommandRuntimeOptions()
+        let environment = ["PEEKABOO_DAEMON_SOCKET": "/tmp/custom-daemon.sock"]
+
+        #expect(BridgeDiagnostics.runtimeCandidateSocketPaths(
+            runtimeOptions: options,
+            environment: environment
+        ) == ["/tmp/custom-daemon.sock"])
+
+        let diagnosticPaths = BridgeDiagnostics.diagnosticSocketPaths(
+            runtimeOptions: options,
+            environment: environment
+        )
+        #expect(diagnosticPaths.first == "/tmp/custom-daemon.sock")
+        #expect(diagnosticPaths.contains(PeekabooBridgeConstants.peekabooSocketPath))
+        #expect(diagnosticPaths.contains(PeekabooBridgeConstants.claudeSocketPath))
+    }
+
+    @Test
+    func `default bridge diagnostics include the legacy runtime fallback`() {
+        let runtimePaths = BridgeDiagnostics.runtimeCandidateSocketPaths(
+            runtimeOptions: CommandRuntimeOptions(),
+            environment: [:]
+        )
+
+        #expect(runtimePaths == [
+            PeekabooBridgeConstants.daemonSocketPath,
+            PeekabooBridgeConstants.peekabooSocketPath,
+        ])
+    }
+
+    @Test
+    func `explicit bridge diagnostics probe only the explicit runtime socket`() {
+        var options = CommandRuntimeOptions()
+        options.bridgeSocketPath = "/tmp/explicit.sock"
+
+        #expect(BridgeDiagnostics.diagnosticSocketPaths(
+            runtimeOptions: options,
+            environment: ["PEEKABOO_DAEMON_SOCKET": "/tmp/ignored.sock"]
+        ) == ["/tmp/explicit.sock"])
+    }
+
+    @Test
     func `on demand daemon arguments use auto mode and idle timeout`() {
         let args = CommandRuntime.onDemandDaemonArguments(socketPath: "/tmp/daemon.sock", idleTimeoutSeconds: 12.5)
 
@@ -356,6 +410,117 @@ struct CommandRuntimeInjectionTests {
         #expect(args.contains("/tmp/daemon.sock"))
         #expect(args.contains("--idle-timeout-seconds"))
         #expect(args.contains("12.500"))
+    }
+
+    @Test
+    func `manual daemon migration preserves mode without idle timeout`() {
+        let args = DaemonLaunchPolicy.daemonArguments(
+            socketPath: "/tmp/daemon.sock",
+            mode: .manual,
+            pollIntervalMs: 375,
+            idleTimeoutSeconds: 12.5
+        )
+
+        #expect(args.contains("manual"))
+        #expect(args.contains("--poll-interval-ms"))
+        #expect(args.contains("375"))
+        #expect(!args.contains("--idle-timeout-seconds"))
+    }
+
+    @Test
+    func `automatic daemon migration preserves live settings`() {
+        let status = PeekabooDaemonStatus(
+            running: true,
+            mode: .auto,
+            windowTracker: PeekabooDaemonWindowTrackerStatus(
+                trackedWindows: 1,
+                lastEventAt: nil,
+                lastPollAt: nil,
+                axObserverCount: 1,
+                cgPollIntervalMs: 425
+            ),
+            activity: PeekabooDaemonActivityStatus(
+                activeRequests: 0,
+                lastActivityAt: nil,
+                idleTimeoutSeconds: 47.5,
+                idleExitAt: nil
+            ),
+            supportsConditionalStop: true
+        )
+
+        let args = DaemonLaunchPolicy.migratedDaemonArguments(
+            socketPath: "/tmp/daemon.sock",
+            status: status,
+            fallbackIdleTimeoutSeconds: 300
+        )
+
+        #expect(args?.contains("auto") == true)
+        #expect(args?.contains("425") == true)
+        #expect(args?.contains("47.500") == true)
+    }
+
+    @Test
+    func `daemon startup waits for a draining lease`() async throws {
+        let socketPath = "/tmp/peekaboo-daemon-wait-\(UUID().uuidString).sock"
+        let leasePath = "\(socketPath).lock"
+        let leaseFD = open(
+            leasePath,
+            O_CREAT | O_EXCL | O_RDWR | O_CLOEXEC | O_NOFOLLOW,
+            S_IRUSR | S_IWUSR
+        )
+        #expect(leaseFD >= 0)
+        defer {
+            if leaseFD >= 0 {
+                flock(leaseFD, LOCK_UN)
+                close(leaseFD)
+            }
+            unlink(leasePath)
+        }
+        #expect(flock(leaseFD, LOCK_EX | LOCK_NB) == 0)
+
+        let waitTask = Task {
+            await DaemonLaunchPolicy.waitForDaemonSocketAvailability(
+                socketPath: socketPath,
+                client: DaemonControlClient(socketPath: socketPath),
+                timeout: 1
+            )
+        }
+        try await Task.sleep(nanoseconds: 200_000_000)
+        #expect(flock(leaseFD, LOCK_UN) == 0)
+
+        #expect(await waitTask.value == .available)
+    }
+
+    @Test
+    @MainActor
+    func `replacement rollback retries after active work drains`() async throws {
+        let socketPath = "/tmp/peekaboo-daemon-rollback-\(UUID().uuidString).sock"
+        defer {
+            unlink(socketPath)
+            unlink("\(socketPath).lock")
+        }
+        let daemon = PeekabooDaemon(configuration: .init(
+            mode: .manual,
+            bridgeSocketPath: socketPath,
+            allowlistedTeams: [],
+            windowTrackingEnabled: false,
+            hostKind: .onDemand
+        ))
+        try await daemon.startChecked()
+        #expect(await daemon.admitActivity(operation: .captureScreen))
+
+        let status = await daemon.daemonStatus()
+        let rollbackTask = Task {
+            await DaemonLaunchPolicy.stopReplacement(
+                client: DaemonControlClient(socketPath: socketPath),
+                replacement: .init(status: status, processID: getpid())
+            )
+        }
+        try await Task.sleep(nanoseconds: 300_000_000)
+        await daemon.recordActivityEnd(operation: .captureScreen)
+
+        #expect(await rollbackTask.value)
+        await daemon.waitUntilStopped()
     }
 
     @Test

--- a/Apps/CLI/Tests/CLIRuntimeTests/CommandRuntimeInjectionTests.swift
+++ b/Apps/CLI/Tests/CLIRuntimeTests/CommandRuntimeInjectionTests.swift
@@ -360,6 +360,66 @@ struct CommandRuntimeInjectionTests {
     }
 
     @Test
+    func `implicit runtime candidates preserve the default app fallback only`() {
+        #expect(DaemonLaunchPolicy.implicitRuntimeCandidateRole(
+            socketPath: PeekabooBridgeConstants.daemonSocketPath,
+            daemonSocketPath: PeekabooBridgeConstants.daemonSocketPath
+        ) == .reusableDaemon)
+        #expect(DaemonLaunchPolicy.implicitRuntimeCandidateRole(
+            socketPath: PeekabooBridgeConstants.peekabooSocketPath,
+            daemonSocketPath: PeekabooBridgeConstants.daemonSocketPath
+        ) == .defaultAppFallback)
+        #expect(DaemonLaunchPolicy.implicitRuntimeCandidateRole(
+            socketPath: PeekabooBridgeConstants.peekabooSocketPath,
+            daemonSocketPath: "/tmp/custom-daemon.sock"
+        ) == nil)
+    }
+
+    @Test
+    func `default app fallback accepts GUI hosts and legacy daemons`() {
+        let guiHandshake = PeekabooBridgeHandshakeResponse(
+            negotiatedVersion: PeekabooBridgeConstants.protocolVersion,
+            hostKind: .gui,
+            build: nil,
+            supportedOperations: [.captureScreen]
+        )
+        let daemonHandshake = PeekabooBridgeHandshakeResponse(
+            negotiatedVersion: PeekabooBridgeConstants.protocolVersion,
+            hostKind: .onDemand,
+            build: nil,
+            supportedOperations: [.captureScreen]
+        )
+        let embeddedHandshake = PeekabooBridgeHandshakeResponse(
+            negotiatedVersion: PeekabooBridgeConstants.protocolVersion,
+            hostKind: .inProcess,
+            build: nil,
+            supportedOperations: [.captureScreen]
+        )
+        let daemonStatus = PeekabooDaemonStatus(running: true, mode: .auto)
+
+        #expect(DaemonLaunchPolicy.isSelectableImplicitRuntimeCandidate(
+            role: .defaultAppFallback,
+            handshake: guiHandshake,
+            daemonStatus: nil
+        ))
+        #expect(DaemonLaunchPolicy.isSelectableImplicitRuntimeCandidate(
+            role: .defaultAppFallback,
+            handshake: daemonHandshake,
+            daemonStatus: daemonStatus
+        ))
+        #expect(!DaemonLaunchPolicy.isSelectableImplicitRuntimeCandidate(
+            role: .defaultAppFallback,
+            handshake: embeddedHandshake,
+            daemonStatus: nil
+        ))
+        #expect(!DaemonLaunchPolicy.isSelectableImplicitRuntimeCandidate(
+            role: .reusableDaemon,
+            handshake: guiHandshake,
+            daemonStatus: nil
+        ))
+    }
+
+    @Test
     func `bridge diagnostics select only runtime-routed sockets`() {
         let options = CommandRuntimeOptions()
         let environment = ["PEEKABOO_DAEMON_SOCKET": "/tmp/custom-daemon.sock"]

--- a/Apps/CLI/Tests/CoreCLITests/DaemonCommandTests.swift
+++ b/Apps/CLI/Tests/CoreCLITests/DaemonCommandTests.swift
@@ -1,3 +1,5 @@
+import Commander
+import PeekabooBridge
 import Testing
 @testable import PeekabooCLI
 
@@ -23,7 +25,7 @@ struct DaemonCommandTests {
     func `Daemon stop defaults`() throws {
         let command = try DaemonCommand.Stop.parse([])
         #expect(command.bridgeSocket == nil)
-        #expect(command.waitSeconds == 3)
+        #expect(command.waitSeconds == DaemonControlClient.defaultShutdownWaitSeconds)
     }
 
     @Test
@@ -49,5 +51,85 @@ struct DaemonCommandTests {
         #expect(command.bridgeSocket == "/tmp/peekaboo.sock")
         #expect(command.pollIntervalMs == 500)
         #expect(command.idleTimeoutSeconds == 2.5)
+    }
+
+    @Test
+    func `standalone MCP daemon mode is rejected`() {
+        #expect(throws: ValidationError.self) {
+            try DaemonCommand.Run.configuration(
+                mode: "mcp",
+                bridgeSocket: nil,
+                pollInterval: 1,
+                idleTimeoutSeconds: nil
+            )
+        }
+    }
+
+    @Test
+    func `legacy migration accepts daemon status only`() {
+        let bridge = PeekabooDaemonBridgeStatus(
+            socketPath: "/tmp/bridge.sock",
+            hostKind: .onDemand,
+            allowedOperations: [.daemonStatus, .daemonStop]
+        )
+        let daemon = PeekabooDaemonStatus(
+            running: true,
+            mode: .manual,
+            bridge: bridge,
+            supportsConditionalStop: true
+        )
+        let legacyMCPDaemon = PeekabooDaemonStatus(
+            running: true,
+            mode: .mcp,
+            bridge: PeekabooDaemonBridgeStatus(
+                socketPath: "/tmp/bridge.sock",
+                hostKind: .inProcess,
+                allowedOperations: [.daemonStatus, .daemonStop]
+            )
+        )
+        let appHost = PeekabooDaemonStatus(
+            running: true,
+            mode: nil,
+            bridge: PeekabooDaemonBridgeStatus(
+                socketPath: "/tmp/bridge.sock",
+                hostKind: .gui,
+                allowedOperations: [.permissionsStatus]
+            )
+        )
+
+        #expect(DaemonControlClient.isControllableDaemonStatus(daemon))
+        #expect(DaemonControlClient.isControllableDaemonStatus(legacyMCPDaemon))
+        #expect(!DaemonControlClient.isControllableDaemonStatus(appHost))
+        #expect(DaemonControlClient.isReusableDaemonStatus(daemon))
+        #expect(!DaemonControlClient.isReusableDaemonStatus(legacyMCPDaemon))
+        #expect(!DaemonControlClient.isReusableDaemonStatus(appHost))
+        #expect(DaemonControlClient.migrationMode(for: daemon) == .manual)
+        #expect(DaemonControlClient.migrationMode(for: legacyMCPDaemon) == nil)
+        #expect(DaemonControlClient.migrationMode(for: appHost) == nil)
+        #expect(DaemonControlClient.supportsSafeMigration(daemon))
+        #expect(!DaemonControlClient.supportsSafeMigration(legacyMCPDaemon))
+
+        let autoDaemon = PeekabooDaemonStatus(
+            running: true,
+            mode: .auto,
+            bridge: bridge,
+            supportsConditionalStop: true
+        )
+        #expect(DaemonControlClient.migrationMode(for: autoDaemon) == .auto)
+        #expect(DaemonControlClient.isIdleForMigration(autoDaemon))
+
+        let busyDaemon = PeekabooDaemonStatus(
+            running: true,
+            mode: .auto,
+            bridge: bridge,
+            activity: PeekabooDaemonActivityStatus(
+                activeRequests: 1,
+                lastActivityAt: nil,
+                idleTimeoutSeconds: 300,
+                idleExitAt: nil
+            ),
+            supportsConditionalStop: true
+        )
+        #expect(!DaemonControlClient.isIdleForMigration(busyDaemon))
     }
 }

--- a/Apps/CLI/Tests/CoreCLITests/PeekabooBridgeConstantsTests.swift
+++ b/Apps/CLI/Tests/CoreCLITests/PeekabooBridgeConstantsTests.swift
@@ -3,6 +3,12 @@ import Testing
 
 struct PeekabooBridgeConstantsTests {
     @Test
+    func `Peekaboo host sockets have distinct roles`() {
+        #expect(PeekabooBridgeConstants.peekabooSocketPath.hasSuffix("/Peekaboo/bridge.sock"))
+        #expect(PeekabooBridgeConstants.daemonSocketPath.hasSuffix("/Peekaboo/daemon.sock"))
+    }
+
+    @Test
     func `Claude socket path uses Application Support/Claude`() {
         #expect(PeekabooBridgeConstants.claudeSocketPath.hasSuffix("/Claude/bridge.sock"))
     }

--- a/Apps/CLI/Tests/CoreCLITests/PeekabooBridgeHostUnauthorizedResponseTests.swift
+++ b/Apps/CLI/Tests/CoreCLITests/PeekabooBridgeHostUnauthorizedResponseTests.swift
@@ -25,7 +25,7 @@ struct PeekabooBridgeHostUnauthorizedResponseTests {
             requestTimeoutSec: 2
         )
 
-        await host.start()
+        try await host.startChecked()
         defer { Task { await host.stop() } }
 
         let requestData = try JSONEncoder.peekabooBridgeEncoder().encode(PeekabooBridgeRequest.permissionsStatus)

--- a/Apps/CLI/Tests/CoreCLITests/PermissionHelpersTests.swift
+++ b/Apps/CLI/Tests/CoreCLITests/PermissionHelpersTests.swift
@@ -1,7 +1,41 @@
+import PeekabooBridge
 import Testing
 @testable import PeekabooCLI
 
 struct PermissionHelpersTests {
+    @Test
+    func `permission bridge follows the runtime daemon socket`() {
+        let paths = PermissionHelpers.remotePermissionSocketPaths(
+            explicitSocket: nil,
+            environment: ["PEEKABOO_DAEMON_SOCKET": "/tmp/custom-daemon.sock"]
+        )
+
+        #expect(paths == ["/tmp/custom-daemon.sock"])
+    }
+
+    @Test
+    func `permission bridge includes the default legacy runtime fallback`() {
+        let paths = PermissionHelpers.remotePermissionSocketPaths(
+            explicitSocket: nil,
+            environment: [:]
+        )
+
+        #expect(paths == [
+            PeekabooBridgeConstants.daemonSocketPath,
+            PeekabooBridgeConstants.peekabooSocketPath,
+        ])
+    }
+
+    @Test
+    func `permission bridge explicit socket overrides the daemon`() {
+        let paths = PermissionHelpers.remotePermissionSocketPaths(
+            explicitSocket: "/tmp/explicit.sock",
+            environment: ["PEEKABOO_DAEMON_SOCKET": "/tmp/custom-daemon.sock"]
+        )
+
+        #expect(paths == ["/tmp/explicit.sock"])
+    }
+
     @Test
     func `bridge hint explains remote screen recording denial`() {
         let response = PermissionHelpers.PermissionStatusResponse(

--- a/Apps/Mac/Peekaboo/PeekabooApp.swift
+++ b/Apps/Mac/Peekaboo/PeekabooApp.swift
@@ -190,6 +190,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     let updaterController: any UpdaterProviding = makeUpdaterController()
     var windowOpener: ((String) -> Void)?
     private var bridgeHost: PeekabooBridgeHost?
+    private var bridgeStartTask: Task<Void, Never>?
     private var didSchedulePermissionsOnboarding = false
 
     // State connections
@@ -261,7 +262,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             self.didSetupNotificationObservers = true
         }
 
-        if self.bridgeHost == nil {
+        if self.bridgeHost == nil, self.bridgeStartTask == nil {
             self.startBridgeHost(services: context.services)
         }
 
@@ -309,6 +310,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     func applicationWillTerminate(_: Notification) {
         self.statusBarController?.removeStatusItem()
         self.statusBarController = nil
+        self.bridgeStartTask?.cancel()
+        self.bridgeStartTask = nil
 
         if let bridgeHost = self.bridgeHost {
             Task { await bridgeHost.stop() }
@@ -441,13 +444,36 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         let allowlistedTeams: Set = ["Y5PE65HELJ"]
 
         self.logger.info("Starting Peekaboo Bridge at \(PeekabooBridgeConstants.peekabooSocketPath, privacy: .public)")
-        self.bridgeHost = PeekabooBridgeBootstrap.startHost(
-            services: services,
-            hostKind: .gui,
-            socketPath: PeekabooBridgeConstants.peekabooSocketPath,
-            allowlistedTeams: allowlistedTeams,
-            allowlistedBundles: allowlistedBundles,
-            allowedOperations: PeekabooBridgeOperation.remoteDefaultAllowlist)
+        self.bridgeStartTask = Task { @MainActor [weak self] in
+            guard let self else { return }
+            defer { self.bridgeStartTask = nil }
+            var retryDelayNanoseconds: UInt64 = 250_000_000
+            while !Task.isCancelled {
+                do {
+                    self.bridgeHost = try await PeekabooBridgeBootstrap.startHostChecked(
+                        services: services,
+                        hostKind: .gui,
+                        socketPath: PeekabooBridgeConstants.peekabooSocketPath,
+                        allowlistedTeams: allowlistedTeams,
+                        allowlistedBundles: allowlistedBundles,
+                        allowedOperations: PeekabooBridgeOperation.remoteDefaultAllowlist)
+                    return
+                } catch PeekabooBridgeHostError.socketAlreadyOwned {
+                    self.logger.info(
+                        "Peekaboo Bridge socket is busy; retrying after legacy host migration")
+                    do {
+                        try await Task.sleep(nanoseconds: retryDelayNanoseconds)
+                    } catch {
+                        return
+                    }
+                    retryDelayNanoseconds = min(retryDelayNanoseconds * 2, 5_000_000_000)
+                } catch {
+                    self.logger
+                        .error("Failed to start Peekaboo Bridge: \(error.localizedDescription, privacy: .public)")
+                    return
+                }
+            }
+        }
     }
 
     // MARK: - Public Access

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+- Bridge hosts now use atomic lease-backed socket ownership and bounded nonblocking transport, keep Peekaboo.app and the reusable daemon on distinct paths, preserve lifecycle settings while migrating legacy daemons, prevent MCP from hosting a bridge listener, safely recover stale sockets, and release abandoned client connections instead of wedging. Thanks @Artifact-LV for #184.
+
 ## [3.4.2] - 2026-06-12
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 ### Fixed
-- Bridge hosts now use atomic lease-backed socket ownership and bounded nonblocking transport, keep Peekaboo.app and the reusable daemon on distinct paths, preserve lifecycle settings while migrating legacy daemons, prevent MCP from hosting a bridge listener, safely recover stale sockets, and release abandoned client connections instead of wedging. Thanks @Artifact-LV for #184.
+- Bridge hosts now use atomic lease-backed socket ownership and bounded nonblocking transport, keep Peekaboo.app and the reusable daemon on distinct paths while preserving the healthy app's TCC-backed fallback, preserve lifecycle settings while migrating legacy daemons, prevent MCP from hosting a bridge listener, safely recover stale sockets, and release abandoned client connections instead of wedging. Thanks @Artifact-LV for #184.
 
 ## [3.4.2] - 2026-06-12
 

--- a/Core/PeekabooCore/Sources/PeekabooBridge/DaemonModels.swift
+++ b/Core/PeekabooCore/Sources/PeekabooBridge/DaemonModels.swift
@@ -8,6 +8,14 @@ public enum PeekabooDaemonMode: String, Codable, Sendable {
     case mcp
 }
 
+public struct PeekabooBridgeDaemonStopRequest: Codable, Sendable {
+    public let expectedPID: pid_t
+
+    public init(expectedPID: pid_t) {
+        self.expectedPID = expectedPID
+    }
+}
+
 public struct PeekabooDaemonActivityStatus: Codable, Sendable {
     public let activeRequests: Int
     public let lastActivityAt: Date?
@@ -95,6 +103,7 @@ public struct PeekabooDaemonStatus: Codable, Sendable {
     public let windowTracker: PeekabooDaemonWindowTrackerStatus?
     public let browser: PeekabooBridgeBrowserStatus?
     public let activity: PeekabooDaemonActivityStatus?
+    public let supportsConditionalStop: Bool?
 
     public init(
         running: Bool,
@@ -106,7 +115,8 @@ public struct PeekabooDaemonStatus: Codable, Sendable {
         snapshots: PeekabooDaemonSnapshotStatus? = nil,
         windowTracker: PeekabooDaemonWindowTrackerStatus? = nil,
         browser: PeekabooBridgeBrowserStatus? = nil,
-        activity: PeekabooDaemonActivityStatus? = nil)
+        activity: PeekabooDaemonActivityStatus? = nil,
+        supportsConditionalStop: Bool? = nil)
     {
         self.running = running
         self.pid = pid
@@ -118,6 +128,7 @@ public struct PeekabooDaemonStatus: Codable, Sendable {
         self.windowTracker = windowTracker
         self.browser = browser
         self.activity = activity
+        self.supportsConditionalStop = supportsConditionalStop
     }
 }
 
@@ -133,4 +144,10 @@ public protocol PeekabooDaemonControlProviding: AnyObject, Sendable {
 extension PeekabooDaemonControlProviding {
     public func recordActivityStart(operation _: PeekabooBridgeOperation) async {}
     public func recordActivityEnd(operation _: PeekabooBridgeOperation) async {}
+}
+
+@MainActor
+public protocol PeekabooConditionalDaemonControlProviding: PeekabooDaemonControlProviding {
+    func requestStop(expectedPID: pid_t) async -> Bool
+    func admitActivity(operation: PeekabooBridgeOperation) async -> Bool
 }

--- a/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeBootstrap.swift
+++ b/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeBootstrap.swift
@@ -21,17 +21,44 @@ public enum PeekabooBridgeBootstrap {
             allowlistedBundles: allowlistedBundles,
             allowedOperations: allowedOperations,
             daemonControl: daemonControl)
-
         let host = PeekabooBridgeHost(
             socketPath: socketPath,
             server: server,
             maxMessageBytes: maxMessageBytes,
             allowedTeamIDs: allowlistedTeams,
             requestTimeoutSec: requestTimeoutSec)
-
         Task {
             await host.start()
         }
+        return host
+    }
+
+    @discardableResult
+    public static func startHostChecked(
+        services: any PeekabooBridgeServiceProviding,
+        hostKind: PeekabooBridgeHostKind,
+        socketPath: String,
+        allowlistedTeams: Set<String>,
+        allowlistedBundles: Set<String>,
+        daemonControl: (any PeekabooDaemonControlProviding)? = nil,
+        allowedOperations: Set<PeekabooBridgeOperation> = PeekabooBridgeOperation.remoteDefaultAllowlist,
+        maxMessageBytes: Int = 64 * 1024 * 1024,
+        requestTimeoutSec: TimeInterval = 10) async throws -> PeekabooBridgeHost
+    {
+        let server = PeekabooBridgeServer(
+            services: services,
+            hostKind: hostKind,
+            allowlistedTeams: allowlistedTeams,
+            allowlistedBundles: allowlistedBundles,
+            allowedOperations: allowedOperations,
+            daemonControl: daemonControl)
+        let host = PeekabooBridgeHost(
+            socketPath: socketPath,
+            server: server,
+            maxMessageBytes: maxMessageBytes,
+            allowedTeamIDs: allowlistedTeams,
+            requestTimeoutSec: requestTimeoutSec)
+        try await host.startChecked()
         return host
     }
 }

--- a/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeClient+Status.swift
+++ b/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeClient+Status.swift
@@ -41,6 +41,15 @@ extension PeekabooBridgeClient {
 
     public func daemonStop() async throws -> Bool {
         let response = try await self.send(.daemonStop)
+        return try Self.decodeDaemonStopResponse(response)
+    }
+
+    public func daemonStop(expectedPID: pid_t) async throws -> Bool {
+        let response = try await self.send(.daemonStopIf(.init(expectedPID: expectedPID)))
+        return try Self.decodeDaemonStopResponse(response)
+    }
+
+    private static func decodeDaemonStopResponse(_ response: PeekabooBridgeResponse) throws -> Bool {
         switch response {
         case let .bool(stopped):
             return stopped

--- a/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeClient+Transport.swift
+++ b/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeClient+Transport.swift
@@ -83,6 +83,8 @@ extension PeekabooBridgeClient {
         defer { close(fd) }
 
         Self.disableSigPipe(fd: fd)
+        try PeekabooBridgeSocketIO.configureConnectedSocket(fd)
+        let deadline = Date().addingTimeInterval(timeoutSec)
 
         var addr = sockaddr_un()
         addr.sun_family = sa_family_t(AF_UNIX)
@@ -97,66 +99,16 @@ extension PeekabooBridgeClient {
         let connectResult = withUnsafePointer(to: &addr) { ptr in
             connect(fd, UnsafePointer<sockaddr>(OpaquePointer(ptr)), len)
         }
-        guard connectResult == 0 else { throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .ECONNREFUSED) }
+        if connectResult != 0 {
+            guard errno == EINPROGRESS || errno == EAGAIN || errno == EALREADY else {
+                throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .ECONNREFUSED)
+            }
+            try PeekabooBridgeSocketIO.finishConnect(fd: fd, deadline: deadline)
+        }
 
-        try Self.writeAll(fd: fd, data: requestData)
+        try PeekabooBridgeSocketIO.writeAll(fd: fd, data: requestData, deadline: deadline)
         _ = shutdown(fd, SHUT_WR)
 
-        return try Self.readAll(fd: fd, maxBytes: maxResponseBytes, timeoutSec: timeoutSec)
-    }
-
-    private nonisolated static func writeAll(fd: Int32, data: Data) throws {
-        try data.withUnsafeBytes { buf in
-            guard let base = buf.baseAddress else { return }
-            var written = 0
-            while written < data.count {
-                let n = write(fd, base.advanced(by: written), data.count - written)
-                if n > 0 {
-                    written += n
-                    continue
-                }
-                if n == -1, errno == EINTR { continue }
-                throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO)
-            }
-        }
-    }
-
-    private nonisolated static func readAll(fd: Int32, maxBytes: Int, timeoutSec: TimeInterval) throws -> Data {
-        let deadline = Date().addingTimeInterval(timeoutSec)
-        var data = Data()
-        var buffer = [UInt8](repeating: 0, count: 16 * 1024)
-
-        while true {
-            let remaining = deadline.timeIntervalSinceNow
-            if remaining <= 0 {
-                throw POSIXError(.ETIMEDOUT)
-            }
-
-            var pfd = pollfd(fd: fd, events: Int16(POLLIN), revents: 0)
-            let sliceMs = max(1.0, min(remaining, 0.25) * 1000.0)
-            let polled = poll(&pfd, 1, Int32(sliceMs))
-            if polled == 0 { continue }
-            if polled < 0 {
-                if errno == EINTR { continue }
-                throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO)
-            }
-
-            let n = buffer.withUnsafeMutableBytes { read(fd, $0.baseAddress!, $0.count) }
-            if n > 0 {
-                data.append(buffer, count: n)
-                if data.count > maxBytes {
-                    throw POSIXError(.EMSGSIZE)
-                }
-                continue
-            }
-
-            if n == 0 {
-                return data
-            }
-
-            if errno == EINTR { continue }
-            if errno == EAGAIN { continue }
-            throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO)
-        }
+        return try PeekabooBridgeSocketIO.readAll(fd: fd, maxBytes: maxResponseBytes, deadline: deadline)
     }
 }

--- a/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeConstants.swift
+++ b/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeConstants.swift
@@ -5,17 +5,22 @@ public enum PeekabooBridgeConstants {
 
     /// Socket hosted by Peekaboo.app (primary host).
     public static var peekabooSocketPath: String {
-        self.applicationSupportSocketPath(appDirectoryName: "Peekaboo")
+        self.applicationSupportSocketPath(appDirectoryName: "Peekaboo", socketName: self.socketName)
+    }
+
+    /// Socket hosted by the reusable on-demand or manually started daemon.
+    public static var daemonSocketPath: String {
+        self.applicationSupportSocketPath(appDirectoryName: "Peekaboo", socketName: "daemon.sock")
     }
 
     /// Socket hosted by Claude.app (fallback host; piggyback on Claude Desktop TCC grants).
     public static var claudeSocketPath: String {
-        self.applicationSupportSocketPath(appDirectoryName: "Claude")
+        self.applicationSupportSocketPath(appDirectoryName: "Claude", socketName: self.socketName)
     }
 
     /// Socket hosted by Clawdbot.app (fallback host).
     public static var clawdbotSocketPath: String {
-        self.applicationSupportSocketPath(appDirectoryName: "clawdbot")
+        self.applicationSupportSocketPath(appDirectoryName: "clawdbot", socketName: self.socketName)
     }
 
     /// Current protocol version supported by this build.
@@ -27,6 +32,9 @@ public enum PeekabooBridgeConstants {
     /// Compatible protocol range for negotiation. Update when introducing breaking changes.
     public static let supportedProtocolRange: ClosedRange<PeekabooBridgeProtocolVersion> =
         minimumProtocolVersion...protocolVersion
+
+    /// Default deadline for one Bridge request or response.
+    public static let defaultRequestTimeoutSeconds: TimeInterval = 10
 
     /// Build identifier advertised during handshake (falls back to "dev").
     public static var buildIdentifier: String {
@@ -43,12 +51,12 @@ public enum PeekabooBridgeConstants {
         }
     }
 
-    private static func applicationSupportSocketPath(appDirectoryName: String) -> String {
+    private static func applicationSupportSocketPath(appDirectoryName: String, socketName: String) -> String {
         let fileManager = FileManager.default
         let baseDirectory = fileManager.urls(for: .applicationSupportDirectory, in: .userDomainMask).first
             ?? fileManager.homeDirectoryForCurrentUser.appendingPathComponent("Library/Application Support")
         let directory = baseDirectory.appendingPathComponent(appDirectoryName, isDirectory: true)
-        return directory.appendingPathComponent(self.socketName, isDirectory: false).path
+        return directory.appendingPathComponent(socketName, isDirectory: false).path
     }
 }
 

--- a/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeHost.swift
+++ b/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeHost.swift
@@ -3,15 +3,108 @@ import Foundation
 import OSLog
 import Security
 
+public enum PeekabooBridgeHostError: Error, LocalizedError, Sendable {
+    case socketAlreadyOwned(path: String)
+    case unsafeLeaseFile(path: String)
+    case socketPathIsNotSocket(path: String)
+    case socketPathTooLong(path: String)
+    case systemCallFailed(operation: String, path: String, code: Int32)
+
+    public var errorDescription: String? {
+        switch self {
+        case let .socketAlreadyOwned(path):
+            "Bridge socket is already owned by another host: \(path)"
+        case let .unsafeLeaseFile(path):
+            "Refusing to use an unsafe bridge lease file: \(path)"
+        case let .socketPathIsNotSocket(path):
+            "Refusing to replace a non-socket bridge path: \(path)"
+        case let .socketPathTooLong(path):
+            "Bridge socket path is too long: \(path)"
+        case let .systemCallFailed(operation, path, code):
+            "\(operation) failed for \(path): \(String(cString: strerror(code)))"
+        }
+    }
+}
+
 /// Lightweight UNIX-domain socket host for Peekaboo automation.
 ///
 /// This is a single-request-per-connection protocol: clients write one JSON request then half-close,
 /// the host replies with one JSON response and closes.
 public final actor PeekabooBridgeHost {
+    private struct SocketIdentity: Equatable {
+        let device: dev_t
+        let inode: ino_t
+    }
+
+    private struct SocketStatus: Equatable {
+        let identity: SocketIdentity
+        let mode: mode_t
+        let ownerUID: uid_t
+
+        var isSocket: Bool {
+            (self.mode & S_IFMT) == S_IFSOCK
+        }
+    }
+
+    private struct ProcessMetadata {
+        let ownerUID: uid_t
+        let status: UInt32
+    }
+
+    private enum LegacySocketOwnerState {
+        case held
+        case unheld
+        case indeterminate
+    }
+
+    private enum LeaseMarkerState {
+        case empty
+        case identity(SocketIdentity)
+        case incomplete
+        case invalid
+    }
+
+    private struct LeaseMarkerSnapshot {
+        let state: LeaseMarkerState
+    }
+
+    private struct SocketLease {
+        let fd: Int32
+        let recordedIdentity: SocketIdentity?
+    }
+
+    private actor ConnectionTracker {
+        private var activeCount = 0
+        private var idleContinuations: [CheckedContinuation<Void, Never>] = []
+
+        func begin() {
+            self.activeCount += 1
+        }
+
+        func end() {
+            self.activeCount = max(0, self.activeCount - 1)
+            guard self.activeCount == 0 else { return }
+            let continuations = self.idleContinuations
+            self.idleContinuations.removeAll()
+            continuations.forEach { $0.resume() }
+        }
+
+        func waitForIdle() async {
+            guard self.activeCount > 0 else { return }
+            await withCheckedContinuation { continuation in
+                self.idleContinuations.append(continuation)
+            }
+        }
+    }
+
     private nonisolated static let logger = Logger(subsystem: "boo.peekaboo.bridge", category: "host")
+    private nonisolated static let leaseMarkerPrefix = "peekaboo-bridge-lease-v1"
 
     private var listenFD: Int32 = -1
+    private var leaseFD: Int32 = -1
+    private var socketIdentity: SocketIdentity?
     private var acceptTask: Task<Void, Never>?
+    private let connectionTracker = ConnectionTracker()
 
     private let socketPath: String
     private let maxMessageBytes: Int
@@ -24,7 +117,7 @@ public final actor PeekabooBridgeHost {
         server: PeekabooBridgeServer,
         maxMessageBytes: Int = 64 * 1024 * 1024,
         allowedTeamIDs: Set<String> = ["Y5PE65HELJ"],
-        requestTimeoutSec: TimeInterval = 10)
+        requestTimeoutSec: TimeInterval = PeekabooBridgeConstants.defaultRequestTimeoutSeconds)
     {
         self.socketPath = socketPath
         self.server = server
@@ -34,47 +127,47 @@ public final actor PeekabooBridgeHost {
     }
 
     public func start() {
+        do {
+            try self.startChecked()
+        } catch {
+            Self.logger.error(
+                "Failed to start bridge host at \(self.socketPath, privacy: .public): \(error.localizedDescription)")
+        }
+    }
+
+    public func startChecked() throws {
         guard self.listenFD == -1 else { return }
 
         let path = self.socketPath
         let fm = FileManager.default
 
-        let dir = (path as NSString).deletingLastPathComponent
-        try? fm.createDirectory(atPath: dir, withIntermediateDirectories: true)
-        unlink(path)
+        let parent = (path as NSString).deletingLastPathComponent
+        let dir = parent.isEmpty ? "." : parent
+        try fm.createDirectory(atPath: dir, withIntermediateDirectories: true)
 
-        let fd = socket(AF_UNIX, SOCK_STREAM, 0)
-        guard fd >= 0 else { return }
-
-        var addr = sockaddr_un()
-        addr.sun_family = sa_family_t(AF_UNIX)
-        let capacity = MemoryLayout.size(ofValue: addr.sun_path)
-        let copied = path.withCString { cstr -> Int in
-            strlcpy(&addr.sun_path.0, cstr, capacity)
-        }
-        if copied >= capacity {
-            close(fd)
-            return
-        }
-        addr.sun_len = UInt8(MemoryLayout.size(ofValue: addr))
-        let len = socklen_t(MemoryLayout.size(ofValue: addr))
-        if bind(fd, withUnsafePointer(to: &addr) { UnsafePointer<sockaddr>(OpaquePointer($0)) }, len) != 0 {
-            close(fd)
-            return
+        let lease = try Self.acquireLease(path: path)
+        do {
+            try Self.clearLeaseIdentity(fd: lease.fd, path: path)
+            let (fd, identity) = try Self.makeListeningSocket(
+                path: path,
+                recoverableIdentity: lease.recordedIdentity,
+                leaseFD: lease.fd)
+            self.listenFD = fd
+            self.leaseFD = lease.fd
+            self.socketIdentity = identity
+        } catch {
+            flock(lease.fd, LOCK_UN)
+            close(lease.fd)
+            throw error
         }
 
-        chmod(path, S_IRUSR | S_IWUSR)
-        if listen(fd, SOMAXCONN) != 0 {
-            close(fd)
-            return
-        }
-
-        self.listenFD = fd
+        let fd = self.listenFD
 
         let server = self.server
         let allowedTeamIDs = self.allowedTeamIDs
         let maxMessageBytes = self.maxMessageBytes
         let requestTimeoutSec = self.requestTimeoutSec
+        let connectionTracker = self.connectionTracker
 
         self.acceptTask = Task.detached(priority: .utility) {
             await Self.acceptLoop(
@@ -82,18 +175,902 @@ public final actor PeekabooBridgeHost {
                 server: server,
                 allowedTeamIDs: allowedTeamIDs,
                 maxMessageBytes: maxMessageBytes,
-                requestTimeoutSec: requestTimeoutSec)
+                requestTimeoutSec: requestTimeoutSec,
+                connectionTracker: connectionTracker)
         }
     }
 
-    public func stop() {
-        self.acceptTask?.cancel()
+    public func stop() async {
+        let acceptTask = self.acceptTask
+        acceptTask?.cancel()
         self.acceptTask = nil
         if self.listenFD != -1 {
             close(self.listenFD)
             self.listenFD = -1
         }
-        unlink(self.socketPath)
+        await acceptTask?.value
+        await self.connectionTracker.waitForIdle()
+        var canClearLeaseIdentity = self.socketIdentity == nil
+        if let identity = self.socketIdentity {
+            do {
+                _ = try Self.removeOwnedSocket(
+                    path: self.socketPath,
+                    expectedIdentity: identity)
+                canClearLeaseIdentity = true
+            } catch {
+                Self.logger.error(
+                    """
+                    Failed to remove bridge socket at \(self.socketPath, privacy: .public): \
+                    \(error.localizedDescription)
+                    """)
+            }
+        }
+        self.socketIdentity = nil
+        if self.leaseFD != -1 {
+            if canClearLeaseIdentity {
+                do {
+                    try Self.clearLeaseIdentity(fd: self.leaseFD, path: self.socketPath)
+                } catch {
+                    Self.logger.error(
+                        """
+                        Failed to clear bridge lease at \(self.socketPath, privacy: .public): \
+                        \(error.localizedDescription)
+                        """)
+                }
+            }
+            flock(self.leaseFD, LOCK_UN)
+            close(self.leaseFD)
+            self.leaseFD = -1
+        }
+    }
+
+    private nonisolated static func acquireLease(path: String) throws -> SocketLease {
+        let leasePath = "\(path).lock"
+        var created = true
+        var fd = open(
+            leasePath,
+            O_CREAT | O_EXCL | O_RDWR | O_CLOEXEC | O_NOFOLLOW,
+            S_IRUSR | S_IWUSR)
+        if fd < 0, errno == EEXIST {
+            created = false
+            fd = open(leasePath, O_RDWR | O_CLOEXEC | O_NOFOLLOW)
+        }
+        guard fd >= 0 else {
+            if errno == ELOOP {
+                throw PeekabooBridgeHostError.unsafeLeaseFile(path: leasePath)
+            }
+            throw PeekabooBridgeHostError.systemCallFailed(
+                operation: "open",
+                path: leasePath,
+                code: errno)
+        }
+        var leaseInfo = stat()
+        guard fstat(fd, &leaseInfo) == 0 else {
+            let code = errno
+            close(fd)
+            throw PeekabooBridgeHostError.systemCallFailed(
+                operation: "fstat",
+                path: leasePath,
+                code: code)
+        }
+        guard (leaseInfo.st_mode & S_IFMT) == S_IFREG,
+              leaseInfo.st_uid == geteuid(),
+              leaseInfo.st_nlink == 1
+        else {
+            close(fd)
+            throw PeekabooBridgeHostError.unsafeLeaseFile(path: leasePath)
+        }
+        guard flock(fd, LOCK_EX | LOCK_NB) == 0 else {
+            let code = errno
+            close(fd)
+            if code == EWOULDBLOCK {
+                throw PeekabooBridgeHostError.socketAlreadyOwned(path: path)
+            }
+            throw PeekabooBridgeHostError.systemCallFailed(
+                operation: "flock",
+                path: leasePath,
+                code: code)
+        }
+
+        let markerSnapshot: LeaseMarkerSnapshot
+        do {
+            markerSnapshot = try self.readLeaseMarker(fd: fd, path: leasePath)
+        } catch {
+            flock(fd, LOCK_UN)
+            close(fd)
+            throw error
+        }
+        if !created, case .invalid = markerSnapshot.state {
+            flock(fd, LOCK_UN)
+            close(fd)
+            throw PeekabooBridgeHostError.unsafeLeaseFile(path: leasePath)
+        }
+
+        guard fchmod(fd, S_IRUSR | S_IWUSR) == 0 else {
+            let code = errno
+            flock(fd, LOCK_UN)
+            close(fd)
+            throw PeekabooBridgeHostError.systemCallFailed(
+                operation: "fchmod",
+                path: leasePath,
+                code: code)
+        }
+
+        let recordedIdentity: SocketIdentity? = switch markerSnapshot.state {
+        case .empty, .incomplete, .invalid:
+            nil
+        case let .identity(identity):
+            identity
+        }
+        return SocketLease(
+            fd: fd,
+            recordedIdentity: recordedIdentity)
+    }
+
+    private nonisolated static func makeListeningSocket(
+        path: String,
+        recoverableIdentity: SocketIdentity?,
+        leaseFD: Int32) throws -> (Int32, SocketIdentity)
+    {
+        _ = try self.socketAddress(path: path)
+        let recoverableStatus = try self.recoverableSocketStatus(
+            path: path,
+            recoverableIdentity: recoverableIdentity)
+
+        let temporaryPath = try self.temporarySocketPath(for: path)
+        let fd = socket(AF_UNIX, SOCK_STREAM, 0)
+        guard fd >= 0 else {
+            throw PeekabooBridgeHostError.systemCallFailed(
+                operation: "socket",
+                path: path,
+                code: errno)
+        }
+
+        var boundIdentity: SocketIdentity?
+        do {
+            try PeekabooBridgeSocketIO.setCloseOnExec(fd)
+            let address = try self.socketAddress(path: temporaryPath)
+            var localAddress = address
+            let length = socklen_t(MemoryLayout.size(ofValue: localAddress))
+            let bindResult = withUnsafePointer(to: &localAddress) {
+                Darwin.bind(fd, UnsafePointer<sockaddr>(OpaquePointer($0)), length)
+            }
+            guard bindResult == 0 else {
+                throw PeekabooBridgeHostError.systemCallFailed(
+                    operation: "bind",
+                    path: temporaryPath,
+                    code: errno)
+            }
+
+            guard let temporaryStatus = self.socketStatus(path: temporaryPath),
+                  temporaryStatus.isSocket
+            else {
+                throw PeekabooBridgeHostError.systemCallFailed(
+                    operation: "lstat",
+                    path: temporaryPath,
+                    code: errno)
+            }
+            boundIdentity = temporaryStatus.identity
+
+            guard chmod(temporaryPath, S_IRUSR | S_IWUSR) == 0 else {
+                throw PeekabooBridgeHostError.systemCallFailed(
+                    operation: "chmod",
+                    path: temporaryPath,
+                    code: errno)
+            }
+            guard let permissionedStatus = self.socketStatus(path: temporaryPath),
+                  permissionedStatus.isSocket,
+                  permissionedStatus.identity == temporaryStatus.identity
+            else {
+                throw PeekabooBridgeHostError.socketAlreadyOwned(path: temporaryPath)
+            }
+            guard listen(fd, SOMAXCONN) == 0 else {
+                throw PeekabooBridgeHostError.systemCallFailed(
+                    operation: "listen",
+                    path: temporaryPath,
+                    code: errno)
+            }
+            try self.publishSocket(
+                temporaryPath: temporaryPath,
+                finalPath: path,
+                temporaryStatus: temporaryStatus,
+                replacing: recoverableStatus)
+
+            guard let publishedStatus = self.socketStatus(path: path),
+                  publishedStatus.isSocket,
+                  publishedStatus.identity == temporaryStatus.identity
+            else {
+                throw PeekabooBridgeHostError.socketAlreadyOwned(path: path)
+            }
+            try self.recordLeaseIdentity(
+                temporaryStatus.identity,
+                fd: leaseFD,
+                path: path)
+            return (fd, temporaryStatus.identity)
+        } catch {
+            try? self.clearLeaseIdentity(fd: leaseFD, path: path)
+            if let boundIdentity {
+                for candidate in [temporaryPath, path] {
+                    _ = try? self.removeOwnedSocket(
+                        path: candidate,
+                        expectedIdentity: boundIdentity)
+                }
+            }
+            close(fd)
+            throw error
+        }
+    }
+
+    private nonisolated static func recoverableSocketStatus(
+        path: String,
+        recoverableIdentity: SocketIdentity?) throws -> SocketStatus?
+    {
+        guard let status = self.socketStatus(path: path) else {
+            let code = errno
+            if code == ENOENT { return nil }
+            throw PeekabooBridgeHostError.systemCallFailed(
+                operation: "lstat",
+                path: path,
+                code: code)
+        }
+        guard status.isSocket else {
+            throw PeekabooBridgeHostError.socketPathIsNotSocket(path: path)
+        }
+        let canRecoverLegacySocket = recoverableIdentity == nil &&
+            status.ownerUID == geteuid() &&
+            self.legacySocketOwnerState(
+                path: path,
+                targetIdentity: status.identity,
+                ownerUID: status.ownerUID) == .unheld
+        guard status.identity == recoverableIdentity || canRecoverLegacySocket else {
+            throw PeekabooBridgeHostError.socketAlreadyOwned(path: path)
+        }
+        return status
+    }
+
+    private nonisolated static func temporarySocketPath(for path: String) throws -> String {
+        let parent = (path as NSString).deletingLastPathComponent
+        let directory = parent.isEmpty ? "." : parent
+        let separatorBytes = directory == "/" ? 0 : 1
+        let capacity = MemoryLayout.size(ofValue: sockaddr_un().sun_path)
+        let availableBytes = capacity - 1 - directory.utf8.count - separatorBytes
+        guard availableBytes > 0 else {
+            throw PeekabooBridgeHostError.socketPathTooLong(path: path)
+        }
+
+        let alphabet = Array("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789")
+        let filenameLength = min(16, availableBytes)
+        let finalFilename = (path as NSString).lastPathComponent
+        for _ in 0..<128 {
+            let filename = String((0..<filenameLength).map { _ in alphabet.randomElement()! })
+            guard filename != finalFilename else { continue }
+            let candidate = (directory as NSString).appendingPathComponent(filename)
+            guard self.socketStatus(path: candidate) == nil, errno == ENOENT else { continue }
+            _ = try self.socketAddress(path: candidate)
+            return candidate
+        }
+
+        throw PeekabooBridgeHostError.systemCallFailed(
+            operation: "temporary socket path",
+            path: path,
+            code: EEXIST)
+    }
+
+    private nonisolated static func throwExistingSocketError(path: String) throws -> Never {
+        guard let status = self.socketStatus(path: path) else {
+            let code = errno
+            throw PeekabooBridgeHostError.systemCallFailed(
+                operation: "lstat",
+                path: path,
+                code: code)
+        }
+        guard status.isSocket else {
+            throw PeekabooBridgeHostError.socketPathIsNotSocket(path: path)
+        }
+        throw PeekabooBridgeHostError.socketAlreadyOwned(path: path)
+    }
+
+    private nonisolated static func publishSocket(
+        temporaryPath: String,
+        finalPath: String,
+        temporaryStatus: SocketStatus,
+        replacing recoverableStatus: SocketStatus?) throws
+    {
+        guard let recoverableStatus else {
+            let publishResult = renameatx_np(
+                AT_FDCWD,
+                temporaryPath,
+                AT_FDCWD,
+                finalPath,
+                UInt32(RENAME_EXCL))
+            guard publishResult == 0 else {
+                let code = errno
+                if code == EEXIST {
+                    try self.throwExistingSocketError(path: finalPath)
+                }
+                throw PeekabooBridgeHostError.systemCallFailed(
+                    operation: "renameatx_np",
+                    path: finalPath,
+                    code: code)
+            }
+            return
+        }
+
+        let swapResult = renameatx_np(
+            AT_FDCWD,
+            temporaryPath,
+            AT_FDCWD,
+            finalPath,
+            UInt32(RENAME_SWAP))
+        if swapResult != 0 {
+            let swapCode = errno
+            if swapCode == ENOENT {
+                let publishResult = renameatx_np(
+                    AT_FDCWD,
+                    temporaryPath,
+                    AT_FDCWD,
+                    finalPath,
+                    UInt32(RENAME_EXCL))
+                if publishResult == 0 {
+                    return
+                }
+                let publishCode = errno
+                if publishCode == EEXIST {
+                    try self.throwExistingSocketError(path: finalPath)
+                }
+                throw PeekabooBridgeHostError.systemCallFailed(
+                    operation: "renameatx_np",
+                    path: finalPath,
+                    code: publishCode)
+            }
+            throw PeekabooBridgeHostError.systemCallFailed(
+                operation: "renameatx_np",
+                path: finalPath,
+                code: swapCode)
+        }
+
+        let publishedStatus = self.socketStatus(path: finalPath)
+        let displacedStatus = self.socketStatus(path: temporaryPath)
+        guard publishedStatus?.isSocket == true,
+              publishedStatus?.identity == temporaryStatus.identity,
+              displacedStatus == recoverableStatus
+        else {
+            let restoreResult = renameatx_np(
+                AT_FDCWD,
+                temporaryPath,
+                AT_FDCWD,
+                finalPath,
+                UInt32(RENAME_SWAP))
+            guard restoreResult == 0 else {
+                throw PeekabooBridgeHostError.systemCallFailed(
+                    operation: "renameatx_np restore",
+                    path: finalPath,
+                    code: errno)
+            }
+            try self.throwExistingSocketError(path: finalPath)
+        }
+
+        guard unlink(temporaryPath) == 0 else {
+            throw PeekabooBridgeHostError.systemCallFailed(
+                operation: "unlink quarantined socket",
+                path: temporaryPath,
+                code: errno)
+        }
+        self.logger.info(
+            """
+            Replaced stale bridge socket path=\(finalPath, privacy: .public) \
+            inode=\(recoverableStatus.identity.inode, privacy: .public)
+            """)
+    }
+
+    @discardableResult
+    private nonisolated static func removeOwnedSocket(
+        path: String,
+        expectedIdentity: SocketIdentity) throws -> Bool
+    {
+        guard self.socketStatus(path: path) != nil else {
+            let code = errno
+            if code == ENOENT { return true }
+            throw PeekabooBridgeHostError.systemCallFailed(
+                operation: "lstat",
+                path: path,
+                code: code)
+        }
+
+        let (placeholderPath, placeholderIdentity) = try self.createPlaceholder(for: path)
+        var placeholderLocation: String? = placeholderPath
+        defer {
+            if let placeholderLocation,
+               self.socketStatus(path: placeholderLocation)?.identity == placeholderIdentity
+            {
+                unlink(placeholderLocation)
+            }
+        }
+
+        let swapResult = renameatx_np(
+            AT_FDCWD,
+            placeholderPath,
+            AT_FDCWD,
+            path,
+            UInt32(RENAME_SWAP))
+        guard swapResult == 0 else {
+            let code = errno
+            if code == ENOENT { return true }
+            throw PeekabooBridgeHostError.systemCallFailed(
+                operation: "renameatx_np",
+                path: path,
+                code: code)
+        }
+        placeholderLocation = path
+
+        guard self.socketStatus(path: placeholderPath)?.identity == expectedIdentity else {
+            let restoreResult = renameatx_np(
+                AT_FDCWD,
+                placeholderPath,
+                AT_FDCWD,
+                path,
+                UInt32(RENAME_SWAP))
+            guard restoreResult == 0 else {
+                throw PeekabooBridgeHostError.systemCallFailed(
+                    operation: "renameatx_np restore",
+                    path: path,
+                    code: errno)
+            }
+            placeholderLocation = placeholderPath
+            return false
+        }
+
+        let cleanupPath = try self.temporarySocketPath(for: path)
+        let movePlaceholderResult = renameatx_np(
+            AT_FDCWD,
+            path,
+            AT_FDCWD,
+            cleanupPath,
+            UInt32(RENAME_EXCL))
+        guard movePlaceholderResult == 0 else {
+            let code = errno
+            let restoreResult = renameatx_np(
+                AT_FDCWD,
+                placeholderPath,
+                AT_FDCWD,
+                path,
+                UInt32(RENAME_SWAP))
+            if restoreResult == 0 {
+                placeholderLocation = placeholderPath
+            }
+            throw PeekabooBridgeHostError.systemCallFailed(
+                operation: "renameatx_np quarantine",
+                path: path,
+                code: code)
+        }
+        placeholderLocation = cleanupPath
+
+        guard unlink(placeholderPath) == 0 else {
+            throw PeekabooBridgeHostError.systemCallFailed(
+                operation: "unlink quarantined socket",
+                path: placeholderPath,
+                code: errno)
+        }
+        guard unlink(cleanupPath) == 0 else {
+            throw PeekabooBridgeHostError.systemCallFailed(
+                operation: "unlink socket placeholder",
+                path: cleanupPath,
+                code: errno)
+        }
+        placeholderLocation = nil
+        return true
+    }
+
+    private nonisolated static func createPlaceholder(
+        for path: String) throws -> (path: String, identity: SocketIdentity)
+    {
+        for _ in 0..<128 {
+            let placeholderPath = try self.temporarySocketPath(for: path)
+            let fd = open(
+                placeholderPath,
+                O_CREAT | O_EXCL | O_RDWR | O_CLOEXEC | O_NOFOLLOW,
+                S_IRUSR | S_IWUSR)
+            if fd < 0, errno == EEXIST {
+                continue
+            }
+            guard fd >= 0 else {
+                throw PeekabooBridgeHostError.systemCallFailed(
+                    operation: "open placeholder",
+                    path: placeholderPath,
+                    code: errno)
+            }
+            close(fd)
+
+            guard let status = self.socketStatus(path: placeholderPath),
+                  !status.isSocket,
+                  status.ownerUID == geteuid()
+            else {
+                unlink(placeholderPath)
+                throw PeekabooBridgeHostError.unsafeLeaseFile(path: placeholderPath)
+            }
+            return (placeholderPath, status.identity)
+        }
+
+        throw PeekabooBridgeHostError.systemCallFailed(
+            operation: "create placeholder",
+            path: path,
+            code: EEXIST)
+    }
+
+    private nonisolated static func socketAddress(path: String) throws -> sockaddr_un {
+        var address = sockaddr_un()
+        address.sun_family = sa_family_t(AF_UNIX)
+        let capacity = MemoryLayout.size(ofValue: address.sun_path)
+        let copied = path.withCString { strlcpy(&address.sun_path.0, $0, capacity) }
+        guard copied < capacity else {
+            throw PeekabooBridgeHostError.socketPathTooLong(path: path)
+        }
+        address.sun_len = UInt8(MemoryLayout.size(ofValue: address))
+        return address
+    }
+
+    private nonisolated static func readLeaseMarker(fd: Int32, path: String) throws -> LeaseMarkerSnapshot {
+        var info = stat()
+        guard fstat(fd, &info) == 0 else {
+            throw PeekabooBridgeHostError.systemCallFailed(
+                operation: "fstat",
+                path: path,
+                code: errno)
+        }
+        guard info.st_size > 0 else {
+            return LeaseMarkerSnapshot(state: .empty)
+        }
+        guard info.st_size <= 64 * 1024 else {
+            return LeaseMarkerSnapshot(state: .invalid)
+        }
+
+        var buffer = [UInt8](repeating: 0, count: Int(info.st_size))
+        var bytesRead = 0
+        while bytesRead < buffer.count {
+            let result = buffer.withUnsafeMutableBytes { bytes in
+                pread(
+                    fd,
+                    bytes.baseAddress!.advanced(by: bytesRead),
+                    bytes.count - bytesRead,
+                    off_t(bytesRead))
+            }
+            if result > 0 {
+                bytesRead += result
+                continue
+            }
+            if result == -1, errno == EINTR {
+                continue
+            }
+            if result == 0 {
+                return LeaseMarkerSnapshot(state: .invalid)
+            }
+            throw PeekabooBridgeHostError.systemCallFailed(
+                operation: "pread",
+                path: path,
+                code: errno)
+        }
+
+        guard let contents = String(bytes: buffer, encoding: .utf8) else {
+            return LeaseMarkerSnapshot(state: .invalid)
+        }
+
+        var lastIdentity: SocketIdentity?
+        var sawIncompleteRecord = false
+        let records = contents.split(separator: "\n", omittingEmptySubsequences: false)
+        for (index, record) in records.enumerated() {
+            if record.isEmpty { continue }
+            if let identity = self.parseLeaseIdentity(record) {
+                lastIdentity = identity
+                continue
+            }
+            if index == records.indices.last, self.isIncompleteLeaseRecord(record) {
+                sawIncompleteRecord = true
+                continue
+            }
+            return LeaseMarkerSnapshot(state: .invalid)
+        }
+        if let lastIdentity {
+            return LeaseMarkerSnapshot(state: .identity(lastIdentity))
+        }
+        return LeaseMarkerSnapshot(state: sawIncompleteRecord ? .incomplete : .empty)
+    }
+
+    private nonisolated static func parseLeaseIdentity(_ record: Substring) -> SocketIdentity? {
+        let fields = record.split(whereSeparator: \.isWhitespace)
+        guard fields.count == 3,
+              fields[0] == Substring(self.leaseMarkerPrefix),
+              let device = UInt64(fields[1]),
+              let inode = UInt64(fields[2]),
+              let convertedDevice = dev_t(exactly: device),
+              let convertedInode = ino_t(exactly: inode)
+        else {
+            return nil
+        }
+        return SocketIdentity(device: convertedDevice, inode: convertedInode)
+    }
+
+    private nonisolated static func isIncompleteLeaseRecord(_ record: Substring) -> Bool {
+        let prefix = Substring(self.leaseMarkerPrefix)
+        if prefix.starts(with: record) {
+            return true
+        }
+        guard record.hasPrefix(prefix) else { return false }
+
+        let suffix = record.dropFirst(prefix.count)
+        guard suffix.allSatisfy({ $0.isWhitespace || $0.isNumber }) else { return false }
+        let fields = suffix.split(whereSeparator: \.isWhitespace)
+        guard fields.count <= 2 else { return false }
+        if let deviceField = fields.first {
+            guard let device = UInt64(deviceField), dev_t(exactly: device) != nil else { return false }
+        }
+        if fields.count == 2 {
+            guard let inode = UInt64(fields[1]), ino_t(exactly: inode) != nil else { return false }
+        }
+        return true
+    }
+
+    private nonisolated static func recordLeaseIdentity(
+        _ identity: SocketIdentity,
+        fd: Int32,
+        path: String) throws
+    {
+        let marker = "\(self.leaseMarkerPrefix) \(UInt64(identity.device)) \(UInt64(identity.inode))\n"
+        var info = stat()
+        guard fstat(fd, &info) == 0 else {
+            throw PeekabooBridgeHostError.systemCallFailed(
+                operation: "fstat",
+                path: "\(path).lock",
+                code: errno)
+        }
+        guard info.st_size == 0 else {
+            throw PeekabooBridgeHostError.unsafeLeaseFile(path: "\(path).lock")
+        }
+
+        let bytes = Array(marker.utf8)
+
+        var written = 0
+        while written < bytes.count {
+            let result = bytes.withUnsafeBytes { buffer in
+                pwrite(
+                    fd,
+                    buffer.baseAddress!.advanced(by: written),
+                    bytes.count - written,
+                    off_t(written))
+            }
+            if result > 0 {
+                written += result
+                continue
+            }
+            if result == -1, errno == EINTR {
+                continue
+            }
+            throw PeekabooBridgeHostError.systemCallFailed(
+                operation: "pwrite",
+                path: "\(path).lock",
+                code: errno)
+        }
+
+        guard fsync(fd) == 0 else {
+            throw PeekabooBridgeHostError.systemCallFailed(
+                operation: "fsync",
+                path: "\(path).lock",
+                code: errno)
+        }
+    }
+
+    private nonisolated static func clearLeaseIdentity(fd: Int32, path: String) throws {
+        guard ftruncate(fd, 0) == 0 else {
+            throw PeekabooBridgeHostError.systemCallFailed(
+                operation: "ftruncate",
+                path: "\(path).lock",
+                code: errno)
+        }
+        guard fsync(fd) == 0 else {
+            throw PeekabooBridgeHostError.systemCallFailed(
+                operation: "fsync",
+                path: "\(path).lock",
+                code: errno)
+        }
+    }
+
+    private nonisolated static func socketStatus(path: String) -> SocketStatus? {
+        var info = stat()
+        guard lstat(path, &info) == 0 else { return nil }
+        return SocketStatus(
+            identity: SocketIdentity(device: info.st_dev, inode: info.st_ino),
+            mode: info.st_mode,
+            ownerUID: info.st_uid)
+    }
+
+    private nonisolated static func legacySocketOwnerState(
+        path: String,
+        targetIdentity: SocketIdentity,
+        ownerUID: uid_t) -> LegacySocketOwnerState
+    {
+        let estimatedCount = proc_listallpids(nil, 0)
+        guard estimatedCount > 0 else { return .indeterminate }
+
+        var pids = [pid_t](repeating: 0, count: Int(estimatedCount) + 64)
+        let listedCount = proc_listallpids(
+            &pids,
+            Int32(pids.count * MemoryLayout<pid_t>.stride))
+        guard listedCount > 0, Int(listedCount) < pids.count else { return .indeterminate }
+
+        var inspectionWasIncomplete = false
+        for pid in pids.prefix(Int(listedCount)) where pid > 0 {
+            guard let process = self.processMetadata(pid: pid) else {
+                if kill(pid, 0) == 0 {
+                    inspectionWasIncomplete = true
+                }
+                continue
+            }
+            guard process.ownerUID == ownerUID, process.status != UInt32(SZOMB) else { continue }
+
+            let descriptorBytes = proc_pidinfo(pid, PROC_PIDLISTFDS, 0, nil, 0)
+            guard descriptorBytes > 0 else {
+                if let current = self.processMetadata(pid: pid),
+                   current.ownerUID == ownerUID,
+                   current.status != UInt32(SZOMB)
+                {
+                    inspectionWasIncomplete = true
+                }
+                continue
+            }
+
+            let descriptorCapacity = Int(descriptorBytes) / MemoryLayout<proc_fdinfo>.stride + 16
+            var descriptors = [proc_fdinfo](repeating: proc_fdinfo(), count: descriptorCapacity)
+            let descriptorBufferBytes = Int32(descriptors.count * MemoryLayout<proc_fdinfo>.stride)
+            let listedDescriptorBytes = proc_pidinfo(
+                pid,
+                PROC_PIDLISTFDS,
+                0,
+                &descriptors,
+                descriptorBufferBytes)
+            guard listedDescriptorBytes > 0 else {
+                if let current = self.processMetadata(pid: pid),
+                   current.ownerUID == ownerUID,
+                   current.status != UInt32(SZOMB)
+                {
+                    inspectionWasIncomplete = true
+                }
+                continue
+            }
+            guard listedDescriptorBytes < descriptorBufferBytes else {
+                inspectionWasIncomplete = true
+                continue
+            }
+
+            let descriptorCount = Int(listedDescriptorBytes) / MemoryLayout<proc_fdinfo>.stride
+            for descriptor in descriptors.prefix(descriptorCount)
+                where descriptor.proc_fdtype == PROX_FDTYPE_SOCKET
+            {
+                var socketInfo = socket_fdinfo()
+                let socketInfoSize = Int32(MemoryLayout<socket_fdinfo>.stride)
+                let socketInfoResult = proc_pidfdinfo(
+                    pid,
+                    descriptor.proc_fd,
+                    PROC_PIDFDSOCKETINFO,
+                    &socketInfo,
+                    socketInfoSize)
+                guard socketInfoResult == socketInfoSize else {
+                    if self.processStillHasSocketDescriptor(pid: pid, fd: descriptor.proc_fd) != false {
+                        inspectionWasIncomplete = true
+                    }
+                    continue
+                }
+                guard socketInfo.psi.soi_family == AF_UNIX,
+                      socketInfo.psi.soi_kind == SOCKINFO_UN
+                else {
+                    continue
+                }
+
+                var address = socketInfo.psi.soi_proto.pri_un.unsi_addr.ua_sun
+                let boundPath = withUnsafePointer(to: &address.sun_path.0) {
+                    String(cString: $0)
+                }
+                if boundPath == path {
+                    return .held
+                }
+                if boundPath.hasPrefix("/") {
+                    if self.socketStatus(path: boundPath)?.identity == targetIdentity {
+                        return .held
+                    }
+                    continue
+                }
+
+                if let currentDirectory = self.processCurrentDirectory(pid: pid) {
+                    let baseURL = URL(fileURLWithPath: currentDirectory, isDirectory: true)
+                    let resolvedPath = URL(
+                        fileURLWithPath: boundPath,
+                        relativeTo: baseURL).standardizedFileURL.path
+                    if self.socketStatus(path: resolvedPath)?.identity == targetIdentity {
+                        return .held
+                    }
+                }
+
+                // The kernel retains a relative UNIX socket name but not the process's bind-time cwd.
+                // If the process changed directories, matching the final component is the strongest safe
+                // signal available. Treat it as incomplete inspection instead of deleting a possibly live socket.
+                if (boundPath as NSString).lastPathComponent == (path as NSString).lastPathComponent {
+                    inspectionWasIncomplete = true
+                }
+            }
+        }
+        return inspectionWasIncomplete ? .indeterminate : .unheld
+    }
+
+    private nonisolated static func processCurrentDirectory(pid: pid_t) -> String? {
+        var pathInfo = proc_vnodepathinfo()
+        let pathInfoSize = Int32(MemoryLayout<proc_vnodepathinfo>.stride)
+        let result = proc_pidinfo(
+            pid,
+            PROC_PIDVNODEPATHINFO,
+            0,
+            &pathInfo,
+            pathInfoSize)
+        guard result == pathInfoSize else { return nil }
+
+        var path = pathInfo.pvi_cdir.vip_path
+        return withUnsafePointer(to: &path.0) { pointer in
+            let value = String(cString: pointer)
+            return value.isEmpty ? nil : value
+        }
+    }
+
+    private nonisolated static func processMetadata(pid: pid_t) -> ProcessMetadata? {
+        var processInfo = proc_bsdinfo()
+        let processInfoSize = Int32(MemoryLayout<proc_bsdinfo>.stride)
+        let processInfoResult = proc_pidinfo(
+            pid,
+            PROC_PIDTBSDINFO,
+            0,
+            &processInfo,
+            processInfoSize)
+        if processInfoResult == processInfoSize {
+            return ProcessMetadata(ownerUID: processInfo.pbi_uid, status: processInfo.pbi_status)
+        }
+
+        var mib = [CTL_KERN, KERN_PROC, KERN_PROC_PID, pid]
+        var kernelInfo = kinfo_proc()
+        var kernelInfoSize = MemoryLayout<kinfo_proc>.stride
+        let result = sysctl(
+            &mib,
+            u_int(mib.count),
+            &kernelInfo,
+            &kernelInfoSize,
+            nil,
+            0)
+        guard result == 0, kernelInfoSize == MemoryLayout<kinfo_proc>.stride else {
+            return nil
+        }
+        return ProcessMetadata(
+            ownerUID: kernelInfo.kp_eproc.e_ucred.cr_uid,
+            status: UInt32(kernelInfo.kp_proc.p_stat))
+    }
+
+    private nonisolated static func processStillHasSocketDescriptor(pid: pid_t, fd: Int32) -> Bool? {
+        let descriptorBytes = proc_pidinfo(pid, PROC_PIDLISTFDS, 0, nil, 0)
+        guard descriptorBytes > 0 else {
+            return self.processMetadata(pid: pid)?.status == UInt32(SZOMB) ? false : nil
+        }
+
+        let capacity = Int(descriptorBytes) / MemoryLayout<proc_fdinfo>.stride + 16
+        var descriptors = [proc_fdinfo](repeating: proc_fdinfo(), count: capacity)
+        let descriptorBufferBytes = Int32(descriptors.count * MemoryLayout<proc_fdinfo>.stride)
+        let listedBytes = proc_pidinfo(
+            pid,
+            PROC_PIDLISTFDS,
+            0,
+            &descriptors,
+            descriptorBufferBytes)
+        guard listedBytes > 0, listedBytes < descriptorBufferBytes else {
+            return self.processMetadata(pid: pid)?.status == UInt32(SZOMB) ? false : nil
+        }
+
+        let count = Int(listedBytes) / MemoryLayout<proc_fdinfo>.stride
+        return descriptors.prefix(count).contains {
+            $0.proc_fd == fd && $0.proc_fdtype == PROX_FDTYPE_SOCKET
+        }
     }
 
     private nonisolated static func acceptLoop(
@@ -101,7 +1078,8 @@ public final actor PeekabooBridgeHost {
         server: PeekabooBridgeServer,
         allowedTeamIDs: Set<String>,
         maxMessageBytes: Int,
-        requestTimeoutSec: TimeInterval) async
+        requestTimeoutSec: TimeInterval,
+        connectionTracker: ConnectionTracker) async
     {
         while !Task.isCancelled {
             var addr = sockaddr()
@@ -116,6 +1094,14 @@ public final actor PeekabooBridgeHost {
             }
 
             Self.disableSigPipe(fd: client)
+            do {
+                try PeekabooBridgeSocketIO.configureConnectedSocket(client)
+            } catch {
+                self.logger.error("failed to configure bridge client socket: \(error.localizedDescription)")
+                close(client)
+                continue
+            }
+            await connectionTracker.begin()
             Task.detached(priority: .utility) {
                 defer { close(client) }
                 await Self.handleClient(
@@ -124,6 +1110,7 @@ public final actor PeekabooBridgeHost {
                     allowedTeamIDs: allowedTeamIDs,
                     maxMessageBytes: maxMessageBytes,
                     requestTimeoutSec: requestTimeoutSec)
+                await connectionTracker.end()
             }
         }
     }
@@ -138,7 +1125,10 @@ public final actor PeekabooBridgeHost {
         let peer = self.peerInfoIfAllowed(fd: fd, allowedTeamIDs: allowedTeamIDs)
 
         do {
-            let requestData = try self.readAll(fd: fd, maxBytes: maxMessageBytes, timeoutSec: requestTimeoutSec)
+            let requestData = try PeekabooBridgeSocketIO.readAll(
+                fd: fd,
+                maxBytes: maxMessageBytes,
+                deadline: Date().addingTimeInterval(requestTimeoutSec))
 
             guard let peer else {
                 let envelope = PeekabooBridgeErrorEnvelope(
@@ -152,13 +1142,19 @@ public final actor PeekabooBridgeHost {
 
                 let encoder = JSONEncoder.peekabooBridgeEncoder()
                 let responseData = (try? encoder.encode(PeekabooBridgeResponse.error(envelope))) ?? Data()
-                try self.writeAll(fd: fd, data: responseData)
+                try PeekabooBridgeSocketIO.writeAll(
+                    fd: fd,
+                    data: responseData,
+                    deadline: Date().addingTimeInterval(requestTimeoutSec))
                 return
             }
 
             let responseData = await server.decodeAndHandle(requestData, peer: peer)
 
-            try self.writeAll(fd: fd, data: responseData)
+            try PeekabooBridgeSocketIO.writeAll(
+                fd: fd,
+                data: responseData,
+                deadline: Date().addingTimeInterval(requestTimeoutSec))
         } catch {
             self.logger.error("bridge socket request failed: \(error.localizedDescription, privacy: .public)")
         }
@@ -167,61 +1163,6 @@ public final actor PeekabooBridgeHost {
     private nonisolated static func disableSigPipe(fd: Int32) {
         var one: Int32 = 1
         _ = setsockopt(fd, SOL_SOCKET, SO_NOSIGPIPE, &one, socklen_t(MemoryLayout.size(ofValue: one)))
-    }
-
-    private nonisolated static func readAll(fd: Int32, maxBytes: Int, timeoutSec: TimeInterval) throws -> Data {
-        let deadline = Date().addingTimeInterval(timeoutSec)
-        var data = Data()
-        var buffer = [UInt8](repeating: 0, count: 16 * 1024)
-
-        while true {
-            let remaining = deadline.timeIntervalSinceNow
-            if remaining <= 0 {
-                throw POSIXError(.ETIMEDOUT)
-            }
-
-            var pfd = pollfd(fd: fd, events: Int16(POLLIN), revents: 0)
-            let sliceMs = max(1.0, min(remaining, 0.25) * 1000.0)
-            let polled = poll(&pfd, 1, Int32(sliceMs))
-            if polled == 0 { continue }
-            if polled < 0 {
-                if errno == EINTR { continue }
-                throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO)
-            }
-
-            let n = buffer.withUnsafeMutableBytes { read(fd, $0.baseAddress!, $0.count) }
-            if n > 0 {
-                data.append(buffer, count: n)
-                if data.count > maxBytes {
-                    throw POSIXError(.EMSGSIZE)
-                }
-                continue
-            }
-
-            if n == 0 {
-                return data
-            }
-
-            if errno == EINTR { continue }
-            if errno == EAGAIN { continue }
-            throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO)
-        }
-    }
-
-    private nonisolated static func writeAll(fd: Int32, data: Data) throws {
-        try data.withUnsafeBytes { buf in
-            guard let base = buf.baseAddress else { return }
-            var written = 0
-            while written < data.count {
-                let n = write(fd, base.advanced(by: written), data.count - written)
-                if n > 0 {
-                    written += n
-                    continue
-                }
-                if n == -1, errno == EINTR { continue }
-                throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO)
-            }
-        }
     }
 
     private nonisolated static func peerInfoIfAllowed(fd: Int32, allowedTeamIDs: Set<String>) -> PeekabooBridgePeer? {

--- a/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeRequestResponse.swift
+++ b/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeRequestResponse.swift
@@ -8,6 +8,7 @@ public enum PeekabooBridgeRequest: Codable, Sendable {
     case requestPostEventPermission
     case daemonStatus
     case daemonStop
+    case daemonStopIf(PeekabooBridgeDaemonStopRequest)
     case browserStatus(PeekabooBridgeBrowserChannelRequest)
     case browserConnect(PeekabooBridgeBrowserChannelRequest)
     case browserDisconnect
@@ -97,6 +98,7 @@ extension PeekabooBridgeRequest {
         case .requestPostEventPermission: .requestPostEventPermission
         case .daemonStatus: .daemonStatus
         case .daemonStop: .daemonStop
+        case .daemonStopIf: .daemonStop
         case .browserStatus: .browserStatus
         case .browserConnect: .browserConnect
         case .browserDisconnect: .browserDisconnect

--- a/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeServer+Handlers.swift
+++ b/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeServer+Handlers.swift
@@ -89,6 +89,14 @@ extension PeekabooBridgeServer {
             }
             let stopped = await daemonControl.requestStop()
             return .bool(stopped)
+        case let .daemonStopIf(payload):
+            guard let daemonControl = self.daemonControl as? any PeekabooConditionalDaemonControlProviding else {
+                throw PeekabooBridgeErrorEnvelope(
+                    code: .operationNotSupported,
+                    message: "Conditional daemon stop is not supported by this host")
+            }
+            let stopped = await daemonControl.requestStop(expectedPID: payload.expectedPID)
+            return .bool(stopped)
         case let .handshake(payload):
             return try self.handleHandshake(payload, peer: peer)
         default:

--- a/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeServer.swift
+++ b/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeServer.swift
@@ -120,8 +120,19 @@ public final class PeekabooBridgeServer {
 
         do {
             try self.validateOperationAccess(for: request, permissions: permissions, effectiveOps: effectiveOps)
-            if let daemonControl = self.daemonControl, op != .daemonStatus {
-                await daemonControl.recordActivityStart(operation: op)
+            if let daemonControl = self.daemonControl,
+               op != .daemonStatus,
+               op != .daemonStop
+            {
+                if let conditionalControl = daemonControl as? any PeekabooConditionalDaemonControlProviding {
+                    guard await conditionalControl.admitActivity(operation: op) else {
+                        throw PeekabooBridgeErrorEnvelope(
+                            code: .serverBusy,
+                            message: "Daemon is shutting down")
+                    }
+                } else {
+                    await daemonControl.recordActivityStart(operation: op)
+                }
                 do {
                     let response = try await self.handleAuthorized(request, peer: peer)
                     await daemonControl.recordActivityEnd(operation: op)

--- a/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeSocketIO.swift
+++ b/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeSocketIO.swift
@@ -1,0 +1,117 @@
+import Darwin
+import Foundation
+
+enum PeekabooBridgeSocketIO {
+    static func configureConnectedSocket(_ fd: Int32) throws {
+        try self.setCloseOnExec(fd)
+
+        let flags = fcntl(fd, F_GETFL)
+        guard flags >= 0 else {
+            throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO)
+        }
+        guard fcntl(fd, F_SETFL, flags | O_NONBLOCK) == 0 else {
+            throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO)
+        }
+    }
+
+    static func setCloseOnExec(_ fd: Int32) throws {
+        let flags = fcntl(fd, F_GETFD)
+        guard flags >= 0 else {
+            throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO)
+        }
+        guard fcntl(fd, F_SETFD, flags | FD_CLOEXEC) == 0 else {
+            throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO)
+        }
+    }
+
+    static func finishConnect(fd: Int32, deadline: Date) throws {
+        _ = try self.wait(fd: fd, events: Int16(POLLOUT), deadline: deadline)
+
+        var socketError: Int32 = 0
+        var length = socklen_t(MemoryLayout.size(ofValue: socketError))
+        guard getsockopt(fd, SOL_SOCKET, SO_ERROR, &socketError, &length) == 0 else {
+            throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO)
+        }
+        guard socketError == 0 else {
+            throw POSIXError(POSIXErrorCode(rawValue: socketError) ?? .EIO)
+        }
+    }
+
+    static func readAll(fd: Int32, maxBytes: Int, deadline: Date) throws -> Data {
+        var data = Data()
+        var buffer = [UInt8](repeating: 0, count: 16 * 1024)
+
+        while true {
+            _ = try self.wait(fd: fd, events: Int16(POLLIN), deadline: deadline)
+
+            let count = buffer.withUnsafeMutableBytes { read(fd, $0.baseAddress!, $0.count) }
+            if count > 0 {
+                data.append(buffer, count: count)
+                if data.count > maxBytes {
+                    throw POSIXError(.EMSGSIZE)
+                }
+                continue
+            }
+            if count == 0 {
+                return data
+            }
+            if errno == EINTR || errno == EAGAIN {
+                continue
+            }
+            throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO)
+        }
+    }
+
+    static func writeAll(fd: Int32, data: Data, deadline: Date) throws {
+        try data.withUnsafeBytes { buffer in
+            guard let baseAddress = buffer.baseAddress else { return }
+            var written = 0
+
+            while written < data.count {
+                guard deadline.timeIntervalSinceNow > 0 else {
+                    throw POSIXError(.ETIMEDOUT)
+                }
+
+                let count = write(fd, baseAddress.advanced(by: written), data.count - written)
+                if count > 0 {
+                    written += count
+                    continue
+                }
+                if count == -1, errno == EINTR {
+                    continue
+                }
+                if count == -1, errno == EAGAIN {
+                    _ = try self.wait(fd: fd, events: Int16(POLLOUT), deadline: deadline)
+                    continue
+                }
+                throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO)
+            }
+        }
+    }
+
+    private static func wait(fd: Int32, events: Int16, deadline: Date) throws -> Int16 {
+        while true {
+            let remaining = deadline.timeIntervalSinceNow
+            guard remaining > 0 else {
+                throw POSIXError(.ETIMEDOUT)
+            }
+
+            var descriptor = pollfd(fd: fd, events: events, revents: 0)
+            let timeoutMs = Int32(ceil(max(1.0, min(remaining, 0.25) * 1000.0)))
+            let result = poll(&descriptor, 1, timeoutMs)
+            if result == 0 {
+                continue
+            }
+            if result < 0 {
+                if errno == EINTR {
+                    continue
+                }
+                throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO)
+            }
+            if descriptor.revents & Int16(POLLNVAL) != 0 {
+                throw POSIXError(.EBADF)
+            }
+            return descriptor.revents
+        }
+    }
+}

--- a/Core/PeekabooCore/Sources/PeekabooCore/Daemon/PeekabooDaemon.swift
+++ b/Core/PeekabooCore/Sources/PeekabooCore/Daemon/PeekabooDaemon.swift
@@ -5,10 +5,11 @@ import PeekabooBridge
 import PeekabooFoundation
 
 @MainActor
-public final class PeekabooDaemon: PeekabooDaemonControlProviding {
+public final class PeekabooDaemon: PeekabooConditionalDaemonControlProviding {
     public struct Configuration: Sendable {
         public let mode: PeekabooDaemonMode
         public let bridgeSocketPath: String
+        public let bridgeHostingEnabled: Bool
         public let allowlistedTeams: Set<String>
         public let allowlistedBundles: Set<String>
         public let allowedOperations: Set<PeekabooBridgeOperation>
@@ -20,7 +21,7 @@ public final class PeekabooDaemon: PeekabooDaemonControlProviding {
 
         public init(
             mode: PeekabooDaemonMode,
-            bridgeSocketPath: String = PeekabooBridgeConstants.peekabooSocketPath,
+            bridgeSocketPath: String = PeekabooBridgeConstants.daemonSocketPath,
             allowlistedTeams: Set<String> = ["Y5PE65HELJ"],
             allowlistedBundles: Set<String> = [],
             allowedOperations: Set<PeekabooBridgeOperation> = PeekabooBridgeOperation.remoteDefaultAllowlist,
@@ -28,10 +29,12 @@ public final class PeekabooDaemon: PeekabooDaemonControlProviding {
             windowPollInterval: TimeInterval = 1.0,
             hostKind: PeekabooBridgeHostKind,
             exitOnStop: Bool = false,
-            idleTimeout: TimeInterval? = nil)
+            idleTimeout: TimeInterval? = nil,
+            bridgeHostingEnabled: Bool = true)
         {
             self.mode = mode
             self.bridgeSocketPath = bridgeSocketPath
+            self.bridgeHostingEnabled = bridgeHostingEnabled
             self.allowlistedTeams = allowlistedTeams
             self.allowlistedBundles = allowlistedBundles
             self.allowedOperations = allowedOperations
@@ -43,7 +46,7 @@ public final class PeekabooDaemon: PeekabooDaemonControlProviding {
         }
 
         public static func auto(
-            bridgeSocketPath: String = PeekabooBridgeConstants.peekabooSocketPath,
+            bridgeSocketPath: String = PeekabooBridgeConstants.daemonSocketPath,
             windowPollInterval: TimeInterval = 1.0,
             idleTimeout: TimeInterval = 300) -> Configuration
         {
@@ -58,7 +61,7 @@ public final class PeekabooDaemon: PeekabooDaemonControlProviding {
         }
 
         public static func manual(
-            bridgeSocketPath: String = PeekabooBridgeConstants.peekabooSocketPath,
+            bridgeSocketPath: String = PeekabooBridgeConstants.daemonSocketPath,
             windowPollInterval: TimeInterval = 1.0) -> Configuration
         {
             Configuration(
@@ -83,6 +86,20 @@ public final class PeekabooDaemon: PeekabooDaemonControlProviding {
                 hostKind: .inProcess,
                 exitOnStop: true)
         }
+
+        public static func embeddedMCP(
+            windowPollInterval: TimeInterval = 1.0) -> Configuration
+        {
+            Configuration(
+                mode: .mcp,
+                bridgeSocketPath: PeekabooBridgeConstants.daemonSocketPath,
+                allowlistedTeams: [],
+                windowTrackingEnabled: true,
+                windowPollInterval: windowPollInterval,
+                hostKind: .inProcess,
+                exitOnStop: false,
+                bridgeHostingEnabled: false)
+        }
     }
 
     private let logger = Logger(subsystem: "boo.peekaboo.core", category: "Daemon")
@@ -96,6 +113,7 @@ public final class PeekabooDaemon: PeekabooDaemonControlProviding {
     private var activeRequestCount = 0
     private var lastActivityAt: Date?
     private var idleShutdownTask: Task<Void, Never>?
+    private var shutdownTask: Task<Void, Never>?
 
     public init(configuration: Configuration) {
         self.configuration = configuration
@@ -104,6 +122,14 @@ public final class PeekabooDaemon: PeekabooDaemonControlProviding {
     }
 
     public func start() async {
+        do {
+            try await self.startChecked()
+        } catch {
+            self.logger.error("Failed to start Peekaboo daemon: \(error.localizedDescription, privacy: .public)")
+        }
+    }
+
+    public func startChecked() async throws {
         self.services.installAgentRuntimeDefaults()
         self.services.ensureVisualizerConnection()
 
@@ -115,15 +141,30 @@ public final class PeekabooDaemon: PeekabooDaemonControlProviding {
             self.windowTracker = tracker
         }
 
-        if self.bridgeHost == nil {
-            self.bridgeHost = PeekabooBridgeBootstrap.startHost(
-                services: self.services,
-                hostKind: self.configuration.hostKind,
-                socketPath: self.configuration.bridgeSocketPath,
-                allowlistedTeams: self.configuration.allowlistedTeams,
-                allowlistedBundles: self.configuration.allowlistedBundles,
-                daemonControl: self,
-                allowedOperations: self.configuration.allowedOperations)
+        if self.bridgeHost == nil, self.configuration.bridgeHostingEnabled {
+            do {
+                let bridgeHost = try await PeekabooBridgeBootstrap.startHostChecked(
+                    services: self.services,
+                    hostKind: self.configuration.hostKind,
+                    socketPath: self.configuration.bridgeSocketPath,
+                    allowlistedTeams: self.configuration.allowlistedTeams,
+                    allowlistedBundles: self.configuration.allowlistedBundles,
+                    daemonControl: self,
+                    allowedOperations: self.configuration.allowedOperations)
+                if self.isStopping {
+                    await bridgeHost.stop()
+                    self.windowTracker?.stop()
+                    self.windowTracker = nil
+                    WindowMovementTracking.provider = nil
+                    return
+                }
+                self.bridgeHost = bridgeHost
+            } catch {
+                self.windowTracker?.stop()
+                self.windowTracker = nil
+                WindowMovementTracking.provider = nil
+                throw error
+            }
         }
 
         self.logger.info("Peekaboo daemon started mode=\(self.configuration.mode.rawValue)")
@@ -132,11 +173,24 @@ public final class PeekabooDaemon: PeekabooDaemonControlProviding {
     }
 
     public func runUntilStop() async {
-        await self.start()
-        await withCheckedContinuation { continuation in
-            self.stopContinuation = continuation
+        do {
+            try await self.runUntilStopChecked()
+        } catch {
+            self.logger.error("Failed to run Peekaboo daemon: \(error.localizedDescription, privacy: .public)")
         }
-        await self.shutdown()
+    }
+
+    public func runUntilStopChecked() async throws {
+        try await self.startChecked()
+        guard !self.isStopping else { return }
+        await withCheckedContinuation { continuation in
+            if self.isStopping {
+                continuation.resume()
+            } else {
+                self.stopContinuation = continuation
+            }
+        }
+        await self.shutdownTask?.value
     }
 
     public func daemonStatus() async -> PeekabooDaemonStatus {
@@ -144,10 +198,12 @@ public final class PeekabooDaemon: PeekabooDaemonControlProviding {
         let snapshots = await self.snapshotStatus()
         let trackerStatus = self.windowTracker?.status()
 
-        let bridgeStatus = PeekabooDaemonBridgeStatus(
-            socketPath: self.configuration.bridgeSocketPath,
-            hostKind: self.configuration.hostKind,
-            allowedOperations: Array(self.configuration.allowedOperations).sorted { $0.rawValue < $1.rawValue })
+        let bridgeStatus = self.configuration.bridgeHostingEnabled
+            ? PeekabooDaemonBridgeStatus(
+                socketPath: self.configuration.bridgeSocketPath,
+                hostKind: self.configuration.hostKind,
+                allowedOperations: Array(self.configuration.allowedOperations).sorted { $0.rawValue < $1.rawValue })
+            : nil
 
         let windowStatus = trackerStatus.map { status in
             PeekabooDaemonWindowTrackerStatus(
@@ -168,12 +224,33 @@ public final class PeekabooDaemon: PeekabooDaemonControlProviding {
             snapshots: snapshots,
             windowTracker: windowStatus,
             browser: try? self.services.browserStatus(channel: nil),
-            activity: self.activityStatus(now: Date()))
+            activity: self.activityStatus(now: Date()),
+            supportsConditionalStop: true)
     }
 
     public func requestStop() async -> Bool {
-        guard !self.isStopping else { return false }
+        await self.requestStopIfIdle()
+    }
+
+    public func requestStop(expectedPID: pid_t) async -> Bool {
+        guard expectedPID == getpid() else { return false }
+        return await self.requestStopIfIdle()
+    }
+
+    private func requestStopIfIdle() async -> Bool {
+        guard !self.isStopping, self.activeRequestCount == 0 else { return false }
         self.isStopping = true
+        self.shutdownTask = Task { [self] in
+            await self.finishStop()
+        }
+        return true
+    }
+
+    public func waitUntilStopped() async {
+        await self.shutdownTask?.value
+    }
+
+    private func finishStop() async {
         await self.shutdown()
         self.stopContinuation?.resume()
         self.stopContinuation = nil
@@ -181,17 +258,20 @@ public final class PeekabooDaemon: PeekabooDaemonControlProviding {
         if self.configuration.exitOnStop {
             exit(0)
         }
-
-        return true
     }
 
     public func recordActivityStart(operation: PeekabooBridgeOperation) async {
-        guard !self.isStopping else { return }
+        _ = await self.admitActivity(operation: operation)
+    }
+
+    public func admitActivity(operation: PeekabooBridgeOperation) async -> Bool {
+        guard !self.isStopping else { return false }
         self.activeRequestCount += 1
         self.lastActivityAt = Date()
         self.idleShutdownTask?.cancel()
         self.idleShutdownTask = nil
         self.logger.debug("daemon activity started op=\(operation.rawValue)")
+        return true
     }
 
     public func recordActivityEnd(operation: PeekabooBridgeOperation) async {
@@ -205,16 +285,17 @@ public final class PeekabooDaemon: PeekabooDaemonControlProviding {
     private func shutdown() async {
         self.idleShutdownTask?.cancel()
         self.idleShutdownTask = nil
-        await self.services.browser.disconnect()
-
-        self.windowTracker?.stop()
-        self.windowTracker = nil
-        WindowMovementTracking.provider = nil
 
         if let host = self.bridgeHost {
             await host.stop()
             self.bridgeHost = nil
         }
+
+        await self.services.browser.disconnect()
+
+        self.windowTracker?.stop()
+        self.windowTracker = nil
+        WindowMovementTracking.provider = nil
     }
 
     private func snapshotStatus() async -> PeekabooDaemonSnapshotStatus {

--- a/Core/PeekabooCore/Tests/PeekabooTests/PeekabooBridgeHostOwnershipTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/PeekabooBridgeHostOwnershipTests.swift
@@ -1,0 +1,501 @@
+import Darwin
+import Foundation
+import PeekabooBridge
+import PeekabooCore
+import PeekabooFoundation
+import Testing
+
+@Suite(.serialized)
+struct PeekabooBridgeHostOwnershipTests {
+    @Test
+    func `second host cannot replace a live leased socket`() async throws {
+        let socketPath = Self.socketPath()
+        defer { Self.removeSocketArtifacts(socketPath) }
+
+        let first = await Self.makeHost(socketPath: socketPath)
+        let second = await Self.makeHost(socketPath: socketPath)
+        try await first.startChecked()
+        defer { Task { await first.stop() } }
+
+        await #expect(throws: PeekabooBridgeHostError.self) {
+            try await second.startChecked()
+        }
+
+        let handshake = try await Self.client(socketPath: socketPath).handshake(client: Self.clientIdentity())
+        #expect(handshake.hostKind == .gui)
+    }
+
+    @Test
+    func `host refuses to replace a live legacy listener`() async throws {
+        let socketPath = Self.socketPath()
+        let listener = try Self.bindSocket(path: socketPath, listen: true)
+        defer {
+            close(listener)
+            Self.removeSocketArtifacts(socketPath)
+        }
+
+        let host = await Self.makeHost(socketPath: socketPath)
+        do {
+            try await host.startChecked()
+            Issue.record("Expected the live listener to retain socket ownership")
+            await host.stop()
+        } catch let error as PeekabooBridgeHostError {
+            guard case let .socketAlreadyOwned(path) = error else {
+                Issue.record("Expected socketAlreadyOwned, got \(error)")
+                return
+            }
+            #expect(path == socketPath)
+            #expect(FileManager.default.fileExists(atPath: socketPath))
+        }
+    }
+
+    @Test
+    func `host refuses to replace a legacy socket before listen`() async throws {
+        let socketPath = Self.socketPath()
+        let listener = try Self.bindSocket(path: socketPath, listen: false)
+        defer {
+            close(listener)
+            Self.removeSocketArtifacts(socketPath)
+        }
+
+        let host = await Self.makeHost(socketPath: socketPath)
+        await #expect(throws: PeekabooBridgeHostError.self) {
+            try await host.startChecked()
+        }
+
+        #expect(FileManager.default.fileExists(atPath: socketPath))
+    }
+
+    @Test
+    func `host recognizes a live legacy listener through an equivalent path`() async throws {
+        let name = "peekaboo-bridge-ownership-\(UUID().uuidString).sock"
+        let boundPath = "/tmp/\(name)"
+        let equivalentPath = "/private/tmp/\(name)"
+        let listener = try Self.bindSocket(path: boundPath, listen: true)
+        defer {
+            close(listener)
+            Self.removeSocketArtifacts(boundPath)
+        }
+
+        let host = await Self.makeHost(socketPath: equivalentPath)
+        await #expect(throws: PeekabooBridgeHostError.self) {
+            try await host.startChecked()
+        }
+
+        #expect(FileManager.default.fileExists(atPath: boundPath))
+    }
+
+    @Test
+    func `host recognizes a live relative listener after the owner changes directory`() async throws {
+        let originalDirectory = FileManager.default.currentDirectoryPath
+        let directory = "/tmp/peekaboo-relative-owner-\(UUID().uuidString)"
+        let relativePath = "bridge.sock"
+        let absolutePath = "\(directory)/\(relativePath)"
+        try FileManager.default.createDirectory(atPath: directory, withIntermediateDirectories: false)
+        #expect(chdir(directory) == 0)
+        defer {
+            _ = chdir(originalDirectory)
+            try? FileManager.default.removeItem(atPath: directory)
+        }
+        let listener = try Self.bindSocket(path: relativePath, listen: true)
+        #expect(chdir(originalDirectory) == 0)
+        defer {
+            close(listener)
+            Self.removeSocketArtifacts(absolutePath)
+        }
+
+        let host = await Self.makeHost(socketPath: absolutePath)
+        await #expect(throws: PeekabooBridgeHostError.self) {
+            try await host.startChecked()
+        }
+
+        #expect(FileManager.default.fileExists(atPath: absolutePath))
+    }
+
+    @Test
+    func `host preserves a relative socket before listen after the owner changes directory`() async throws {
+        let originalDirectory = FileManager.default.currentDirectoryPath
+        let directory = "/tmp/peekaboo-relative-owner-\(UUID().uuidString)"
+        let relativePath = "bridge.sock"
+        let absolutePath = "\(directory)/\(relativePath)"
+        try FileManager.default.createDirectory(atPath: directory, withIntermediateDirectories: false)
+        #expect(chdir(directory) == 0)
+        defer {
+            _ = chdir(originalDirectory)
+            try? FileManager.default.removeItem(atPath: directory)
+        }
+        let socket = try Self.bindSocket(path: relativePath, listen: false)
+        #expect(chdir(originalDirectory) == 0)
+        defer {
+            close(socket)
+            Self.removeSocketArtifacts(absolutePath)
+        }
+
+        let host = await Self.makeHost(socketPath: absolutePath)
+        await #expect(throws: PeekabooBridgeHostError.self) {
+            try await host.startChecked()
+        }
+
+        #expect(FileManager.default.fileExists(atPath: absolutePath))
+    }
+
+    @Test
+    func `host recovers a stale lease-owned socket`() async throws {
+        let socketPath = Self.socketPath()
+        let staleListener = try Self.bindSocket(path: socketPath, listen: false)
+        try Self.recordLeaseIdentity(socketPath: socketPath)
+        close(staleListener)
+        defer { Self.removeSocketArtifacts(socketPath) }
+
+        let host = await Self.makeHost(socketPath: socketPath)
+        try await host.startChecked()
+
+        let handshake = try await Self.client(socketPath: socketPath).handshake(client: Self.clientIdentity())
+        #expect(handshake.hostKind == .gui)
+
+        await host.stop()
+        #expect(!FileManager.default.fileExists(atPath: socketPath))
+        #expect(try Data(contentsOf: URL(fileURLWithPath: "\(socketPath).lock")).isEmpty)
+    }
+
+    @Test
+    func `host recovers a stale socket created before leases`() async throws {
+        let socketPath = Self.socketPath()
+        let staleListener = try Self.bindSocket(path: socketPath, listen: false)
+        close(staleListener)
+        defer { Self.removeSocketArtifacts(socketPath) }
+
+        let host = await Self.makeHost(socketPath: socketPath)
+        try await host.startChecked()
+
+        let handshake = try await Self.client(socketPath: socketPath).handshake(client: Self.clientIdentity())
+        #expect(handshake.hostKind == .gui)
+
+        await host.stop()
+        #expect(!FileManager.default.fileExists(atPath: socketPath))
+    }
+
+    @Test
+    func `host recovers after a partial self-generated lease record`() async throws {
+        let socketPath = Self.socketPath()
+        let staleListener = try Self.bindSocket(path: socketPath, listen: false)
+        close(staleListener)
+        try Data("peekaboo-bridge-lease-v1 12".utf8)
+            .write(to: URL(fileURLWithPath: "\(socketPath).lock"))
+        defer { Self.removeSocketArtifacts(socketPath) }
+
+        let host = await Self.makeHost(socketPath: socketPath)
+        try await host.startChecked()
+
+        let handshake = try await Self.client(socketPath: socketPath).handshake(client: Self.clientIdentity())
+        #expect(handshake.hostKind == .gui)
+        let leaseContents = try String(contentsOfFile: "\(socketPath).lock", encoding: .utf8)
+        #expect(!leaseContents.contains("peekaboo-bridge-lease-v1 12\n"))
+        #expect(leaseContents.split(separator: "\n").count == 1)
+
+        await host.stop()
+    }
+
+    @Test
+    func `host uses the last complete lease record before a partial tail`() async throws {
+        let socketPath = Self.socketPath()
+        let staleListener = try Self.bindSocket(path: socketPath, listen: false)
+        try Self.recordLeaseIdentity(socketPath: socketPath)
+        let leaseURL = URL(fileURLWithPath: "\(socketPath).lock")
+        let handle = try FileHandle(forWritingTo: leaseURL)
+        try handle.seekToEnd()
+        try handle.write(contentsOf: Data("\npeekaboo-bridge-lea".utf8))
+        try handle.close()
+        close(staleListener)
+        defer { Self.removeSocketArtifacts(socketPath) }
+
+        let host = await Self.makeHost(socketPath: socketPath)
+        try await host.startChecked()
+
+        let handshake = try await Self.client(socketPath: socketPath).handshake(client: Self.clientIdentity())
+        #expect(handshake.hostKind == .gui)
+
+        await host.stop()
+    }
+
+    @Test
+    func `host refuses to replace a non-socket path`() async throws {
+        let socketPath = Self.socketPath()
+        let contents = Data("owned by another subsystem".utf8)
+        #expect(FileManager.default.createFile(atPath: socketPath, contents: contents))
+        defer { Self.removeSocketArtifacts(socketPath) }
+
+        let host = await Self.makeHost(socketPath: socketPath)
+        do {
+            try await host.startChecked()
+            Issue.record("Expected the non-socket path to be preserved")
+            await host.stop()
+        } catch let error as PeekabooBridgeHostError {
+            guard case let .socketPathIsNotSocket(path) = error else {
+                Issue.record("Expected socketPathIsNotSocket, got \(error)")
+                return
+            }
+            #expect(path == socketPath)
+            #expect(try Data(contentsOf: URL(fileURLWithPath: socketPath)) == contents)
+        }
+    }
+
+    @Test
+    func `host refuses a symlinked lease without modifying its target`() async throws {
+        let socketPath = Self.socketPath()
+        let targetPath = "\(socketPath).target"
+        let contents = Data("must remain intact".utf8)
+        #expect(FileManager.default.createFile(atPath: targetPath, contents: contents))
+        try FileManager.default.createSymbolicLink(
+            atPath: "\(socketPath).lock",
+            withDestinationPath: targetPath)
+        defer {
+            Self.removeSocketArtifacts(socketPath)
+            unlink(targetPath)
+        }
+
+        let host = await Self.makeHost(socketPath: socketPath)
+        await #expect(throws: PeekabooBridgeHostError.self) {
+            try await host.startChecked()
+        }
+
+        #expect(try Data(contentsOf: URL(fileURLWithPath: targetPath)) == contents)
+    }
+
+    @Test
+    func `host refuses a malformed existing lease without modifying it`() async throws {
+        let socketPath = Self.socketPath()
+        let leasePath = "\(socketPath).lock"
+        let contents = Data("owned by another subsystem".utf8)
+        #expect(FileManager.default.createFile(atPath: leasePath, contents: contents))
+        #expect(chmod(leasePath, S_IRUSR | S_IWUSR | S_IRGRP) == 0)
+        defer { Self.removeSocketArtifacts(socketPath) }
+
+        let host = await Self.makeHost(socketPath: socketPath)
+        await #expect(throws: PeekabooBridgeHostError.self) {
+            try await host.startChecked()
+        }
+
+        #expect(try Data(contentsOf: URL(fileURLWithPath: leasePath)) == contents)
+        var info = stat()
+        #expect(lstat(leasePath, &info) == 0)
+        #expect(info.st_mode & mode_t(0o777) == S_IRUSR | S_IWUSR | S_IRGRP)
+    }
+
+    @Test
+    func `host rejects an unreachable final socket path`() async {
+        let socketPath = "/tmp/\(String(repeating: "x", count: 120))"
+        defer { Self.removeSocketArtifacts(socketPath) }
+
+        let host = await Self.makeHost(socketPath: socketPath)
+        await #expect(throws: PeekabooBridgeHostError.self) {
+            try await host.startChecked()
+        }
+
+        #expect(!FileManager.default.fileExists(atPath: socketPath))
+    }
+
+    @Test
+    func `host supports a valid final path near the UNIX socket limit`() async throws {
+        let token = UUID().uuidString.replacingOccurrences(of: "-", with: "")
+        let directoryName = "pb-\(token)\(String(repeating: "x", count: 50))"
+        let directory = "/tmp/\(directoryName)"
+        let socketPath = "\(directory)/s"
+        try FileManager.default.createDirectory(atPath: directory, withIntermediateDirectories: false)
+
+        let host = await Self.makeHost(socketPath: socketPath)
+        do {
+            try await host.startChecked()
+            let handshake = try await Self.client(socketPath: socketPath).handshake(client: Self.clientIdentity())
+            #expect(handshake.hostKind == .gui)
+            await host.stop()
+            try FileManager.default.removeItem(atPath: directory)
+        } catch {
+            await host.stop()
+            try? FileManager.default.removeItem(atPath: directory)
+            throw error
+        }
+    }
+
+    @Test
+    func `host supports a relative socket filename`() async throws {
+        let socketPath = "peekaboo-relative-\(UUID().uuidString).sock"
+        defer { Self.removeSocketArtifacts(socketPath) }
+
+        let host = await Self.makeHost(socketPath: socketPath)
+        try await host.startChecked()
+
+        let handshake = try await Self.client(socketPath: socketPath).handshake(client: Self.clientIdentity())
+        #expect(handshake.hostKind == .gui)
+
+        await host.stop()
+    }
+
+    @Test
+    func `stopping an old host preserves a replacement socket`() async throws {
+        let socketPath = Self.socketPath()
+        defer { Self.removeSocketArtifacts(socketPath) }
+
+        let host = await Self.makeHost(socketPath: socketPath)
+        try await host.startChecked()
+
+        #expect(unlink(socketPath) == 0)
+        let replacement = try Self.bindSocket(path: socketPath, listen: true)
+        defer { close(replacement) }
+
+        await host.stop()
+
+        #expect(FileManager.default.fileExists(atPath: socketPath))
+        let probe = socket(AF_UNIX, SOCK_STREAM, 0)
+        #expect(probe >= 0)
+        defer { close(probe) }
+        #expect(Self.connect(fd: probe, path: socketPath) == 0)
+    }
+
+    @Test
+    func `failed socket cleanup preserves lease identity for recovery`() async throws {
+        let directory = "/tmp/peekaboo-bridge-cleanup-\(UUID().uuidString)"
+        let socketPath = "\(directory)/bridge.sock"
+        try FileManager.default.createDirectory(atPath: directory, withIntermediateDirectories: false)
+        defer {
+            _ = chmod(directory, S_IRWXU)
+            try? FileManager.default.removeItem(atPath: directory)
+        }
+
+        let host = await Self.makeHost(socketPath: socketPath)
+        try await host.startChecked()
+        let markerBefore = try Data(contentsOf: URL(fileURLWithPath: "\(socketPath).lock"))
+
+        #expect(chmod(directory, S_IRUSR | S_IXUSR) == 0)
+        await host.stop()
+        #expect(chmod(directory, S_IRWXU) == 0)
+
+        #expect(FileManager.default.fileExists(atPath: socketPath))
+        let markerAfter = try Data(contentsOf: URL(fileURLWithPath: "\(socketPath).lock"))
+        #expect(markerAfter == markerBefore)
+
+        let replacement = await Self.makeHost(socketPath: socketPath)
+        try await replacement.startChecked()
+        await replacement.stop()
+    }
+
+    @Test
+    func `host stop drains accepted connections through their deadline`() async throws {
+        let socketPath = Self.socketPath()
+        defer { Self.removeSocketArtifacts(socketPath) }
+
+        let host = await Self.makeHost(socketPath: socketPath, requestTimeoutSec: 0.3)
+        try await host.startChecked()
+
+        let client = socket(AF_UNIX, SOCK_STREAM, 0)
+        #expect(client >= 0)
+        defer { close(client) }
+        #expect(Self.connect(fd: client, path: socketPath) == 0)
+        try await Task.sleep(nanoseconds: 50_000_000)
+
+        let start = Date()
+        await host.stop()
+
+        #expect(Date().timeIntervalSince(start) >= 0.15)
+    }
+
+    private static func makeHost(
+        socketPath: String,
+        requestTimeoutSec: TimeInterval = 2) async -> PeekabooBridgeHost
+    {
+        let server = await MainActor.run {
+            PeekabooBridgeServer(
+                services: PeekabooServices(),
+                hostKind: .gui,
+                allowlistedTeams: [],
+                allowlistedBundles: [],
+                permissionStatusEvaluator: { _ in
+                    PermissionsStatus(
+                        screenRecording: true,
+                        accessibility: true,
+                        appleScript: true,
+                        postEvent: true)
+                })
+        }
+        return PeekabooBridgeHost(
+            socketPath: socketPath,
+            server: server,
+            allowedTeamIDs: [],
+            requestTimeoutSec: requestTimeoutSec)
+    }
+
+    private static func client(socketPath: String) -> PeekabooBridgeClient {
+        PeekabooBridgeClient(socketPath: socketPath, requestTimeoutSec: 2)
+    }
+
+    private static func clientIdentity() -> PeekabooBridgeClientIdentity {
+        PeekabooBridgeClientIdentity(
+            bundleIdentifier: "boo.peekaboo.tests",
+            teamIdentifier: nil,
+            processIdentifier: getpid(),
+            hostname: Host.current().name)
+    }
+
+    private static func socketPath() -> String {
+        "/tmp/peekaboo-bridge-ownership-\(UUID().uuidString).sock"
+    }
+
+    private static func removeSocketArtifacts(_ socketPath: String) {
+        unlink(socketPath)
+        unlink("\(socketPath).lock")
+    }
+
+    private static func recordLeaseIdentity(socketPath: String) throws {
+        var info = stat()
+        guard lstat(socketPath, &info) == 0 else {
+            throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO)
+        }
+        let marker = "peekaboo-bridge-lease-v1 \(UInt64(info.st_dev)) \(UInt64(info.st_ino))\n"
+        try Data(marker.utf8).write(to: URL(fileURLWithPath: "\(socketPath).lock"))
+    }
+
+    private static func bindSocket(path: String, listen shouldListen: Bool) throws -> Int32 {
+        let fd = socket(AF_UNIX, SOCK_STREAM, 0)
+        guard fd >= 0 else {
+            throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO)
+        }
+
+        do {
+            var address = try Self.socketAddress(path: path)
+            let length = socklen_t(MemoryLayout.size(ofValue: address))
+            let result = withUnsafePointer(to: &address) {
+                Darwin.bind(fd, UnsafePointer<sockaddr>(OpaquePointer($0)), length)
+            }
+            guard result == 0 else {
+                throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO)
+            }
+            if shouldListen {
+                guard Darwin.listen(fd, SOMAXCONN) == 0 else {
+                    throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO)
+                }
+            }
+            return fd
+        } catch {
+            close(fd)
+            throw error
+        }
+    }
+
+    private static func connect(fd: Int32, path: String) -> Int32 {
+        guard var address = try? socketAddress(path: path) else { return -1 }
+        let length = socklen_t(MemoryLayout.size(ofValue: address))
+        return withUnsafePointer(to: &address) {
+            Darwin.connect(fd, UnsafePointer<sockaddr>(OpaquePointer($0)), length)
+        }
+    }
+
+    private static func socketAddress(path: String) throws -> sockaddr_un {
+        var address = sockaddr_un()
+        address.sun_family = sa_family_t(AF_UNIX)
+        let capacity = MemoryLayout.size(ofValue: address.sun_path)
+        let copied = path.withCString { strlcpy(&address.sun_path.0, $0, capacity) }
+        guard copied < capacity else { throw POSIXError(.ENAMETOOLONG) }
+        address.sun_len = UInt8(MemoryLayout.size(ofValue: address))
+        return address
+    }
+}

--- a/Core/PeekabooCore/Tests/PeekabooTests/PeekabooBridgeSocketIOTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/PeekabooBridgeSocketIOTests.swift
@@ -1,0 +1,87 @@
+import Darwin
+import Foundation
+import Testing
+@testable import PeekabooBridge
+
+@Suite(.serialized)
+struct PeekabooBridgeSocketIOTests {
+    @Test
+    func `read times out when peer remains idle`() throws {
+        let sockets = try Self.socketPair()
+        defer {
+            close(sockets.reader)
+            close(sockets.writer)
+        }
+        try PeekabooBridgeSocketIO.configureConnectedSocket(sockets.reader)
+
+        do {
+            _ = try PeekabooBridgeSocketIO.readAll(
+                fd: sockets.reader,
+                maxBytes: 1024,
+                deadline: Date().addingTimeInterval(0.05))
+            Issue.record("Expected idle read to time out")
+        } catch let error as POSIXError {
+            #expect(error.code == .ETIMEDOUT)
+        }
+    }
+
+    @Test
+    func `write times out when peer does not drain its socket`() throws {
+        let sockets = try Self.socketPair()
+        defer {
+            close(sockets.reader)
+            close(sockets.writer)
+        }
+        try PeekabooBridgeSocketIO.configureConnectedSocket(sockets.writer)
+
+        var sendBufferBytes: Int32 = 4096
+        #expect(setsockopt(
+            sockets.writer,
+            SOL_SOCKET,
+            SO_SNDBUF,
+            &sendBufferBytes,
+            socklen_t(MemoryLayout.size(ofValue: sendBufferBytes))) == 0)
+
+        do {
+            try PeekabooBridgeSocketIO.writeAll(
+                fd: sockets.writer,
+                data: Data(repeating: 0xAB, count: 8 * 1024 * 1024),
+                deadline: Date().addingTimeInterval(0.05))
+            Issue.record("Expected undrained write to time out")
+        } catch let error as POSIXError {
+            #expect(error.code == .ETIMEDOUT)
+        }
+    }
+
+    @Test
+    func `nonblocking transport preserves a complete payload`() throws {
+        let sockets = try Self.socketPair()
+        defer {
+            close(sockets.reader)
+            close(sockets.writer)
+        }
+        try PeekabooBridgeSocketIO.configureConnectedSocket(sockets.reader)
+        try PeekabooBridgeSocketIO.configureConnectedSocket(sockets.writer)
+
+        let expected = Data("bridge payload".utf8)
+        try PeekabooBridgeSocketIO.writeAll(
+            fd: sockets.writer,
+            data: expected,
+            deadline: Date().addingTimeInterval(1))
+        #expect(shutdown(sockets.writer, SHUT_WR) == 0)
+
+        let received = try PeekabooBridgeSocketIO.readAll(
+            fd: sockets.reader,
+            maxBytes: 1024,
+            deadline: Date().addingTimeInterval(1))
+        #expect(received == expected)
+    }
+
+    private static func socketPair() throws -> (reader: Int32, writer: Int32) {
+        var descriptors: [Int32] = [-1, -1]
+        guard socketpair(AF_UNIX, SOCK_STREAM, 0, &descriptors) == 0 else {
+            throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO)
+        }
+        return (descriptors[0], descriptors[1])
+    }
+}

--- a/Core/PeekabooCore/Tests/PeekabooTests/PeekabooBridgeTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/PeekabooBridgeTests.swift
@@ -108,7 +108,7 @@ struct PeekabooBridgeTests {
             allowedTeamIDs: [],
             requestTimeoutSec: 2)
 
-        await host.start()
+        try await host.startChecked()
         defer { Task { await host.stop() } }
 
         let identity = PeekabooBridgeClientIdentity(
@@ -141,7 +141,7 @@ struct PeekabooBridgeTests {
             allowedTeamIDs: [],
             requestTimeoutSec: 2)
 
-        await host.start()
+        try await host.startChecked()
         defer { Task { await host.stop() } }
 
         let identity = PeekabooBridgeClientIdentity(
@@ -906,7 +906,7 @@ extension PeekabooBridgeTests {
             allowedTeamIDs: [],
             requestTimeoutSec: 2)
 
-        await host.start()
+        try await host.startChecked()
         defer { Task { await host.stop() } }
 
         let identity = PeekabooBridgeClientIdentity(
@@ -953,7 +953,7 @@ extension PeekabooBridgeTests {
             allowedTeamIDs: [],
             requestTimeoutSec: 2)
 
-        await host.start()
+        try await host.startChecked()
         defer { Task { await host.stop() } }
 
         let remote = await MainActor.run {
@@ -992,7 +992,7 @@ extension PeekabooBridgeTests {
             allowedTeamIDs: [],
             requestTimeoutSec: 2)
 
-        await host.start()
+        try await host.startChecked()
         defer { Task { await host.stop() } }
 
         let remote = await MainActor.run {
@@ -1026,7 +1026,7 @@ extension PeekabooBridgeTests {
             allowedTeamIDs: [],
             requestTimeoutSec: 2)
 
-        await host.start()
+        try await host.startChecked()
         defer { Task { await host.stop() } }
 
         let remote = await MainActor.run {
@@ -1074,7 +1074,7 @@ extension PeekabooBridgeTests {
             allowedTeamIDs: [],
             requestTimeoutSec: 2)
 
-        await host.start()
+        try await host.startChecked()
         defer { Task { await host.stop() } }
 
         let remote = await MainActor.run {
@@ -1107,7 +1107,7 @@ extension PeekabooBridgeTests {
             allowedTeamIDs: [],
             requestTimeoutSec: 2)
 
-        await host.start()
+        try await host.startChecked()
         defer { Task { await host.stop() } }
 
         let remote = await MainActor.run {
@@ -1709,8 +1709,6 @@ private final class UnimplementedDialogService: DialogServiceProtocol {
 
 @MainActor
 private final class StubDaemonControl: PeekabooDaemonControlProviding {
-    private var activeRequests = 0
-
     func daemonStatus() async -> PeekabooDaemonStatus {
         PeekabooDaemonStatus(
             running: true,
@@ -1722,18 +1720,14 @@ private final class StubDaemonControl: PeekabooDaemonControlProviding {
                 hostKind: .onDemand,
                 allowedOperations: [.daemonStatus]),
             activity: PeekabooDaemonActivityStatus(
-                activeRequests: self.activeRequests,
+                activeRequests: 0,
                 lastActivityAt: Date(),
                 idleTimeoutSeconds: 10,
-                idleExitAt: self.activeRequests == 0 ? Date().addingTimeInterval(10) : nil))
+                idleExitAt: Date().addingTimeInterval(10)))
     }
 
     func requestStop() async -> Bool {
         true
-    }
-
-    func recordActivityStart(operation: PeekabooBridgeOperation) async {
-        self.activeRequests += 1
     }
 }
 

--- a/Core/PeekabooCore/Tests/PeekabooTests/PeekabooDaemonTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/PeekabooDaemonTests.swift
@@ -1,4 +1,5 @@
 import Foundation
+import PeekabooAutomationKit
 import PeekabooBridge
 import PeekabooCore
 import Testing
@@ -6,6 +7,15 @@ import Testing
 @Suite(.tags(.safe))
 @MainActor
 struct PeekabooDaemonTests {
+    @Test
+    func `daemon configuration defaults to the dedicated socket`() {
+        let configuration = PeekabooDaemon.Configuration(
+            mode: .manual,
+            hostKind: .onDemand)
+
+        #expect(configuration.bridgeSocketPath == PeekabooBridgeConstants.daemonSocketPath)
+    }
+
     @Test
     func `auto daemon reports activity and idle deadline`() async {
         let daemon = PeekabooDaemon(configuration: .init(
@@ -16,7 +26,7 @@ struct PeekabooDaemonTests {
             hostKind: .onDemand,
             idleTimeout: 10))
 
-        await daemon.recordActivityStart(operation: .listApplications)
+        #expect(await daemon.admitActivity(operation: .listApplications))
         var status = await daemon.daemonStatus()
         #expect(status.mode == .auto)
         #expect(status.activity?.activeRequests == 1)
@@ -29,5 +39,60 @@ struct PeekabooDaemonTests {
         #expect(status.activity?.idleExitAt != nil)
 
         _ = await daemon.requestStop()
+    }
+
+    @Test
+    func `daemon refuses stop while an operational request is active`() async {
+        let daemon = PeekabooDaemon(configuration: .embeddedMCP())
+
+        #expect(await daemon.admitActivity(operation: .captureScreen))
+        #expect(await daemon.requestStop() == false)
+        #expect(await (daemon.daemonStatus()).activity?.activeRequests == 1)
+
+        await daemon.recordActivityEnd(operation: .captureScreen)
+        #expect(await daemon.requestStop())
+    }
+
+    @Test
+    func `daemon rejects activity and mismatched stop after shutdown begins`() async {
+        let daemon = PeekabooDaemon(configuration: .embeddedMCP())
+
+        #expect(await daemon.requestStop(expectedPID: getpid() + 1) == false)
+        #expect(await daemon.requestStop(expectedPID: getpid()))
+        #expect(await daemon.admitActivity(operation: .waitForElement) == false)
+    }
+
+    @Test
+    func `MCP daemon does not expose a bridge listener`() async {
+        let configuration = PeekabooDaemon.Configuration.embeddedMCP()
+        #expect(!configuration.bridgeHostingEnabled)
+        #expect(!configuration.exitOnStop)
+
+        let daemon = PeekabooDaemon(configuration: configuration)
+        let status = await daemon.daemonStatus()
+
+        #expect(status.mode == .mcp)
+        #expect(status.bridge == nil)
+    }
+
+    @Test
+    func `embedded MCP shutdown completes tracker cleanup`() async throws {
+        let daemon = PeekabooDaemon(configuration: .embeddedMCP())
+        try await daemon.startChecked()
+        #expect(WindowMovementTracking.provider != nil)
+
+        #expect(await daemon.requestStop())
+        await daemon.waitUntilStopped()
+
+        #expect(WindowMovementTracking.provider == nil)
+    }
+
+    @Test
+    func `legacy MCP configuration still hosts its requested bridge`() {
+        let configuration = PeekabooDaemon.Configuration.mcp(bridgeSocketPath: "/tmp/legacy-mcp.sock")
+
+        #expect(configuration.bridgeSocketPath == "/tmp/legacy-mcp.sock")
+        #expect(configuration.bridgeHostingEnabled)
+        #expect(configuration.exitOnStop)
     }
 }

--- a/Core/PeekabooCore/Tests/PeekabooTests/RemoteApplicationServiceTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/RemoteApplicationServiceTests.swift
@@ -29,7 +29,7 @@ struct RemoteApplicationServiceTests {
             allowedTeamIDs: [],
             requestTimeoutSec: 2)
 
-        await host.start()
+        try await host.startChecked()
         defer { Task { await host.stop() } }
 
         let directClient = PeekabooBridgeClient(socketPath: socketPath, requestTimeoutSec: 2)

--- a/Core/PeekabooCore/Tests/PeekabooTests/RemoteInspectUIBridgeTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/RemoteInspectUIBridgeTests.swift
@@ -46,7 +46,7 @@ struct RemoteInspectUIBridgeTests {
             allowedTeamIDs: [],
             requestTimeoutSec: 2)
 
-        await host.start()
+        try await host.startChecked()
         do {
             let client = PeekabooBridgeClient(socketPath: socketPath, requestTimeoutSec: 2)
             let remote = await MainActor.run {

--- a/docs/bridge-host.md
+++ b/docs/bridge-host.md
@@ -29,8 +29,9 @@ Bridge diagnostics inspect sockets in this order:
    - Socket: `~/Library/Application Support/clawdbot/bridge.sock`
 5. **Local in-process** (no host available; requires the caller process to have TCC grants)
 
-Only the explicit Bridge override or daemon socket participates in normal runtime selection. The app-host sockets remain
-visible in diagnostics and can be selected with `--bridge-socket` or `PEEKABOO_BRIDGE_SOCKET`.
+Normal runtime selection prefers the reusable daemon, then a healthy Peekaboo.app GUI host before starting a daemon.
+This preserves existing app-held TCC grants while keeping socket ownership separate. Other app-host sockets remain
+diagnostic-only unless selected with `--bridge-socket` or `PEEKABOO_BRIDGE_SOCKET`.
 
 There is **no auto-launch** of Peekaboo.app.
 

--- a/docs/bridge-host.md
+++ b/docs/bridge-host.md
@@ -17,17 +17,25 @@ This replaces the previous XPC-based helper approach.
 Normal CLI automation commands prefer the on-demand Peekaboo daemon socket and will auto-start that daemon when it
 is missing. This keeps bursty command sequences warm without probing unrelated host apps.
 
-Explicit bridge diagnostics can still inspect host sockets in this order:
+Bridge diagnostics inspect sockets in this order:
 
-1. **Peekaboo.app** (primary host)
+1. **Peekaboo daemon** (normal automation runtime)
+   - Socket: `~/Library/Application Support/Peekaboo/daemon.sock`
+2. **Peekaboo.app** (permission broker)
    - Socket: `~/Library/Application Support/Peekaboo/bridge.sock`
-2. **Claude.app** (fallback host; piggyback on Claude Desktop TCC grants)
+3. **Claude.app** (fallback host; piggyback on Claude Desktop TCC grants)
    - Socket: `~/Library/Application Support/Claude/bridge.sock`
-3. **Clawdbot.app** (fallback host)
+4. **Clawdbot.app** (fallback host)
    - Socket: `~/Library/Application Support/clawdbot/bridge.sock`
-4. **Local in-process** (no host available; requires the caller process to have TCC grants)
+5. **Local in-process** (no host available; requires the caller process to have TCC grants)
+
+Only the explicit Bridge override or daemon socket participates in normal runtime selection. The app-host sockets remain
+visible in diagnostics and can be selected with `--bridge-socket` or `PEEKABOO_BRIDGE_SOCKET`.
 
 There is **no auto-launch** of Peekaboo.app.
+
+`peekaboo mcp` never hosts a Bridge listener. When it must run services locally, its in-process daemon is limited to
+the window tracker and other process-local support.
 
 ## Transport
 
@@ -37,6 +45,15 @@ There is **no auto-launch** of Peekaboo.app.
 - Payloads are `Codable` JSON with a small handshake for:
   - protocol version negotiation
   - capability/operation advertisement
+- Each listener holds an exclusive lease beside its socket for its full lifetime.
+- A host removes an existing socket only after acquiring the lease and matching the path to the exact device/inode
+  recorded by the previous lease owner. Pre-lease sockets are recovered only after proving no same-user process has the
+  exact UNIX path open; a failed connect alone never marks a socket stale.
+- New listeners bind and secure a private temporary socket, then publish it atomically without replacing an existing
+  path.
+- Shutdown removes the socket only when its filesystem identity still matches the listener that created it.
+- Connect, request read, and response write paths are nonblocking and deadline-bound so abandoned clients release their
+  connection tasks instead of exhausting the host.
 
 Protocol `1.3` adds element action operations:
 

--- a/docs/commands/daemon.md
+++ b/docs/commands/daemon.md
@@ -18,6 +18,8 @@ commands detect that legacy daemon by its daemon status. Peekaboo.app is never t
 Normal automation commands migrate legacy auto or manual daemons that advertise atomic conditional stop. The daemon
 keeps its prior lifecycle mode, poll interval, and auto idle timeout, so a manually started daemon remains manual after
 migration. MCP sessions remain process-owned and are never migrated.
+When `bridge.sock` belongs to a healthy Peekaboo.app GUI host instead, normal commands keep using that app-held TCC
+context and start the reusable daemon only if the app host is unavailable or lacks the required capability.
 Automatic migration defers while operational requests are active and keeps using the legacy daemon for that invocation.
 Older daemons without conditional stop remain on `bridge.sock` until they exit or are explicitly stopped. Explicit
 `daemon start` asks the user to stop those older daemons first, and asks for a retry when supported daemons are busy.

--- a/docs/commands/daemon.md
+++ b/docs/commands/daemon.md
@@ -9,6 +9,19 @@ read_when:
 
 Manage the on-demand headless daemon that keeps Peekaboo state warm, tracks windows live, and serves bridge requests.
 
+The default listener is `~/Library/Application Support/Peekaboo/daemon.sock`, separate from Peekaboo.app's
+`bridge.sock`.
+
+After upgrading from a version that used `bridge.sock` for the daemon, default `status`, `start`, and `stop`
+commands detect that legacy daemon by its daemon status. Peekaboo.app is never treated as a daemon.
+
+Normal automation commands migrate legacy auto or manual daemons that advertise atomic conditional stop. The daemon
+keeps its prior lifecycle mode, poll interval, and auto idle timeout, so a manually started daemon remains manual after
+migration. MCP sessions remain process-owned and are never migrated.
+Automatic migration defers while operational requests are active and keeps using the legacy daemon for that invocation.
+Older daemons without conditional stop remain on `bridge.sock` until they exit or are explicitly stopped. Explicit
+`daemon start` asks the user to stop those older daemons first, and asks for a retry when supported daemons are busy.
+
 ## Commands
 
 ### Start
@@ -16,7 +29,7 @@ Manage the on-demand headless daemon that keeps Peekaboo state warm, tracks wind
 peekaboo daemon start
 ```
 Options:
-- `--bridge-socket <path>` override the default bridge socket path.
+- `--bridge-socket <path>` override the default daemon socket path.
 - `--poll-interval-ms <ms>` window tracker poll interval (default 1000ms).
 - `--wait-seconds <sec>` how long to wait for startup (default 3s).
 
@@ -38,8 +51,8 @@ Shows:
 peekaboo daemon stop
 ```
 Options:
-- `--bridge-socket <path>` override the default bridge socket path.
-- `--wait-seconds <sec>` how long to wait for shutdown (default 3s).
+- `--bridge-socket <path>` override the default daemon socket path.
+- `--wait-seconds <sec>` how long to wait for shutdown (default 12s, above the Bridge request deadline).
 
 ## Notes
 - Normal automation commands auto-start the daemon in `auto` mode when the default daemon socket is unavailable.

--- a/docs/commands/permissions.md
+++ b/docs/commands/permissions.md
@@ -46,7 +46,7 @@ peekaboo permissions request-event-synthesizing
 
 ## Troubleshooting
 - Verify Screen Recording + Accessibility permissions (`peekaboo permissions status`).
-- Check the printed `Source:` line. If it says `Peekaboo Bridge`, the status reflects the selected host app's TCC grants. Grant Screen Recording to that host, or force local capture with `--no-remote --capture-engine cg` only when the caller process is running in the active Aqua GUI session and already has permission. SSH, LaunchAgent, Codex, and other background launchd sessions can still return wallpaper-only pixels despite TCC grants, so prefer Bridge there.
+- Check the printed `Source:` line. If it says `Peekaboo Bridge`, the status reflects the explicit Bridge socket or selected reusable daemon's TCC grants. Grant Screen Recording to that host process, or force local capture with `--no-remote --capture-engine cg` only when the caller process is running in the active Aqua GUI session and already has permission. SSH, LaunchAgent, Codex, and other background launchd sessions can still return wallpaper-only pixels despite TCC grants, so prefer Bridge there.
 - Treat `--capture-engine` as a local-debug override: it disables Bridge selection for that command.
 - If capture returns a blank desktop, wallpaper, or no windows while `permissions status` reports Screen Recording as denied, run `peekaboo permissions request-screen-recording` and then restart the affected Peekaboo process. Homebrew upgrades can move the CLI to a new Cellar path, so confirm the enabled System Settings row belongs to the current binary.
 - Confirm your target (app/window/selector) with `peekaboo list`/`peekaboo see` before rerunning.

--- a/docs/daemon.md
+++ b/docs/daemon.md
@@ -77,6 +77,8 @@ MCP (stdio)  ───┘                             │
 - Automation-oriented CLI commands prefer the default Peekaboo daemon socket.
 - The reusable daemon owns `~/Library/Application Support/Peekaboo/daemon.sock`; it never shares
   Peekaboo.app's `bridge.sock`.
+- If no reusable daemon is running, normal commands use a healthy Peekaboo.app GUI host before auto-starting a daemon,
+  preserving existing app-held TCC grants.
 - On upgrade, daemon control detects a still-running legacy auto or manual daemon on `bridge.sock`. Daemons that
   advertise conditional stop migrate to the dedicated listener while preserving lifecycle mode, poll interval, and
   auto idle timeout.

--- a/docs/daemon.md
+++ b/docs/daemon.md
@@ -75,6 +75,14 @@ MCP (stdio)  ───┘                             │
 
 ### Auto daemon routing
 - Automation-oriented CLI commands prefer the default Peekaboo daemon socket.
+- The reusable daemon owns `~/Library/Application Support/Peekaboo/daemon.sock`; it never shares
+  Peekaboo.app's `bridge.sock`.
+- On upgrade, daemon control detects a still-running legacy auto or manual daemon on `bridge.sock`. Daemons that
+  advertise conditional stop migrate to the dedicated listener while preserving lifecycle mode, poll interval, and
+  auto idle timeout.
+- Migration defers while the daemon has active requests. Older daemons without conditional stop remain on the legacy
+  socket until they exit or are explicitly stopped, avoiding a status-to-stop race. Daemon stop drains accepted
+  connections before shutting down operational services.
 - If no default daemon is reachable, command runtime starts `peekaboo daemon run --mode auto` and reconnects.
 - Auto daemons track Bridge request activity and shut down after an idle timeout (default 300 seconds).
 - `peekaboo list apps`, `peekaboo app list`, `--no-remote`, `PEEKABOO_NO_REMOTE`, explicit input strategy overrides, and explicit capture engine overrides keep commands local.

--- a/docs/permissions.md
+++ b/docs/permissions.md
@@ -46,14 +46,15 @@ For build and runtime version details, see [platform-support.md](platform-suppor
 ## Bridge and subprocess runners
 
 `peekaboo permissions status` prints a `Source:` line. If it says `Peekaboo Bridge`, capture and automation
-permissions are being checked on the selected host app. Grant Screen Recording and Accessibility to that host,
+permissions are being checked through the explicit Bridge socket or selected reusable daemon. Grant Screen
+Recording and Accessibility to that host process,
 or bypass Bridge for local capture only when the caller is known to run in the active Aqua GUI session:
 
 ```bash
 peekaboo see --mode screen --screen-index 0 --no-remote --capture-engine cg --json
 ```
 
-This is useful for app-launched subprocess runners where the parent process has TCC grants but the Bridge host
+This is useful for app-launched subprocess runners where the parent process has TCC grants but the selected host
 does not. For SSH, LaunchAgent, Codex, and other background launchd sessions, prefer the Bridge path even when
 TCC appears granted; CoreGraphics can otherwise report success while returning only the desktop wallpaper or a
 redacted image. Passing `--capture-engine` is a local-debug override and disables Bridge selection for that


### PR DESCRIPTION
## Summary

- give every Bridge listener exclusive lease-backed ownership and atomically publish/remove its UNIX socket
- bound connect/read/write work with nonblocking deadlines and drain accepted clients before releasing ownership
- separate Peekaboo.app (`bridge.sock`) from the reusable daemon (`daemon.sock`), migrate legacy daemons replacement-first while preserving lifecycle settings, and keep custom sockets isolated
- preserve the default healthy Peekaboo.app GUI fallback before daemon auto-start while still migrating legacy on-demand daemons
- stop MCP from hosting a Bridge listener and make daemon stop/migration PID-conditional
- document the ownership and migration contracts and add regression coverage for stale sockets, contention, cleanup, draining, routing, and rollback

## Root cause

The app, reusable daemon, and MCP process could contend for one socket without an ownership lease. A failed connection was enough to treat a path as stale, blocking Bridge I/O could strand accepted clients, and daemon migration could retire the serving process before a replacement was proven healthy. Together those paths allowed ungranted processes to replace the granted app host and left shutdown/startup races wedged.

## Impact

Bridge hosts can no longer replace a live owner. The reusable daemon has its own socket, abandoned clients are deadline-bound, legacy migration preserves mode/poll/idle settings and keeps the old daemon serving if replacement fails, healthy Peekaboo.app GUI hosting remains the automatic default fallback, and embedded MCP remains process-local.

## Validation

- `pnpm run format`
- `pnpm run lint` (0 serious findings)
- `pnpm run lint:docs`
- `pnpm run test:safe` (507 tests, 68 suites)
- `swift test --package-path Apps/CLI --filter CommandRuntimeInjectionTests` (28 tests)
- `swift test --package-path Core/PeekabooCore --no-parallel` (918 tests, 132 suites; expected automation skips)
- `pnpm run build:cli`
- `./scripts/build-mac-debug.sh`
- live daemon start/status/conditional-stop on an isolated socket
- live second-host contention rejection while the first host remained usable
- live healthy Peekaboo.app GUI fallback with the production-team-signed exact new CLI and no daemon socket created
- live legacy `bridge.sock` to `daemon.sock` migration after the fallback refactor, preserving mode, 425 ms poll interval, and 47.5 s idle timeout
- live replacement-start failure proving the legacy daemon remained serving
- live custom-socket isolation with legacy and custom daemons concurrently healthy
- live MCP stdio lifecycle proving no socket listener was published
- live abandoned-client drain/restart: replacement waited 11 seconds for lease release, then started with a new PID
- final autoreview: clean, no accepted/actionable findings (0.91 confidence)

## Live Evidence

Healthy Peekaboo.app fallback, selected before daemon auto-start:

```text
ASSERT signed_cli_team=Y5PE65HELJ app_pid=5184 explicit_ready=yes daemon_socket_exists=no
[2026-06-12T06:47:36.261Z] DEBUG: Runtime host: remote gui via /tmp/.../Library/Application Support/Peekaboo/bridge.sock (build 3.4.2 (1))
LIVE_APP_FALLBACK_OK
```

Legacy on-demand daemon still migrates after the fallback refactor:

```text
ASSERT old_pid=5486 new_pid=5513 legacy_running=false mode=auto poll=425 idle=47.5
[2026-06-12T06:47:46.742Z] DEBUG: Runtime host: remote onDemand via /tmp/.../Library/Application Support/Peekaboo/daemon.sock (build 3.1.1 (3.1.1))
LIVE_MIGRATION_AFTER_FALLBACK_OK
```

A second listener is rejected while the owner remains usable:

```text
Error: Bridge socket is already owned by another host
ASSERT secondary_rc=1 primary_pid=59301 still_running=true
```

An abandoned client delays replacement until the lease is released:

```text
ASSERT old_pid=62962 new_pid=63179 elapsed=11s running=true socket=/tmp/.../daemon.sock
```

Embedded MCP publishes no Bridge socket:

```text
ASSERT stdout_bytes=0 stderr_bytes=0 sockets=0
```

Fixes #184