### PR TITLE
docs: refresh Peekaboo agent skill guidance

### DIFF
--- a/Apps/CLI/Sources/PeekabooCLI/Commands/AI/SeeCommand.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/AI/SeeCommand.swift
@@ -376,8 +376,8 @@ extension SeeCommand: ParsableCommand {
                         description: "Capture the frontmost window, print structured output, and save annotations."
                     ),
                     CommandUsageExample(
-                        command: "peekaboo see --app Safari --window-title \"Login\" --json",
-                        description: "Target a specific Safari window to collect stable element IDs."
+                        command: "peekaboo see --app Safari --window-title \"Login\" --json --path /tmp/safari-login.png",
+                        description: "Target a specific Safari window to collect fresh element IDs and keep the capture artifact in /tmp."
                     ),
                     CommandUsageExample(
                         command: "peekaboo see --mode screen --screen-index 0 --analyze 'Summarize the dashboard'",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [3.5.3] - 2026-06-13
 
 ### Fixed
+- Peekaboo agent skill install and usage guidance now uses the current `skills/peekaboo` path, treats observed element IDs as opaque, and keeps screenshot artifacts in explicit temporary paths. Thanks @coygeek for #197.
 - `peekaboo app list` now excludes accessory/background processes by default, while `--include-background` restores them as documented.
 - Menu-extra clicks now reject items parked outside active displays by menu bar managers instead of moving the pointer to offscreen coordinates and reporting false success.
 - Background element/query/coordinate clicks now pin actions to the requested process and exact window, reject mismatched window/PID selectors and unverifiable snapshots, invalidate implicit latest snapshots without deleting history, and no longer require Event Synthesizing when Accessibility completes the click.

--- a/docs/agent-skill.md
+++ b/docs/agent-skill.md
@@ -2,12 +2,12 @@
 summary: 'Install and maintain the thin Peekaboo CLI agent skill.'
 read_when:
   - 'setting up Peekaboo with AI agents'
-  - 'updating the peekaboo-cli skill'
+  - 'updating the peekaboo skill'
 ---
 
 # Agent Skill for Peekaboo
 
-The `peekaboo-cli` skill teaches agents when and how to call the installed Peekaboo CLI for macOS automation. It intentionally stays thin: agents should use live CLI help and canonical docs instead of a copied command reference that can drift.
+The `peekaboo` skill teaches agents when and how to use Peekaboo for macOS automation, screenshots, native accessibility inspection, browser chrome, and repo validation. It intentionally stays thin: agents should use live CLI help, `peekaboo learn`, `peekaboo tools`, and canonical docs instead of a copied command reference that can drift.
 
 ## Install
 
@@ -16,11 +16,11 @@ Copy the skill directory into your agent's skills folder:
 ```bash
 # Claude Code
 mkdir -p ~/.claude/skills
-cp -r skills/peekaboo-cli ~/.claude/skills/
+cp -r skills/peekaboo ~/.claude/skills/
 
 # OpenClaw
 mkdir -p ~/.openclaw/skills
-cp -r skills/peekaboo-cli ~/.openclaw/skills/
+cp -r skills/peekaboo ~/.openclaw/skills/
 ```
 
 Restart the agent after installing or updating the skill.
@@ -39,7 +39,7 @@ Agents should also use `peekaboo learn`, `peekaboo tools`, and `peekaboo <comman
 
 ## Canonical Docs
 
-- Skill file: `skills/peekaboo-cli/SKILL.md`
+- Skill file: `skills/peekaboo/SKILL.md`
 - Command index: `docs/commands/README.md`
 - Command pages: `docs/commands/*.md`
 - Permissions: `docs/permissions.md`
@@ -47,4 +47,4 @@ Agents should also use `peekaboo learn`, `peekaboo tools`, and `peekaboo <comman
 
 ## Maintenance Rule
 
-Do not add generated per-command reference files to the skill. Update Commander metadata, `peekaboo learn`, or `docs/commands/*` instead.
+Keep the skill compact and progressive. Its frontmatter should contain only `name` and `description`, and its body should explain observation strategy and validation flow without vendoring generated command catalogs. Update Commander metadata, `peekaboo learn`, or `docs/commands/*` when command behavior changes.

--- a/docs/agent-skill.md
+++ b/docs/agent-skill.md
@@ -7,7 +7,7 @@ read_when:
 
 # Agent Skill for Peekaboo
 
-The `peekaboo` skill teaches agents when and how to use Peekaboo for macOS automation, screenshots, native accessibility inspection, browser chrome, and repo validation. It intentionally stays thin: agents should use live CLI help, `peekaboo learn`, `peekaboo tools`, and canonical docs instead of a copied command reference that can drift.
+The `peekaboo` skill teaches agents when and how to use Peekaboo for macOS automation, screenshots, native accessibility inspection, native app and browser chrome, browser-page tooling, and repo validation. It intentionally stays thin: agents should use live CLI help, `peekaboo learn`, `peekaboo tools`, and canonical docs instead of a copied command reference that can drift.
 
 ## Install
 

--- a/docs/automation.md
+++ b/docs/automation.md
@@ -15,7 +15,7 @@ Peekaboo's automation surface is small but covers the whole macOS UI graph. Each
 
 Every input command accepts one of three target shapes:
 
-- **Element ID** — `--id E12` (from `peekaboo see`); the most reliable.
+- **Element ID** — `--on B1` or `--id T2` (from `peekaboo see` or `peekaboo inspect-ui`); the most reliable.
 - **Label / role / app** — positional query text such as `peekaboo click "Send" --app Mail`; resolved via the AX tree.
 - **Coordinates** — `--coords 480,120`; target-relative when paired with `--app`, `--pid`, or `--window-*`, global otherwise. Add `--global-coords` to force screen coordinates with a target.
 

--- a/docs/automation.md
+++ b/docs/automation.md
@@ -15,7 +15,7 @@ Peekaboo's automation surface is small but covers the whole macOS UI graph. Each
 
 Every input command accepts one of three target shapes:
 
-- **Element ID** — `--on B1` or `--id T2` (from `peekaboo see` or `peekaboo inspect-ui`); the most reliable.
+- **Element ID** — `--on <id>` or `--id <id>` from a fresh `peekaboo see` or `peekaboo inspect-ui` capture; preferred when available. Treat IDs as opaque strings and copy the exact value returned by the capture.
 - **Label / role / app** — positional query text such as `peekaboo click "Send" --app Mail`; resolved via the AX tree.
 - **Coordinates** — `--coords 480,120`; target-relative when paired with `--app`, `--pid`, or `--window-*`, global otherwise. Add `--global-coords` to force screen coordinates with a target.
 
@@ -28,7 +28,7 @@ Peekaboo has two input delivery modes:
 - **Background** (default when a target process is known) posts process-targeted input without activating the app. `click`, `type`, `press`, `hotkey`, and `paste` use this mode when you pass `--app`, `--pid`, `--window-id`, or a snapshot with process metadata.
 - **Foreground** focuses the target first, then sends normal/global input to the active key window or mouse focus. Add `--foreground` when an app ignores background input, when a text field only accepts key-window input, or when you want focus/Space switching to be part of the action.
 
-Focus flags such as `--space-switch`, `--bring-to-current-space`, and `--no-auto-focus` belong to foreground delivery; using them implies `--foreground`. Background element/query clicks can complete through Accessibility alone. Keyboard input, coordinate clicks, and synthetic click fallback require Event Synthesizing for the sender shown by `peekaboo permissions status`; request it with `peekaboo permissions request-event-synthesizing`.
+Focus flags such as `--space-switch` and `--bring-to-current-space` imply foreground delivery. `--no-auto-focus` is different: it disables Peekaboo's focus attempt, so use it only when the target state is already correct and you want to avoid changing focus. Background element/query clicks can complete through Accessibility alone. Keyboard input, coordinate clicks, and synthetic click fallback require Event Synthesizing for the sender shown by `peekaboo permissions status`; request it with `peekaboo permissions request-event-synthesizing`.
 
 Examples:
 
@@ -79,7 +79,7 @@ For UX parity with humans (jitter, easing, dwell), see [human-typing.md](human-t
 
 ```bash
 # 1. Inspect first to find a stable label.
-peekaboo see --app Safari --annotate --path safari.png
+peekaboo see --app Safari --annotate --path /tmp/safari.png
 
 # 2. Click it.
 peekaboo click "Reload" --app Safari

--- a/docs/commands/see.md
+++ b/docs/commands/see.md
@@ -7,19 +7,19 @@ read_when:
 
 # `peekaboo see`
 
-`peekaboo see` captures the current macOS UI, extracts accessibility metadata, and (optionally) saves annotated screenshots. CLI and agent flows rely on these UI maps to find element IDs such as `B1` and `T2`, bounds, labels, and snapshot IDs.
+`peekaboo see` captures the current macOS UI, extracts accessibility metadata, and (optionally) saves annotated screenshots. CLI and agent flows rely on these UI maps to find fresh element IDs, bounds, labels, and snapshot IDs.
 
 ```bash
 # Capture frontmost window, print JSON, and save an annotated PNG
 peekaboo see --json --annotate --path /tmp/see.png
 
 # Target a specific app or window title
-peekaboo see --app "Google Chrome" --window-title "Login"
+peekaboo see --app "Google Chrome" --window-title "Login" --json --path /tmp/chrome-login.png
 ```
 
 ## When to use
 
-- Before issuing `click`/`type` commands so you have stable element IDs.
+- Before issuing `click`/`type` commands so you have fresh element IDs.
 - When debugging automation failures—`--json` includes raw bounds, labels, and snapshot IDs.
 - To snapshot UI regressions (pass `--annotate` + `--path`).
 
@@ -40,6 +40,8 @@ peekaboo see --app "Google Chrome" --window-title "Login"
 | `--max-children <n>` | Override maximum AX children visited per node (`PEEKABOO_AX_MAX_CHILDREN` fallback, default 250). |
 
 Note: `--app menubar` captures only the menu bar strip; `--menubar` attempts to find the active popover and OCR its text.
+
+For agent and automation runs, pass `--path` to a known temporary file when using `see` so capture artifacts land where expected. Use `peekaboo inspect-ui --json` when you need AX metadata and no screenshot artifact.
 
 ## Automatic web focus fallback (Nov 2025)
 
@@ -65,11 +67,11 @@ When `--json` is supplied, the CLI prints:
 Use `jq` or any JSON parser to find elements:
 
 ```bash
-peekaboo see --app "Safari" --json \
+peekaboo see --app "Safari" --json --path /tmp/safari-see.png \
   | jq '.data.ui_elements[] | select(.label | test("Sign in"; "i"))'
 
 # Toolbar buttons that only expose AXDescription:
-peekaboo see --app "Google Chrome" --json \
+peekaboo see --app "Google Chrome" --json --path /tmp/chrome-see.png \
   | jq '.data.ui_elements[] | select((.description // "") | test("Wingman"; "i"))'
 ```
 

--- a/docs/commands/see.md
+++ b/docs/commands/see.md
@@ -7,7 +7,7 @@ read_when:
 
 # `peekaboo see`
 
-`peekaboo see` captures the current macOS UI, extracts accessibility metadata, and (optionally) saves annotated screenshots. CLI and agent flows rely on these UI maps to find element IDs (`elem_123`), bounds, labels, and snapshot IDs.
+`peekaboo see` captures the current macOS UI, extracts accessibility metadata, and (optionally) saves annotated screenshots. CLI and agent flows rely on these UI maps to find element IDs such as `B1` and `T2`, bounds, labels, and snapshot IDs.
 
 ```bash
 # Capture frontmost window, print JSON, and save an annotated PNG

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -45,16 +45,16 @@ the daemon on demand. `peekaboo bridge status --verbose` shows the selected runt
 
 ## 3. Inspect the UI
 
-`see` returns a structured map of clickable elements with stable IDs:
+`see` returns a structured map of clickable elements with fresh IDs:
 
 ```bash
-peekaboo see --app Safari --json | jq '.elements[0:3]'
+peekaboo see --app Safari --json --path /tmp/safari-see.png | jq '.data.ui_elements[0:3]'
 ```
 
 Add `--annotate` to write a labelled PNG you can eyeball:
 
 ```bash
-peekaboo see --app Safari --annotate --path safari.png
+peekaboo see --app Safari --annotate --path /tmp/safari.png
 ```
 
 Each element has `id`, `role`, `label`, `frame`, and `actions`. Pass an `id` to other commands to act on it.

--- a/skills/peekaboo/SKILL.md
+++ b/skills/peekaboo/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: peekaboo
-description: "Use Peekaboo for macOS desktop automation, screenshots, visual UI maps, native accessibility inspection, app/window/menu/dialog control, browser chrome automation, MCP diagnostics, and Peekaboo repo validation. Use when Codex needs current macOS UI state, direct desktop control, safe live smoke tests, or changes to the Peekaboo repository."
+description: "Use Peekaboo for macOS desktop automation, screenshots, visual UI maps, native accessibility inspection, app/window/menu/dialog control, native app and browser chrome control, browser-page MCP tooling, MCP diagnostics, and Peekaboo repo validation. Use when Codex needs current macOS UI state, direct desktop control, privacy-aware live smoke tests, or changes to the Peekaboo repository."
 ---
 
 # Peekaboo
@@ -41,41 +41,43 @@ Peekaboo is a macOS automation CLI and agent runtime. Prefer the freshly built r
 
 ## Observation Strategy
 
-- Use `peekaboo inspect-ui` (CLI) or `inspect_ui` (MCP) for native macOS AX text, labels, buttons, text fields, control state, and element IDs when a screenshot is not needed.
+- Use `peekaboo inspect-ui` (CLI) or `inspect_ui` (MCP) for native macOS AX text, labels, buttons, text fields, control state, and element IDs when a screenshot would add noise.
 - Use `peekaboo see` for screenshots, visual layout, annotated maps, pixels, colors, screen/menu-bar targets, or cases where AX text is missing or incomplete.
 - Use `browser` for browser page content, forms, DOM/a11y snapshots, console, network, page screenshots, and performance traces when browser tooling is available.
-- Use native Peekaboo tools for macOS chrome, browser chrome, menus, dialogs, permissions, windows, and non-browser apps.
+- Use native Peekaboo tools for app chrome, browser toolbars, menus, dialogs, permissions, windows, and non-browser apps.
 - Treat element IDs from `see` or `inspect_ui` as valid only for the current visible state. After a mutating action, verify from the action result or fetch fresh state.
 
 ## Operating Rules
 
-- Use `peekaboo see --json` or `peekaboo inspect-ui --json` before element interactions so you have fresh element IDs and snapshot IDs.
-- Prefer element IDs from the current snapshot, such as `B1` or `T2`, for clicks and typing. Use labels when IDs are unavailable and coordinates only as a last resort.
+- Use `peekaboo see --json --path /tmp/<name>.png` or `peekaboo inspect-ui --json` before element interactions so you have fresh element IDs and snapshot IDs.
+- Prefer the exact element ID string from the current snapshot for clicks and typing; treat ID shapes as opaque. Use labels when IDs are unavailable and coordinates only as a last resort.
 - Check `peekaboo permissions status --json` before assuming a capture or control failure is a CLI bug.
 - Use `--json` when another tool or agent needs to parse results.
 - Respect the user's desktop: avoid destructive app/window actions unless requested.
 - If a command fails because the target UI changed, recapture with `see` or `inspect-ui` before retrying.
 - `see --json` element bounds are screen coordinates. Snapshot IDs keep element actions tied to the observed UI.
+- When using `see` in agent smoke tests, pass an explicit `/tmp` `--path` so capture artifacts do not land in a user-visible default location.
 - Prefer `--foreground` only when an app requires a key window, Space switch, or foreground mouse event. Background delivery is the default when Peekaboo can resolve a target process.
 
 ## Common Workflows
 
 ```bash
-# AX-only state when no screenshot is needed.
+# AX-only state when a screenshot would add noise.
 peekaboo inspect-ui --app-target Calculator --json > /tmp/peekaboo-calc-ax.json
 
 # Visual layout plus element IDs and snapshot ID.
-peekaboo see --app Calculator --json > /tmp/calc.json
+peekaboo see --app Calculator --path /tmp/calc.png --json > /tmp/calc.json
 ruby -rjson -e 'j=JSON.parse(File.read("/tmp/calc.json")); puts j.dig("data","snapshot_id"); puts JSON.pretty_generate((j.dig("data","ui_elements")||[]).map{|e| e.slice("id","label","identifier","bounds")})'
 
 # Click an element discovered in the current snapshot.
 SNAP=$(ruby -rjson -e 'j=JSON.parse(File.read("/tmp/calc.json")); puts j.dig("data","snapshot_id")')
-peekaboo click --on B1 --snapshot "$SNAP" --json
+ELEMENT_ID="<element-id-from-current-snapshot>"
+peekaboo click --on "$ELEMENT_ID" --snapshot "$SNAP" --json
 
 # Browser page content and DOM-oriented actions belong to browser tooling.
 peekaboo browser status --json
 
-# Native browser chrome still belongs to Peekaboo.
+# Browser toolbar, menus, permission prompts, and native app chrome still belong to Peekaboo.
 peekaboo menu list --app Safari --json
 ```
 
@@ -93,15 +95,16 @@ Useful overrides:
 peekaboo click --help | rg 'input-strategy|actionOnly|synthOnly'
 
 # UIAX/action click path from a saved snapshot.
-peekaboo see --app Calculator --json > /tmp/calc.json
+peekaboo see --app Calculator --path /tmp/calc.png --json > /tmp/calc.json
 SNAP=$(ruby -rjson -e 'j=JSON.parse(File.read("/tmp/calc.json")); puts j.dig("data","snapshot_id")')
-peekaboo click --on B1 --snapshot "$SNAP" --input-strategy actionOnly --json --focus-background
+ELEMENT_ID="<element-id-from-current-snapshot>"
+peekaboo click --on "$ELEMENT_ID" --snapshot "$SNAP" --input-strategy actionOnly --json --focus-background
 
 # Direct accessibility action; good for proving UIAX independent of pointer events.
-peekaboo perform-action --on B1 --action AXPress --snapshot "$SNAP" --json
+peekaboo perform-action --on "$ELEMENT_ID" --action AXPress --snapshot "$SNAP" --json
 
 # Synthetic click path; allow focus if you need visible app state to mutate.
-peekaboo click --on B2 --snapshot "$SNAP" --input-strategy synthOnly --json --foreground
+peekaboo click --on "$ELEMENT_ID" --snapshot "$SNAP" --input-strategy synthOnly --json --foreground
 
 # Negative control: coordinates cannot use actionOnly.
 peekaboo click --coords 10,10 --input-strategy actionOnly --json
@@ -123,18 +126,19 @@ BIN="$(swift build --package-path Apps/CLI --show-bin-path)/peekaboo"
 "$BIN" permissions status --json > /tmp/peekaboo-skill-refresh-permissions.json
 "$BIN" tools --json > /tmp/peekaboo-skill-refresh-tools.json
 "$BIN" inspect-ui --app-target Calculator --json > /tmp/peekaboo-skill-refresh-calc-ax.json
-"$BIN" see --app Calculator --json --timeout-seconds 10 > /tmp/calc.json
+"$BIN" see --app Calculator --path /tmp/peekaboo-skill-refresh-calc.png --json --timeout-seconds 10 > /tmp/calc.json
 ruby -rjson -e 'j=JSON.parse(File.read("/tmp/calc.json")); puts JSON.pretty_generate((j.dig("data","ui_elements")||[]).select{|e| ["Clear","AllClear","One","Two","Add","Equals","StandardInputView"].include?(e["identifier"].to_s)}.map{|e| e.slice("id","label","identifier","description","help","bounds")})'
 
 SNAP=$(ruby -rjson -e 'j=JSON.parse(File.read("/tmp/calc.json")); puts j.dig("data","snapshot_id")')
-"$BIN" perform-action --on B1 --action AXPress --snapshot "$SNAP" --json
-"$BIN" click --on B2 --snapshot "$SNAP" --input-strategy actionOnly --json --focus-background
+BUTTON_ID="<button-id-from-current-snapshot>"
+"$BIN" perform-action --on "$BUTTON_ID" --action AXPress --snapshot "$SNAP" --json
+"$BIN" click --on "$BUTTON_ID" --snapshot "$SNAP" --input-strategy actionOnly --json --focus-background
 ```
 
 Expected current behavior:
 
 - `see --json` includes `bounds` for each `ui_elements` entry.
-- `inspect-ui --json` and `see --json` should expose IDs such as `B1`/`T2` plus Calculator identifiers such as `One`, `Two`, and `StandardInputView`.
+- `inspect-ui --json` and `see --json` should expose element IDs plus Calculator identifiers such as `One`, `Two`, and `StandardInputView`. Copy the returned ID exactly instead of assuming a prefix or shape.
 - `tools --json` should include `browser`, `click`, `inspect_ui`, and `see`.
 - Snapshot-backed UIAX must use the captured app/window, not the frontmost app.
 

--- a/skills/peekaboo/SKILL.md
+++ b/skills/peekaboo/SKILL.md
@@ -1,35 +1,31 @@
 ---
 name: peekaboo
-description: "Use Peekaboo's live CLI and repo workflows for macOS desktop automation: screenshots, UI maps, app/window control, UIAX/action vs synthetic/CAEvent input paths, typing, menus, clipboard, permissions, MCP diagnostics, Inspector parity, and local validation. Use when a task needs current macOS UI state, direct desktop control, or changes to the Peekaboo repo."
-allowed-tools: Bash(peekaboo:*), Bash(pkb:*), Bash(pnpm:*), Bash(swift:*), Bash(swiftformat:*), Bash(swiftlint:*), Bash(node scripts/docs-list.mjs:*), Bash(ruby:*), Bash(rg:*)
+description: "Use Peekaboo for macOS desktop automation, screenshots, visual UI maps, native accessibility inspection, app/window/menu/dialog control, browser chrome automation, MCP diagnostics, and Peekaboo repo validation. Use when Codex needs current macOS UI state, direct desktop control, safe live smoke tests, or changes to the Peekaboo repository."
 ---
 
 # Peekaboo
 
-Peekaboo is a macOS automation CLI and agent runtime. Prefer the freshly built repo binary and canonical docs over copied command references; command surfaces move fast.
+Peekaboo is a macOS automation CLI and agent runtime. Prefer the freshly built repo binary, live help, and canonical docs over copied command references because command surfaces move quickly.
 
 ## Start Here
 
-1. In repo work, build/use the local binary:
+1. In repo work, build and use the current-source binary:
    ```bash
    pnpm run build:cli
-   BIN="$PWD/Apps/CLI/.build/arm64-apple-macosx/debug/peekaboo"
+   BIN="$(swift build --package-path Apps/CLI --show-bin-path)/peekaboo"
    "$BIN" --version
    ```
-2. Confirm permissions before automation:
+2. Record the installed PATH binary separately when diagnosing environment drift:
    ```bash
-   peekaboo permissions status
-   peekaboo list apps --json
+   command -v peekaboo && peekaboo --version
    ```
-3. For the latest agent-oriented guide:
+3. Confirm permissions and current tool surfaces before automation:
    ```bash
-   peekaboo learn
+   "$BIN" permissions status --json
+   "$BIN" tools --json
+   "$BIN" learn
    ```
-4. For the current tool catalog:
-   ```bash
-   peekaboo tools
-   ```
-5. Find command docs:
+4. Find command docs:
    ```bash
    node scripts/docs-list.mjs
    ```
@@ -43,39 +39,44 @@ Peekaboo is a macOS automation CLI and agent runtime. Prefer the freshly built r
 - Permissions and bridge behavior: `docs/permissions.md`, `docs/bridge-host.md`, `docs/integrations/subprocess.md`
 - Repo rules: `AGENTS.md`
 
+## Observation Strategy
+
+- Use `peekaboo inspect-ui` (CLI) or `inspect_ui` (MCP) for native macOS AX text, labels, buttons, text fields, control state, and element IDs when a screenshot is not needed.
+- Use `peekaboo see` for screenshots, visual layout, annotated maps, pixels, colors, screen/menu-bar targets, or cases where AX text is missing or incomplete.
+- Use `browser` for browser page content, forms, DOM/a11y snapshots, console, network, page screenshots, and performance traces when browser tooling is available.
+- Use native Peekaboo tools for macOS chrome, browser chrome, menus, dialogs, permissions, windows, and non-browser apps.
+- Treat element IDs from `see` or `inspect_ui` as valid only for the current visible state. After a mutating action, verify from the action result or fetch fresh state.
+
 ## Operating Rules
 
-- Use `peekaboo see --json` before element interactions so you have fresh element IDs and snapshot IDs.
-- Prefer element IDs from `see` for clicks and typing; use coordinates only when accessibility metadata is unavailable.
-- Check `peekaboo permissions status` before assuming a capture or control failure is a CLI bug.
+- Use `peekaboo see --json` or `peekaboo inspect-ui --json` before element interactions so you have fresh element IDs and snapshot IDs.
+- Prefer element IDs from the current snapshot, such as `B1` or `T2`, for clicks and typing. Use labels when IDs are unavailable and coordinates only as a last resort.
+- Check `peekaboo permissions status --json` before assuming a capture or control failure is a CLI bug.
 - Use `--json` when another tool or agent needs to parse results.
 - Respect the user's desktop: avoid destructive app/window actions unless requested.
-- If a command fails because the target UI changed, recapture with `peekaboo see --json` before retrying.
-- For repo fixes, add regression coverage when practical and update `CHANGELOG.md` for user-visible behavior.
-- `see --json` element bounds are screen coordinates; snapshot IDs are needed for stable element actions.
-- `--no-auto-focus` can prove background behavior, but synthetic clicks may be ignored by some apps until focus is allowed.
-- If a saved-snapshot UIAX/action click resolves in the wrong app, inspect snapshot `windowContext` preservation.
+- If a command fails because the target UI changed, recapture with `see` or `inspect-ui` before retrying.
+- `see --json` element bounds are screen coordinates. Snapshot IDs keep element actions tied to the observed UI.
+- Prefer `--foreground` only when an app requires a key window, Space switch, or foreground mouse event. Background delivery is the default when Peekaboo can resolve a target process.
 
 ## Common Workflows
 
 ```bash
-# Inspect current UI and save JSON.
-peekaboo see --json > /tmp/peekaboo-see.json
+# AX-only state when no screenshot is needed.
+peekaboo inspect-ui --app-target Calculator --json > /tmp/peekaboo-calc-ax.json
 
-# Inspect a target app and extract useful IDs.
+# Visual layout plus element IDs and snapshot ID.
 peekaboo see --app Calculator --json > /tmp/calc.json
 ruby -rjson -e 'j=JSON.parse(File.read("/tmp/calc.json")); puts j.dig("data","snapshot_id"); puts JSON.pretty_generate((j.dig("data","ui_elements")||[]).map{|e| e.slice("id","label","identifier","bounds")})'
 
-# Click an element discovered by see, with snapshot stability.
+# Click an element discovered in the current snapshot.
 SNAP=$(ruby -rjson -e 'j=JSON.parse(File.read("/tmp/calc.json")); puts j.dig("data","snapshot_id")')
-peekaboo click --on elem_42 --snapshot "$SNAP" --json
+peekaboo click --on B1 --snapshot "$SNAP" --json
 
-# Type into the focused field.
-peekaboo type "Hello from Peekaboo"
+# Browser page content and DOM-oriented actions belong to browser tooling.
+peekaboo browser status --json
 
-# Launch/focus an app, then inspect its windows.
-peekaboo app launch "Safari"
-peekaboo list windows --app Safari --json
+# Native browser chrome still belongs to Peekaboo.
+peekaboo menu list --app Safari --json
 ```
 
 ## Input Path Testing
@@ -94,16 +95,16 @@ peekaboo click --help | rg 'input-strategy|actionOnly|synthOnly'
 # UIAX/action click path from a saved snapshot.
 peekaboo see --app Calculator --json > /tmp/calc.json
 SNAP=$(ruby -rjson -e 'j=JSON.parse(File.read("/tmp/calc.json")); puts j.dig("data","snapshot_id")')
-peekaboo click --on elem_8 --snapshot "$SNAP" --input-strategy actionOnly --json --no-auto-focus
+peekaboo click --on B1 --snapshot "$SNAP" --input-strategy actionOnly --json --focus-background
 
 # Direct accessibility action; good for proving UIAX independent of pointer events.
-peekaboo perform-action --on elem_8 --action AXPress --snapshot "$SNAP" --json
+peekaboo perform-action --on B1 --action AXPress --snapshot "$SNAP" --json
 
 # Synthetic click path; allow focus if you need visible app state to mutate.
-peekaboo click --on elem_20 --snapshot "$SNAP" --input-strategy synthOnly --json
+peekaboo click --on B2 --snapshot "$SNAP" --input-strategy synthOnly --json --foreground
 
 # Negative control: coordinates cannot use actionOnly.
-peekaboo click --coords 10,10 --input-strategy actionOnly --json --no-auto-focus
+peekaboo click --coords 10,10 --input-strategy actionOnly --json
 ```
 
 Interpretation:
@@ -118,38 +119,44 @@ Interpretation:
 Calculator is a handy fixture because it exposes descriptions and identifiers.
 
 ```bash
-BIN="$PWD/Apps/CLI/.build/arm64-apple-macosx/debug/peekaboo"
+BIN="$(swift build --package-path Apps/CLI --show-bin-path)/peekaboo"
+"$BIN" permissions status --json > /tmp/peekaboo-skill-refresh-permissions.json
+"$BIN" tools --json > /tmp/peekaboo-skill-refresh-tools.json
+"$BIN" inspect-ui --app-target Calculator --json > /tmp/peekaboo-skill-refresh-calc-ax.json
 "$BIN" see --app Calculator --json --timeout-seconds 10 > /tmp/calc.json
 ruby -rjson -e 'j=JSON.parse(File.read("/tmp/calc.json")); puts JSON.pretty_generate((j.dig("data","ui_elements")||[]).select{|e| ["Clear","AllClear","One","Two","Add","Equals","StandardInputView"].include?(e["identifier"].to_s)}.map{|e| e.slice("id","label","identifier","description","help","bounds")})'
 
 SNAP=$(ruby -rjson -e 'j=JSON.parse(File.read("/tmp/calc.json")); puts j.dig("data","snapshot_id")')
-"$BIN" perform-action --on elem_8 --action AXPress --snapshot "$SNAP" --json
-"$BIN" click --on elem_19 --snapshot "$SNAP" --input-strategy actionOnly --json --no-auto-focus
-"$BIN" click --on elem_20 --snapshot "$SNAP" --input-strategy synthOnly --json
+"$BIN" perform-action --on B1 --action AXPress --snapshot "$SNAP" --json
+"$BIN" click --on B2 --snapshot "$SNAP" --input-strategy actionOnly --json --focus-background
 ```
 
 Expected current behavior:
 
 - `see --json` includes `bounds` for each `ui_elements` entry.
-- Inspector/Computer Use should show Calculator descriptions/IDs such as `One`, `Two`, `StandardInputView`.
+- `inspect-ui --json` and `see --json` should expose IDs such as `B1`/`T2` plus Calculator identifiers such as `One`, `Two`, and `StandardInputView`.
+- `tools --json` should include `browser`, `click`, `inspect_ui`, and `see`.
 - Snapshot-backed UIAX must use the captured app/window, not the frontmost app.
 
 ## Repo Validation
 
 ```bash
-swiftformat <changed-swift-files>
-TOOLCHAIN_DIR=/Library/Developer/CommandLineTools swiftlint lint --config .swiftlint.yml <changed-swift-files>
-swift build --package-path Apps/CLI
-swift build --package-path Core/PeekabooUICore
-swift build --package-path Apps/PeekabooInspector
-swift test --package-path Apps/CLI --filter <TestName>
-swift test --package-path Core/PeekabooAutomationKit --filter <TestName>
+node scripts/docs-lint.mjs
+ruby -e 'h=File.read("skills/peekaboo/SKILL.md").split(/^---\s*$/,3)[1]; keys=h.lines.grep(/^[A-Za-z0-9_-]+:/).map { |line| line.split(":",2).first }; abort("frontmatter keys: #{keys.inspect}") unless keys.sort == ["description","name"]'
+! rg -n 'elem_[0-9]+' skills/peekaboo/SKILL.md
+! rg -n '^allowed-tools:' skills/peekaboo/SKILL.md
+pnpm run build:cli
+BIN="$(swift build --package-path Apps/CLI --show-bin-path)/peekaboo"; "$BIN" --version
+"$BIN" click --help | rg -- '--foreground|--focus-background|--input-strategy|B1, T2'
+"$BIN" see --help | rg -- '--json|--annotate|--app|--no-web-focus'
+"$BIN" inspect-ui --help | rg 'inspect_ui|--app-target|--snapshot|--json'
+git diff --check -- skills/peekaboo/SKILL.md docs/agent-skill.md docs/commands/see.md docs/automation.md scripts/docs-lint.mjs
 ```
 
 Notes:
 
 - If tests fail with `no such module 'Testing'`, record it as local toolchain fallout; still run builds/lint/live smoke tests.
 - SwiftPM may warn about Commander identity conflicts; do not chase unless the task is dependency hygiene.
-- Build via `pnpm run build:cli` for normal CLI work; direct `swift build --package-path ...` is good for focused validation.
+- Keep live validation artifacts under `/tmp/peekaboo-skill-refresh-*` and do not commit or publish screenshots or UI dumps.
 
 Keep this skill compact. Do not vendor generated command references here; update canonical CLI docs or Commander metadata instead.


### PR DESCRIPTION
Closes #195.

## Summary

Refreshes the Peekaboo agent skill and related docs so agent guidance matches the current repository layout and current CLI behavior.

- points install and maintenance docs at `skills/peekaboo`
- keeps the skill compact with only `name` and `description` frontmatter
- treats `see` / `inspect-ui` element IDs as opaque values copied from fresh output
- uses explicit `/tmp/... --path` examples for `see --json` flows
- updates the generated `see --help` example to avoid JSON-only screenshot ambiguity
- fixes the quickstart `jq` path to use `.data.ui_elements`

## Notes

Related runtime issues remain open: #194 and #196. This PR updates guidance so it stays compatible with those current behaviors; runtime behavior changes remain tracked separately.

## Verification

- `node scripts/docs-lint.mjs`
- skill frontmatter check
- stale-language scans for `peekaboo-cli`, `allowed-tools`, hardcoded stale ID examples, and unsafe `see --json` examples
- `pnpm run build:cli`
- rebuilt `see`, `click`, `inspect-ui`, `browser`, and `tools --json` help/catalog checks
- live Calculator `see` smoke with explicit `/tmp` output path
- `git diff --check`
- local autoreview: clean

## Redacted Terminal Proof

### Updated `see --help` Example

```text
$ peekaboo see --help | rg -- "/tmp/safari-login.png|fresh element IDs|--json|--no-web-focus"
  --window-id <window-id>           Capture a specific window by CoreGraphics window id (window_id from `peekaboo window list --json`)
  --no-web-focus  Skip web-content focus fallback when no text fields are detected
  --json, -j      Emit machine-readable JSON output
  $ peekaboo see --json --annotate --path /tmp/see.png  Capture the frontmost window, print structured output, and save annotations.
  $ peekaboo see --app Safari --window-title "Login" --json --path /tmp/safari-login.png  Target a specific Safari window to collect fresh element IDs and keep the capture artifact in /tmp.
  - --json/-j (alias: --json-output) Emit machine-readable JSON output
```

### Docs Lint And Skill Frontmatter

```text
$ node scripts/docs-lint.mjs
docs-lint: ok
$ ruby -e "...frontmatter keys check..."
frontmatter-ok: description,name
```

### Calculator Smoke With Explicit `/tmp` Screenshot Path

```text
$ peekaboo app launch/focus Calculator; peekaboo see --app Calculator --path /tmp/peekaboo-pr197-calc.png --json --timeout-seconds 10 --no-remote
live-see-ok: elements=247 ids=247 role_coded=0 legacy=247 examples=elem_7,elem_8,elem_9,elem_10,elem_11
snapshot_id_present=true explicit_png_exists=true explicit_png_size=49288 explicit_png_path=/tmp/peekaboo-pr197-calc.png
```

Proof output is intentionally redacted: no raw UI JSON, screenshot contents, or local home paths are included.
