### PR TITLE
feat(ai): accept MiniMax-M3 as a supported vision model

### DIFF
--- a/Apps/CLI/CHANGELOG.md
+++ b/Apps/CLI/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [3.5.3] - 2026-06-13
 
+### Added
+- `peekaboo see --analyze` and `peekaboo agent` now accept MiniMax-M3 through the global and China MiniMax routes. Thanks @Tugser for #191.
+
 ### Fixed
 - Public CLI, agent, MCP, and API guidance now treats runtime element IDs as opaque strings to copy exactly instead of implying role-specific ID shapes. Thanks @coygeek for #194.
 - JSON-only `peekaboo see` runs without `--path` now keep required screenshots in snapshot storage instead of leaving files on Desktop or exposing their temporary paths. Thanks @coygeek for #196.

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/AI/AgentCommand+ModelParsing.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/AI/AgentCommand+ModelParsing.swift
@@ -154,6 +154,7 @@ extension AgentCommand {
     private static let supportedMiniMaxInputs: Set<LanguageModel.MiniMax> = [
         .m27,
         .m27Highspeed,
+        .m3,
     ]
 
     private static let reservedProviderInputs: Set<String> = [

--- a/Apps/CLI/Tests/CoreCLITests/AgentCommandModelParsingTests.swift
+++ b/Apps/CLI/Tests/CoreCLITests/AgentCommandModelParsingTests.swift
@@ -90,6 +90,9 @@ struct AgentCommandTests {
         #expect(command.parseModelString("MiniMax-M3") == .minimax(.m3))
         #expect(command.parseModelString("minimax/MiniMax-M3") == .minimax(.m3))
         #expect(command.parseModelString("minimax/minimax-m3") == .minimax(.m3))
+        #expect(command.parseModelString("minimax-cn/m2.7") == .minimaxCN(.m27))
+        #expect(command.parseModelString("minimaxi/m2.7-highspeed") == .minimaxCN(.m27Highspeed))
+        #expect(command.parseModelString("minimax-cn/MiniMax-M3") == .minimaxCN(.m3))
         #expect(command.parseModelString("minimax-cn/not-a-supported-model") == nil)
     }
 

--- a/Apps/CLI/Tests/CoreCLITests/AgentCommandModelParsingTests.swift
+++ b/Apps/CLI/Tests/CoreCLITests/AgentCommandModelParsingTests.swift
@@ -87,8 +87,9 @@ struct AgentCommandTests {
         #expect(command.parseModelString("MiniMax-M2.7") == .minimax(.m27))
         #expect(command.parseModelString("minimax-m2.7-highspeed") == .minimax(.m27Highspeed))
         #expect(command.parseModelString("minimax") == .minimax(.m27))
-        #expect(command.parseModelString("minimax-cn/m2.7") == .minimaxCN(.m27))
-        #expect(command.parseModelString("minimaxi/m2.7-highspeed") == .minimaxCN(.m27Highspeed))
+        #expect(command.parseModelString("MiniMax-M3") == .minimax(.m3))
+        #expect(command.parseModelString("minimax/MiniMax-M3") == .minimax(.m3))
+        #expect(command.parseModelString("minimax/minimax-m3") == .minimax(.m3))
         #expect(command.parseModelString("minimax-cn/not-a-supported-model") == nil)
     }
 
@@ -376,6 +377,8 @@ struct ModelSelectionIntegrationTests {
             ("claude-opus-4.8", .anthropic(.opus48)),
             ("gemini-3.5-flash", .google(.gemini35Flash)),
             ("MiniMax-M2.7", .minimax(.m27)),
+            ("MiniMax-M3", .minimax(.m3)),
+            ("minimax/MiniMax-M3", .minimax(.m3)),
             ("ollama/llama3.3", .ollama(.llama33)),
             ("openrouter/xiaomi/mimo-v2.5-pro", .openRouter(modelId: "xiaomi/mimo-v2.5-pro")),
         ]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [3.5.3] - 2026-06-13
 
+### Added
+- MiniMax-M3 can now power screenshot analysis and agent runs through the global and China MiniMax routes. Thanks @Tugser for #191.
+
 ### Fixed
 - Daemon launch, socket, and shutdown polling now stop promptly when their parent task is cancelled instead of spinning until the timeout. Thanks @SebTardif for #203.
 - Public CLI, agent, MCP, and API guidance now treats runtime element IDs as opaque strings to copy exactly instead of implying role-specific ID shapes. Thanks @coygeek for #194.

--- a/Core/PeekabooCore/Tests/PeekabooTests/AIProviderParserTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/AIProviderParserTests.swift
@@ -19,6 +19,9 @@ struct AIProviderParserTests {
         #expect(AIProviderParser.parse("minimax/MiniMax-M2.7") == AIProviderParser.ProviderConfig(
             provider: "minimax",
             model: "MiniMax-M2.7"))
+        #expect(AIProviderParser.parse("minimax/MiniMax-M3") == AIProviderParser.ProviderConfig(
+            provider: "minimax",
+            model: "MiniMax-M3"))
         #expect(AIProviderParser.parse("minimax-cn/MiniMax-M2.7") == AIProviderParser.ProviderConfig(
             provider: "minimax-cn",
             model: "MiniMax-M2.7"))


### PR DESCRIPTION
## Summary

Enables **MiniMax-M3** as a first-class, vision-capable model so it can drive Peekaboo's screenshot/image analysis (`peekaboo see --analyze`, MCP `see`, etc.).

Today the whole MiniMax family is marked `supportsVision = false` in Tachikoma, so configuring `minimax/MiniMax-M3` fails with `No configured vision-capable AI model is available`. With this change (plus the Tachikoma side), M3 works end-to-end for vision.

## Changes
- `Apps/CLI/Sources/PeekabooCLI/Commands/AI/AgentCommand+ModelParsing.swift`: add `.m3` to `supportedMiniMaxInputs`.
- `Apps/CLI/Tests/CoreCLITests/AgentCommandModelParsingTests.swift`: M3 parse assertions + parametrized case.
- `Core/PeekabooCore/Tests/PeekabooTests/AIProviderParserTests.swift`: `minimax/MiniMax-M3` config assertion.
- Tachikoma submodule bump for the enum + per-case `supportsVision` + parser entries (depends on **openclaw/Tachikoma#26**).

## Dependency note
This PR bumps the `Tachikoma` submodule to `Tugser/Tachikoma@13d0454` (the fork commit carrying the M3 enum/parser change) so the Peekaboo side compiles and tests pass. **It should be re-pointed to the `openclaw/Tachikoma` `main` commit once openclaw/Tachikoma#26 merges.** Until then, fresh `git submodule update` against the upstream submodule URL may not resolve the SHA.

## Test commands executed
```
swift test --package-path Apps/CLI --filter "AgentCommandModelParsingTests"
swift test --package-path Core/PeekabooCore --filter "AIProviderParserTests"
# Tachikoma (submodule):
swift test --filter "ModelParsingTests|LanguageModelCoverageTests"
```
All pass. Also verified end-to-end locally: `peekaboo see --mode frontmost --analyze "..."` returns a real analysis via `provider=minimax, model=MiniMax-M3`.

## Builds
- `swift build --package-path Apps/CLI` (debug) ✅
- `./scripts/build-swift-arm.sh` (arm64 release, code-signed) ✅
