### PR TITLE
feat(ai): add Kimi (Moonshot) support for CLI vision and agents

### DIFF
--- a/Apps/CLI/CHANGELOG.md
+++ b/Apps/CLI/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [3.5.3] - 2026-06-13
 
+### Added
+- `peekaboo see --analyze` and `peekaboo agent` now accept Kimi K2.6 and K2.7 Code models through Moonshot's API. Thanks @Tugser for #192.
+
 ### Fixed
 - Public CLI, agent, MCP, and API guidance now treats runtime element IDs as opaque strings to copy exactly instead of implying role-specific ID shapes. Thanks @coygeek for #194.
 - JSON-only `peekaboo see` runs without `--path` now keep required screenshots in snapshot storage instead of leaving files on Desktop or exposing their temporary paths. Thanks @coygeek for #196.

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/AI/AgentCommand+ModelParsing.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/AI/AgentCommand+ModelParsing.swift
@@ -68,6 +68,10 @@ extension AgentCommand {
             if Self.supportedMiniMaxInputs.contains(model) {
                 return .minimaxCN(model)
             }
+        case let .kimi(model):
+            if Self.supportedKimiInputs.contains(model) {
+                return .kimi(model)
+            }
         case .ollama, .lmstudio:
             return parsed.supportsTools ? parsed : nil
         case .openRouter:
@@ -156,6 +160,11 @@ extension AgentCommand {
         .m27Highspeed,
     ]
 
+    private static let supportedKimiInputs: Set<LanguageModel.Kimi> = [
+        .k26,
+        .k27,
+    ]
+
     private static let reservedProviderInputs: Set<String> = [
         "openai",
         "anthropic",
@@ -167,6 +176,8 @@ extension AgentCommand {
         "minimax-cn",
         "minimax_cn",
         "minimaxi",
+        "kimi",
+        "moonshot",
         "ollama",
         "lmstudio",
         "lm-studio",
@@ -177,10 +188,12 @@ extension AgentCommand {
         let anthropicModels = Self.supportedAnthropicInputs.map(\.modelId)
         let googleModels = Self.supportedGoogleInputs.map(\.userFacingModelId)
         let miniMaxModels = Self.supportedMiniMaxInputs.map(\.modelId)
-        return (openAIModels + anthropicModels + googleModels + miniMaxModels + [
+        let kimiModels = Self.supportedKimiInputs.map(\.modelId)
+        return (openAIModels + anthropicModels + googleModels + miniMaxModels + kimiModels + [
             "grok/<model>",
             "xai/<model>",
             "minimax-cn/<model>",
+            "kimi/<model>",
             "ollama/<model>",
             "lmstudio/<model>",
             "openrouter/<provider>/<model>",
@@ -246,6 +259,8 @@ extension AgentCommand {
             return configuration.getMiniMaxAPIKey()?.isEmpty == false
         case .minimaxCN:
             return configuration.getMiniMaxChinaAPIKey()?.isEmpty == false
+        case .kimi:
+            return configuration.getKimiAPIKey()?.isEmpty == false
         case .grok:
             return configuration.getGrokAPIKey()?.isEmpty == false
         case .openRouter:
@@ -269,6 +284,8 @@ extension AgentCommand {
             "MiniMax"
         case .minimaxCN:
             "MiniMax China"
+        case .kimi:
+            "Kimi"
         case .ollama:
             "Ollama"
         case .lmstudio:
@@ -296,6 +313,8 @@ extension AgentCommand {
             "MINIMAX_API_KEY"
         case .minimaxCN:
             "MINIMAX_CN_API_KEY or MINIMAX_API_KEY"
+        case .kimi:
+            "MOONSHOT_API_KEY or KIMI_API_KEY"
         case .ollama:
             "OLLAMA_BASE_URL or PEEKABOO_OLLAMA_BASE_URL"
         case .lmstudio:

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/AI/AgentCommand+ModelParsing.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/AI/AgentCommand+ModelParsing.swift
@@ -162,7 +162,8 @@ extension AgentCommand {
 
     private static let supportedKimiInputs: Set<LanguageModel.Kimi> = [
         .k26,
-        .k27,
+        .k27Code,
+        .k27CodeHighspeed,
     ]
 
     private static let reservedProviderInputs: Set<String> = [

--- a/Apps/CLI/Tests/CoreCLITests/AgentCommandModelParsingTests.swift
+++ b/Apps/CLI/Tests/CoreCLITests/AgentCommandModelParsingTests.swift
@@ -93,6 +93,18 @@ struct AgentCommandTests {
     }
 
     @Test
+    func `Kimi (Moonshot) models are accepted`() throws {
+        let command = try AgentCommand.parse([])
+
+        #expect(command.parseModelString("kimi/k2p6") == .kimi(.k26))
+        #expect(command.parseModelString("kimi/k2p7") == .kimi(.k27))
+        #expect(command.parseModelString("kimi/kimi-k2.7-code") == .kimi(.k27))
+        #expect(command.parseModelString("moonshot/k2p7") == .kimi(.k27))
+        #expect(command.parseModelString("kimi-k2.6") == .kimi(.k26))
+        #expect(command.parseModelString("kimi/unknown-model") == nil)
+    }
+
+    @Test
     func `OpenRouter provider model IDs are accepted`() throws {
         let command = try AgentCommand.parse([])
 
@@ -376,6 +388,8 @@ struct ModelSelectionIntegrationTests {
             ("claude-opus-4.8", .anthropic(.opus48)),
             ("gemini-3.5-flash", .google(.gemini35Flash)),
             ("MiniMax-M2.7", .minimax(.m27)),
+            ("kimi/k2p6", .kimi(.k26)),
+            ("kimi/k2p7", .kimi(.k27)),
             ("ollama/llama3.3", .ollama(.llama33)),
             ("openrouter/xiaomi/mimo-v2.5-pro", .openRouter(modelId: "xiaomi/mimo-v2.5-pro")),
         ]

--- a/Apps/CLI/Tests/CoreCLITests/AgentCommandModelParsingTests.swift
+++ b/Apps/CLI/Tests/CoreCLITests/AgentCommandModelParsingTests.swift
@@ -96,10 +96,9 @@ struct AgentCommandTests {
     func `Kimi (Moonshot) models are accepted`() throws {
         let command = try AgentCommand.parse([])
 
-        #expect(command.parseModelString("kimi/k2p6") == .kimi(.k26))
-        #expect(command.parseModelString("kimi/k2p7") == .kimi(.k27))
-        #expect(command.parseModelString("kimi/kimi-k2.7-code") == .kimi(.k27))
-        #expect(command.parseModelString("moonshot/k2p7") == .kimi(.k27))
+        #expect(command.parseModelString("kimi/kimi-k2.6") == .kimi(.k26))
+        #expect(command.parseModelString("kimi/kimi-k2.7-code") == .kimi(.k27Code))
+        #expect(command.parseModelString("moonshot/kimi-k2.7-code-highspeed") == .kimi(.k27CodeHighspeed))
         #expect(command.parseModelString("kimi-k2.6") == .kimi(.k26))
         #expect(command.parseModelString("kimi/unknown-model") == nil)
     }
@@ -388,8 +387,8 @@ struct ModelSelectionIntegrationTests {
             ("claude-opus-4.8", .anthropic(.opus48)),
             ("gemini-3.5-flash", .google(.gemini35Flash)),
             ("MiniMax-M2.7", .minimax(.m27)),
-            ("kimi/k2p6", .kimi(.k26)),
-            ("kimi/k2p7", .kimi(.k27)),
+            ("kimi/kimi-k2.6", .kimi(.k26)),
+            ("kimi/kimi-k2.7-code", .kimi(.k27Code)),
             ("ollama/llama3.3", .ollama(.llama33)),
             ("openrouter/xiaomi/mimo-v2.5-pro", .openRouter(modelId: "xiaomi/mimo-v2.5-pro")),
         ]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [3.5.3] - 2026-06-13
 
+### Added
+- Kimi K2.6 and K2.7 Code can now power screenshot analysis and agent runs through Moonshot's API. Thanks @Tugser for #192.
+
 ### Fixed
 - Daemon launch, socket, and shutdown polling now stop promptly when their parent task is cancelled instead of spinning until the timeout. Thanks @SebTardif for #203.
 - Public CLI, agent, MCP, and API guidance now treats runtime element IDs as opaque strings to copy exactly instead of implying role-specific ID shapes. Thanks @coygeek for #194.

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/Agent/PeekabooAgentService+Execution.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/Agent/PeekabooAgentService+Execution.swift
@@ -144,7 +144,7 @@ extension PeekabooAgentService {
         case .minimax, .minimaxCN:
             8192
         case .kimi:
-            32_768
+            32768
         case .mistral, .groq, .grok, .ollama, .lmstudio, .azureOpenAI, .replicate:
             4096
         case let .openRouter(modelId), let .together(modelId), let .openaiCompatible(modelId, _):

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/Agent/PeekabooAgentService+Execution.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/Agent/PeekabooAgentService+Execution.swift
@@ -143,6 +143,8 @@ extension PeekabooAgentService {
             8192
         case .minimax, .minimaxCN:
             8192
+        case .kimi:
+            32_768
         case .mistral, .groq, .grok, .ollama, .lmstudio, .azureOpenAI, .replicate:
             4096
         case let .openRouter(modelId), let .together(modelId), let .openaiCompatible(modelId, _):

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/Agent/PeekabooAgentService+Streaming.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/Agent/PeekabooAgentService+Streaming.swift
@@ -350,6 +350,25 @@ extension PeekabooAgentService {
             return openRouterMetadata
         }
 
+        if block.type == "kimi_reasoning_content",
+           let target = ReasoningReplayTarget(
+               model: model,
+               configuration: configuration,
+               peekabooConfiguration: peekabooConfiguration),
+           target.provider == "kimi"
+        {
+            var metadata = [
+                "kimi.reasoning_content": block.text,
+                "tachikoma.reasoning.type": block.type,
+                "tachikoma.reasoning.provider": target.provider,
+                "tachikoma.reasoning.model": target.modelId,
+            ]
+            if let endpointIdentity = target.endpointIdentity {
+                metadata["tachikoma.reasoning.base_url"] = endpointIdentity
+            }
+            return metadata
+        }
+
         var customData: [String: String] = if let target = ReasoningReplayTarget(
             model: model,
             configuration: configuration,
@@ -895,6 +914,12 @@ private struct ReasoningReplayTarget {
             self.baseURL = configuration.getBaseURL(for: .minimaxCN) ?? Provider.minimaxCN.defaultBaseURL
             self.allowsReasoningBoundaries = true
             self.allowsLegacyUnknown = true
+        case let .kimi(model):
+            self.provider = "kimi"
+            self.modelId = model.modelId
+            self.baseURL = configuration.getBaseURL(for: .kimi) ?? Provider.kimi.defaultBaseURL
+            self.allowsReasoningBoundaries = true
+            self.allowsLegacyUnknown = false
         case let .custom(provider):
             if let anthropicProvider = provider as? AnthropicProvider {
                 self.provider = "anthropic"

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/Agent/PeekabooAgentService.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/Agent/PeekabooAgentService.swift
@@ -69,6 +69,7 @@ public final class PeekabooAgentService: AgentServiceProtocol {
         case let .lmstudio(model): "lmstudio/\(model.modelId)"
         case let .minimax(model): "minimax/\(model.modelId)"
         case let .minimaxCN(model): "minimax-cn/\(model.modelId)"
+        case let .kimi(model): "kimi/\(model.modelId)"
         case let .openRouter(modelID): "openrouter/\(modelID)"
         case let .together(modelID): "together/\(modelID)"
         case let .replicate(modelID): "replicate/\(modelID)"
@@ -105,6 +106,8 @@ public final class PeekabooAgentService: AgentServiceProtocol {
                 config.getAPIKey(for: .minimax)
             case .minimaxCN:
                 config.getAPIKey(for: .minimaxCN)
+            case .kimi:
+                config.getAPIKey(for: .kimi)
             case .mistral:
                 config.getAPIKey(for: .mistral)
             case .groq:

--- a/Core/PeekabooCore/Sources/PeekabooAutomation/Configuration/ConfigurationManager+Accessors.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAutomation/Configuration/ConfigurationManager+Accessors.swift
@@ -214,6 +214,19 @@ extension ConfigurationManager {
         return fallbackToSharedKey ? self.getMiniMaxAPIKey() : nil
     }
 
+    /// Get Kimi (Moonshot) API key with proper precedence.
+    public func getKimiAPIKey() -> String? {
+        if let envValue = self.environmentValue(for: "MOONSHOT_API_KEY") {
+            return envValue
+        }
+
+        if let credValue = credentials["MOONSHOT_API_KEY"] ?? credentials["KIMI_API_KEY"] {
+            return credValue
+        }
+
+        return self.environmentValue(for: "KIMI_API_KEY")
+    }
+
     /// Get OpenRouter API key with proper precedence.
     public func getOpenRouterAPIKey() -> String? {
         if let envValue = self.environmentValue(for: "OPENROUTER_API_KEY") {
@@ -260,6 +273,9 @@ extension ConfigurationManager {
         }
         if let key = self.getMiniMaxChinaAPIKey(fallbackToSharedKey: false), !key.isEmpty {
             configuration.setAPIKey(key, for: .minimaxCN)
+        }
+        if let key = self.getKimiAPIKey(), !key.isEmpty {
+            configuration.setAPIKey(key, for: .kimi)
         }
         if let key = self.getOpenRouterAPIKey(), !key.isEmpty {
             configuration.setAPIKey(key, for: "openrouter")

--- a/Core/PeekabooCore/Sources/PeekabooAutomation/Configuration/ConfigurationManager+Accessors.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAutomation/Configuration/ConfigurationManager+Accessors.swift
@@ -216,15 +216,19 @@ extension ConfigurationManager {
 
     /// Get Kimi (Moonshot) API key with proper precedence.
     public func getKimiAPIKey() -> String? {
-        if let envValue = self.environmentValue(for: "MOONSHOT_API_KEY") {
-            return envValue
+        for key in ["MOONSHOT_API_KEY", "KIMI_API_KEY"] {
+            if let envValue = self.environmentValue(for: key), !envValue.isEmpty {
+                return envValue
+            }
         }
 
-        if let credValue = credentials["MOONSHOT_API_KEY"] ?? credentials["KIMI_API_KEY"] {
-            return credValue
+        for key in ["MOONSHOT_API_KEY", "KIMI_API_KEY"] {
+            if let credValue = self.credentials[key], !credValue.isEmpty {
+                return credValue
+            }
         }
 
-        return self.environmentValue(for: "KIMI_API_KEY")
+        return nil
     }
 
     /// Get OpenRouter API key with proper precedence.

--- a/Core/PeekabooCore/Sources/PeekabooAutomation/Services/AI/PeekabooAIService.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAutomation/Services/AI/PeekabooAIService.swift
@@ -342,6 +342,7 @@ public final class PeekabooAIService {
     private static func isHostedProviderIdentifier(_ provider: String) -> Bool {
         switch provider {
         case "openai", "anthropic", "google", "gemini", "minimax", "minimax-cn", "minimax_cn", "minimaxi",
+             "kimi", "moonshot",
              "openrouter", "mistral", "groq", "grok", "xai":
             true
         default:
@@ -380,6 +381,9 @@ public final class PeekabooAIService {
             if case .minimaxCN = loose { return loose }
             let parsed = LanguageModel.parse(from: "minimax-cn/\(modelString)")
             if case .minimaxCN = parsed { return parsed }
+            return nil
+        case "kimi", "moonshot":
+            if case .kimi = loose { return loose }
             return nil
         case "openrouter":
             return .openRouter(modelId: modelString)
@@ -462,6 +466,9 @@ public final class PeekabooAIService {
         }
         if let key = configuration.getMiniMaxAPIKey(), !key.isEmpty {
             return self.appendingGeneratedVisionFallbacks(from: parsed, to: [.minimax(.m27)])
+        }
+        if let key = configuration.getKimiAPIKey(), !key.isEmpty {
+            return self.appendingGeneratedVisionFallbacks(from: parsed, to: [.kimi(.k26)])
         }
         if let key = configuration.getOpenRouterAPIKey(), !key.isEmpty {
             return self.appendingGeneratedVisionFallbacks(
@@ -550,6 +557,8 @@ public final class PeekabooAIService {
             configuration.getMiniMaxAPIKey()?.isEmpty == false
         case .minimaxCN:
             configuration.getMiniMaxChinaAPIKey()?.isEmpty == false
+        case .kimi:
+            configuration.getKimiAPIKey()?.isEmpty == false
         case .grok:
             configuration.getGrokAPIKey()?.isEmpty == false
         case .openRouter:
@@ -575,6 +584,7 @@ public final class PeekabooAIService {
         case let .lmstudio(m): ("lmstudio", m.modelId)
         case let .minimax(m): ("minimax", m.modelId)
         case let .minimaxCN(m): ("minimax-cn", m.modelId)
+        case let .kimi(m): ("kimi", m.modelId)
         case let .azureOpenAI(deployment, _, _, _): ("azure-openai", deployment)
         case let .openRouter(modelId): ("openrouter", modelId)
         case let .together(modelId): ("together", modelId)

--- a/Core/PeekabooCore/Sources/PeekabooCore/Support/PeekabooServices+Agent.swift
+++ b/Core/PeekabooCore/Sources/PeekabooCore/Support/PeekabooServices+Agent.swift
@@ -32,6 +32,7 @@ extension PeekabooServices {
         let hasMiniMaxChina = self.configuration.getMiniMaxChinaAPIKey()?.isEmpty == false
         let hasMiniMaxChinaSpecific = self.configuration.getMiniMaxChinaAPIKey(fallbackToSharedKey: false)?
             .isEmpty == false
+        let hasKimi = self.configuration.getKimiAPIKey()?.isEmpty == false
         let hasOpenRouter = self.configuration.getOpenRouterAPIKey()?.isEmpty == false
         let hasGrok = self.configuration.getGrokAPIKey()?.isEmpty == false
         let hasOllama = Self.providerList(providers, containsToolCapableLocalProvider: "ollama")
@@ -48,8 +49,8 @@ extension PeekabooServices {
             .first
         let hasCustomProvider = customDefaultModel != nil
 
-        if hasOpenAI || hasAnthropic || hasGemini || hasMiniMax || hasMiniMaxChina || hasOpenRouter || hasGrok ||
-            hasOllama || hasLMStudio || hasCustomProvider
+        if hasOpenAI || hasAnthropic || hasGemini || hasMiniMax || hasMiniMaxChina || hasKimi || hasOpenRouter ||
+            hasGrok || hasOllama || hasLMStudio || hasCustomProvider
         {
             let environmentProviders = EnvironmentVariables.value(for: "PEEKABOO_AI_PROVIDERS")?
                 .trimmingCharacters(in: .whitespacesAndNewlines)
@@ -63,6 +64,7 @@ extension PeekabooServices {
                 hasMiniMax: hasMiniMax,
                 hasMiniMaxChina: hasMiniMaxChina,
                 hasMiniMaxChinaSpecific: hasMiniMaxChinaSpecific,
+                hasKimi: hasKimi,
                 hasOpenRouter: hasOpenRouter,
                 hasGrok: hasGrok,
                 hasOllama: hasOllama,
@@ -224,6 +226,9 @@ extension PeekabooServices {
         } else if sources.hasMiniMax {
             model = "minimax/MiniMax-M2.7"
             resolvedModel = nil
+        } else if sources.hasKimi {
+            model = "kimi/kimi-k2.6"
+            resolvedModel = nil
         } else if sources.hasOpenRouter {
             model = "openrouter/openai/gpt-oss-120b"
             resolvedModel = nil
@@ -299,6 +304,9 @@ extension PeekabooServices {
                      "minimax_cn" where sources.hasMiniMaxChina,
                      "minimaxi" where sources.hasMiniMaxChina:
                     return "minimax-cn/\(model)"
+                case "kimi" where sources.hasKimi,
+                     "moonshot" where sources.hasKimi:
+                    return "kimi/\(model)"
                 case "openrouter" where sources.hasOpenRouter:
                     return "openrouter/\(model)"
                 case "ollama" where sources.hasOllama:
@@ -397,6 +405,8 @@ extension PeekabooServices {
             return sources.hasMiniMax
         case .minimaxCN:
             return sources.hasMiniMaxChina
+        case .kimi:
+            return sources.hasKimi
         case .openRouter:
             return sources.hasOpenRouter
         case .grok:
@@ -450,6 +460,7 @@ private struct ModelSources {
     let hasMiniMax: Bool
     let hasMiniMaxChina: Bool
     let hasMiniMaxChinaSpecific: Bool
+    let hasKimi: Bool
     let hasOpenRouter: Bool
     let hasGrok: Bool
     let hasOllama: Bool

--- a/Core/PeekabooCore/Tests/PeekabooTests/AIProviderParserTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/AIProviderParserTests.swift
@@ -22,6 +22,9 @@ struct AIProviderParserTests {
         #expect(AIProviderParser.parse("minimax-cn/MiniMax-M2.7") == AIProviderParser.ProviderConfig(
             provider: "minimax-cn",
             model: "MiniMax-M2.7"))
+        #expect(AIProviderParser.parse("kimi/k2p7") == AIProviderParser.ProviderConfig(
+            provider: "kimi",
+            model: "k2p7"))
     }
 
     @Test

--- a/Core/PeekabooCore/Tests/PeekabooTests/AIProviderParserTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/AIProviderParserTests.swift
@@ -22,9 +22,9 @@ struct AIProviderParserTests {
         #expect(AIProviderParser.parse("minimax-cn/MiniMax-M2.7") == AIProviderParser.ProviderConfig(
             provider: "minimax-cn",
             model: "MiniMax-M2.7"))
-        #expect(AIProviderParser.parse("kimi/k2p7") == AIProviderParser.ProviderConfig(
+        #expect(AIProviderParser.parse("kimi/kimi-k2.7-code") == AIProviderParser.ProviderConfig(
             provider: "kimi",
-            model: "k2p7"))
+            model: "kimi-k2.7-code"))
     }
 
     @Test

--- a/Core/PeekabooCore/Tests/PeekabooTests/ConfigurationEnvironmentTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/ConfigurationEnvironmentTests.swift
@@ -88,6 +88,33 @@ struct ConfigurationManagerEnvironmentTests {
     }
 
     @Test
+    func `getKimiAPIKey prefers either environment alias over stored credentials`() throws {
+        let keys = ["MOONSHOT_API_KEY", "KIMI_API_KEY"]
+        let previous = keys.reduce(into: [String: String]()) { values, key in
+            if let value = getenv(key) {
+                values[key] = String(cString: value)
+            }
+        }
+        keys.forEach { unsetenv($0) }
+        defer {
+            for key in keys {
+                if let value = previous[key] {
+                    setenv(key, value, 1)
+                } else {
+                    unsetenv(key)
+                }
+            }
+        }
+
+        try withIsolatedConfigurationEnvironment { _ in
+            try self.manager.saveCredentials(["MOONSHOT_API_KEY": "stored-primary-key"])
+            setenv("KIMI_API_KEY", "environment-alias-key", 1)
+
+            #expect(self.manager.getKimiAPIKey() == "environment-alias-key")
+        }
+    }
+
+    @Test
     func `getSelectedProvider canonicalizes Google aliases from config`() throws {
         try withIsolatedConfigurationEnvironment { configDir in
             let configPath = configDir.appendingPathComponent("config.json")

--- a/Core/PeekabooCore/Tests/PeekabooTests/PeekabooAIServiceProviderTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/PeekabooAIServiceProviderTests.swift
@@ -596,6 +596,17 @@ struct PeekabooAIServiceProviderTests {
 
     @Test
     @MainActor
+    func `Falls back to Kimi when only Kimi key is present`() throws {
+        try self.withIsolatedEnvironment(["MOONSHOT_API_KEY": "key"]) {
+            let service = PeekabooAIService()
+            #expect(service.resolvedDefaultModel == .kimi(.k26))
+            #expect(service.resolvedDefaultVisionModel == .kimi(.k26))
+            #expect(service.availableModels() == [.kimi(.k26)])
+        }
+    }
+
+    @Test
+    @MainActor
     func `Explicit MiniMax China provider can reuse shared MiniMax key`() throws {
         try self.withIsolatedEnvironment(
             ["MINIMAX_API_KEY": "key"],

--- a/Core/PeekabooCore/Tests/PeekabooTests/PeekabooAgentServiceModelTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/PeekabooAgentServiceModelTests.swift
@@ -1052,6 +1052,17 @@ extension PeekabooAgentServiceTests {
 
     @Test
     @MainActor
+    func `Kimi only credentials initialize Kimi default agent`() throws {
+        try self.withIsolatedAgentEnvironment(["MOONSHOT_API_KEY": "test-kimi-key"]) {
+            let services = self.makeServices()
+            let agentService = try #require(services.agent as? PeekabooAgentService)
+
+            #expect(agentService.defaultModel == LanguageModel.kimi(.k26).description)
+        }
+    }
+
+    @Test
+    @MainActor
     func `xAI only credentials initialize Grok default agent`() throws {
         try self.withIsolatedAgentEnvironment(["X_AI_API_KEY": "test-xai-key"]) {
             let services = self.makeServices()

--- a/Core/PeekabooCore/Tests/PeekabooTests/PeekabooAgentServiceModelTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/PeekabooAgentServiceModelTests.swift
@@ -1030,6 +1030,41 @@ extension PeekabooAgentServiceTests {
 
     @Test
     @MainActor
+    func `Nonstreaming Kimi reasoning is replayed before tool continuation`() async throws {
+        let provider = KimiReasoningReplayProvider()
+        let configuration = TachikomaConfiguration(loadFromEnvironment: false)
+        configuration.setProviderFactoryOverride { _, _ in provider }
+
+        let previousConfiguration = TachikomaConfiguration.default
+        TachikomaConfiguration.default = configuration
+        defer {
+            TachikomaConfiguration.default = previousConfiguration
+        }
+
+        let agentService = try PeekabooAgentService(
+            services: PeekabooServices(),
+            defaultModel: .kimi(.k26))
+
+        _ = try await agentService.executeTask(
+            "Use a tool, then continue.",
+            maxSteps: 2,
+            model: .kimi(.k26),
+            enhancementOptions: nil)
+
+        let secondRequestMessages = try #require(provider.secondRequestMessages)
+        let reasoningMessage = try #require(secondRequestMessages.first { message in
+            message.channel == .thinking
+        })
+
+        #expect(reasoningMessage.content == [.text("native Kimi thought")])
+        #expect(reasoningMessage.metadata?.customData?["kimi.reasoning_content"] == "native Kimi thought")
+        #expect(reasoningMessage.metadata?.customData?["tachikoma.reasoning.provider"] == "kimi")
+        #expect(reasoningMessage.metadata?.customData?["tachikoma.reasoning.model"] == "kimi-k2.6")
+        #expect(reasoningMessage.metadata?.customData?["tachikoma.reasoning.base_url"] != nil)
+    }
+
+    @Test
+    @MainActor
     func `Gemini only credentials initialize Gemini default agent`() throws {
         try self.withIsolatedAgentEnvironment(["GEMINI_API_KEY": "test-gemini-key"]) {
             let services = self.makeServices()
@@ -2638,6 +2673,61 @@ private final class OpenRouterReasoningReplayProvider: ModelProvider, @unchecked
                         text: "raw openrouter thinking",
                         type: "openrouter_reasoning",
                         rawJSON: #"{"type":"reasoning"}"#),
+                ])
+        }
+
+        return ProviderResponse(text: "done", finishReason: .stop)
+    }
+
+    func streamText(request: ProviderRequest) async throws -> AsyncThrowingStream<TextStreamDelta, any Error> {
+        let response = try await self.generateText(request: request)
+        return AsyncThrowingStream { continuation in
+            if !response.text.isEmpty {
+                continuation.yield(.text(response.text))
+            }
+            continuation.yield(.done(finishReason: response.finishReason))
+            continuation.finish()
+        }
+    }
+}
+
+private final class KimiReasoningReplayProvider: ModelProvider, @unchecked Sendable {
+    let modelId = "kimi-reasoning-replay-provider"
+    let baseURL: String? = nil
+    let apiKey: String? = nil
+    let capabilities = ModelCapabilities()
+
+    private let lock = NSLock()
+    private var requestCount = 0
+    private var capturedSecondRequestMessages: [ModelMessage]?
+
+    var secondRequestMessages: [ModelMessage]? {
+        self.lock.withLock { self.capturedSecondRequestMessages }
+    }
+
+    func generateText(request: ProviderRequest) async throws -> ProviderResponse {
+        let requestNumber = self.lock.withLock {
+            self.requestCount += 1
+            if self.requestCount == 2 {
+                self.capturedSecondRequestMessages = request.messages
+            }
+            return self.requestCount
+        }
+
+        if requestNumber == 1 {
+            return ProviderResponse(
+                text: "",
+                finishReason: .toolCalls,
+                toolCalls: [
+                    AgentToolCall(
+                        id: "missing-tool",
+                        name: "missing_test_tool",
+                        arguments: [:]),
+                ],
+                reasoning: [
+                    ProviderReasoningBlock(
+                        text: "native Kimi thought",
+                        type: "kimi_reasoning_content"),
                 ])
         }
 


### PR DESCRIPTION
## Summary

Adds **Kimi (Moonshot AI)** support so Peekaboo can use Kimi K2.6/K2.7 (via the `kimi/` provider prefix) for screenshot analysis and agent flows. Targets the Moonshot coding endpoint `https://api.kimi.com/coding/v1` with `MOONSHOT_API_KEY`.

## Changes
- `Apps/CLI/.../AgentCommand+ModelParsing.swift`: `supportedKimiInputs`, `kimi`/`moonshot` hosted parsing, credential/displayName/env-var switches, allowed-model list.
- `Core/PeekabooCore/.../PeekabooAIService.swift`: hosted-provider id, `hasCredentialsOrLocalRuntime`, `providerAndModelName`, `resolveAvailableModels` fallback.
- `Core/PeekabooCore/.../ConfigurationManager+Accessors.swift`: `getKimiAPIKey()` (MOONSHOT_API_KEY/KIMI_API_KEY) + `applyAIProviderKeys` push.
- `Core/PeekabooCore/.../PeekabooAgentService*.swift`: defaultModelSelection, apiKey, maxOutputTokens.
- Tests: Kimi parse cases in `AgentCommandModelParsingTests` and `AIProviderParserTests`.
- Tachikoma submodule bump for the Kimi provider (depends on **openclaw/Tachikoma#27**).

## Dependency note
Bumps `Tachikoma` to `Tugser/Tachikoma@ebcad41` so the Peekaboo side compiles and tests pass. **Re-point to `openclaw/Tachikoma` `main` once openclaw/Tachikoma#27 merges.**

## Test commands executed
```
swift build --package-path Apps/CLI
swift test --package-path Apps/CLI --filter "AgentCommandModelParsingTests"
swift test --package-path Core/PeekabooCore --filter "AIProviderParserTests"
# Tachikoma (submodule):
swift test --filter "ModelParsingTests|LanguageModelCoverageTests"
```
All pass. End-to-end `peekaboo see --analyze` with `kimi/k2p7` reaches `api.kimi.com/coding/v1` and authenticates (request well-formed, image serialized); final live response depends on the user's Kimi coding-plan membership being active.

## Usage
```
export MOONSHOT_API_KEY=...
PEEKABOO_AI_PROVIDERS=kimi/k2p7 peekaboo see --mode frontmost --analyze "..."
```
