### PR TITLE
test(cli): stabilize timeout watermark checks

### DIFF
--- a/Apps/CLI/Tests/CoreCLITests/SeeCommandTimeoutTests.swift
+++ b/Apps/CLI/Tests/CoreCLITests/SeeCommandTimeoutTests.swift
@@ -93,10 +93,7 @@ struct SeeCommandTimeoutTests {
         try await Task.sleep(for: .milliseconds(2))
         #expect(try #require(store.effectiveWatermark()) > firstPendingRead)
 
-        try await Task.sleep(for: .milliseconds(120))
-        let completed = try #require(store.effectiveWatermark())
-        try await Task.sleep(for: .milliseconds(2))
-        #expect(store.effectiveWatermark() == completed)
+        #expect(try await Self.waitForStableWatermark(store))
     }
 
     @Test
@@ -127,9 +124,26 @@ struct SeeCommandTimeoutTests {
         try await Task.sleep(for: .milliseconds(2))
         #expect(try #require(store.effectiveWatermark()) > firstPendingRead)
 
-        try await Task.sleep(for: .milliseconds(120))
-        let completed = try #require(store.effectiveWatermark())
-        try await Task.sleep(for: .milliseconds(2))
-        #expect(store.effectiveWatermark() == completed)
+        #expect(try await Self.waitForStableWatermark(store))
+    }
+
+    private static func waitForStableWatermark(
+        _ store: DesktopMutationWatermarkStore,
+        timeout: Duration = .seconds(1)
+    ) async throws -> Bool {
+        let clock = ContinuousClock()
+        let deadline = clock.now.advanced(by: timeout)
+        var previous = store.effectiveWatermark()
+
+        repeat {
+            try await Task.sleep(for: .milliseconds(5))
+            let current = store.effectiveWatermark()
+            if current != nil, current == previous {
+                return true
+            }
+            previous = current
+        } while clock.now < deadline
+
+        return false
     }
 }


### PR DESCRIPTION
## Summary

- replace fixed post-timeout sleeps with a bounded wait for two consecutive stable watermark reads
- preserve the assertion that pending mutations keep advancing the effective watermark
- apply the same synchronization to both timeout mutation tests

## Why

The fixed 120 ms delay raced the intentionally cancellation-ignoring 100 ms operation on loaded CI runners. The same exact assertion failed in [run 27969780333](https://github.com/openclaw/Peekaboo/actions/runs/27969780333/job/82773527401) and the first run of #200, then passed on rerun.

## Proof

- focused `SeeCommandTimeoutTests` suite — 6 tests passed
- failing timeout case stress — 50/50 passed
- sibling see-timeout case stress — 50/50 passed
- `pnpm run format` — clean
- `pnpm run lint` — 0 serious violations (18 existing warnings)
- `pnpm run test:safe` — 626 tests passed
- Codex autoreview — no actionable findings
