### PR TITLE
Fix background filtering in app list

### DIFF
--- a/Apps/CLI/Sources/PeekabooCLI/Commands/System/AppCommand+List.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/System/AppCommand+List.swift
@@ -45,6 +45,23 @@ extension AppCommand {
             self.resolvedRuntime.configuration.jsonOutput
         }
 
+        static func filteredApplications(
+            _ applications: [ServiceApplicationInfo],
+            includeHidden: Bool,
+            includeBackground: Bool
+        ) -> [ServiceApplicationInfo] {
+            applications.filter { app in
+                if !includeHidden, app.isHidden {
+                    return false
+                }
+                if !includeBackground,
+                   app.activationPolicy == .accessory || app.activationPolicy == .prohibited {
+                    return false
+                }
+                return true
+            }
+        }
+
         /// Enumerate running applications, apply filtering flags, and emit the chosen output representation.
         @MainActor
         mutating func run(using runtime: CommandRuntime) async throws {
@@ -53,12 +70,11 @@ extension AppCommand {
             do {
                 let appsOutput = try await self.services.applications.listApplications()
 
-                // Filter based on flags
-                let filtered = appsOutput.data.applications.filter { app in
-                    if !self.includeHidden && app.isHidden { return false }
-                    if !self.includeBackground && app.name.isEmpty { return false }
-                    return true
-                }
+                let filtered = Self.filteredApplications(
+                    appsOutput.data.applications,
+                    includeHidden: self.includeHidden,
+                    includeBackground: self.includeBackground
+                )
 
                 struct AppInfo: Codable {
                     let name: String

--- a/Apps/CLI/Tests/CoreCLITests/AppListFilteringTests.swift
+++ b/Apps/CLI/Tests/CoreCLITests/AppListFilteringTests.swift
@@ -1,0 +1,72 @@
+import PeekabooCore
+import Testing
+@testable import PeekabooCLI
+
+struct AppListFilteringTests {
+    @Test
+    func `default filtering excludes hidden and background apps`() {
+        let applications = [
+            Self.application(name: "Regular", activationPolicy: .regular),
+            Self.application(name: "Accessory", activationPolicy: .accessory),
+            Self.application(name: "Prohibited", activationPolicy: .prohibited),
+            Self.application(name: "Hidden", isHidden: true, activationPolicy: .regular),
+            Self.application(name: "Unknown", activationPolicy: .unknown),
+            Self.application(name: "Legacy", activationPolicy: nil),
+        ]
+
+        let filtered = AppCommand.ListSubcommand.filteredApplications(
+            applications,
+            includeHidden: false,
+            includeBackground: false
+        )
+
+        #expect(filtered.map(\.name) == ["Regular", "Unknown", "Legacy"])
+    }
+
+    @Test
+    func `include background retains accessory and prohibited apps`() {
+        let applications = [
+            Self.application(name: "Regular", activationPolicy: .regular),
+            Self.application(name: "Accessory", activationPolicy: .accessory),
+            Self.application(name: "Prohibited", activationPolicy: .prohibited),
+        ]
+
+        let filtered = AppCommand.ListSubcommand.filteredApplications(
+            applications,
+            includeHidden: false,
+            includeBackground: true
+        )
+
+        #expect(filtered.map(\.name) == ["Regular", "Accessory", "Prohibited"])
+    }
+
+    @Test
+    func `include hidden is independent from include background`() {
+        let applications = [
+            Self.application(name: "Hidden Regular", isHidden: true, activationPolicy: .regular),
+            Self.application(name: "Hidden Accessory", isHidden: true, activationPolicy: .accessory),
+        ]
+
+        let filtered = AppCommand.ListSubcommand.filteredApplications(
+            applications,
+            includeHidden: true,
+            includeBackground: false
+        )
+
+        #expect(filtered.map(\.name) == ["Hidden Regular"])
+    }
+
+    private static func application(
+        name: String,
+        isHidden: Bool = false,
+        activationPolicy: ServiceApplicationActivationPolicy?
+    ) -> ServiceApplicationInfo {
+        ServiceApplicationInfo(
+            processIdentifier: 42,
+            bundleIdentifier: "example.\(name)",
+            name: name,
+            isHidden: isHidden,
+            activationPolicy: activationPolicy
+        )
+    }
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 ### Fixed
+- `peekaboo app list` now excludes accessory/background processes by default, while `--include-background` restores them as documented.
 - Menu-extra clicks now reject items parked outside active displays by menu bar managers instead of moving the pointer to offscreen coordinates and reporting false success.
 
 ## [3.5.2] - 2026-06-13


### PR DESCRIPTION
## Summary

- filter background applications by activation policy instead of the impossible empty-name heuristic
- preserve unknown and legacy records whose activation policy is unavailable
- add regression coverage for hidden and background filtering as independent options

## Verification

- `swift test --package-path Apps/CLI --filter AppListFilteringTests` (3 tests passed)
- `pnpm run test:safe` (512 tests in 69 suites passed)
- `pnpm run lint` (0 serious issues; 9 existing warnings)
- `autoreview --mode local` (clean, no actionable findings)
- live exact-head CLI: default list dropped from 116 to 19 applications; `--include-background` restored all 116
- live exact-head CLI: Ice and CodexBar were excluded by default and restored with `--include-background`
