### PR TITLE
fix(daemon): honor task cancellation in daemon poll loops

### DIFF
--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Base/Runtime/DaemonLaunchPolicy.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Base/Runtime/DaemonLaunchPolicy.swift
@@ -518,6 +518,7 @@ enum DaemonLaunchPolicy {
                 return .available
             }
             try? await Task.sleep(nanoseconds: 100_000_000)
+            guard !Task.isCancelled else { break }
         }
         return self.bridgeLeaseIsHeld(socketPath: socketPath) ? .timedOut : .available
     }
@@ -568,6 +569,7 @@ enum DaemonLaunchPolicy {
                 return LaunchResult(status: status, processID: processID)
             }
             try? await Task.sleep(nanoseconds: 100_000_000)
+            guard !Task.isCancelled else { break }
         }
         if process.isRunning {
             process.terminate()
@@ -593,6 +595,7 @@ enum DaemonLaunchPolicy {
             }
             _ = try? await client.stopDaemon(expectedPID: expectedPID)
             try? await Task.sleep(nanoseconds: 200_000_000)
+            guard !Task.isCancelled else { break }
         }
 
         return await client.fetchControllableDaemonStatus()?.pid != expectedPID

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [3.5.3] - 2026-06-13
 
 ### Fixed
+- Daemon launch, socket, and shutdown polling now stop promptly when their parent task is cancelled instead of spinning until the timeout. Thanks @SebTardif for #203.
 - Public CLI, agent, MCP, and API guidance now treats runtime element IDs as opaque strings to copy exactly instead of implying role-specific ID shapes. Thanks @coygeek for #194.
 - Sparkle no longer advertises the unpublished 3.5.3 release whose public app download returns 404; the entry will return through the normal release flow when the release is published. Thanks @bcharleson for #199.
 - JSON-only `peekaboo see` runs without `--path` now keep required screenshots in snapshot storage instead of leaving files on Desktop or exposing their temporary paths. Thanks @coygeek for #196.

--- a/scripts/prove-daemon-poll-cancellation.swift
+++ b/scripts/prove-daemon-poll-cancellation.swift
@@ -1,0 +1,93 @@
+// Standalone proof for fix/daemon-poll-cancellation (PR #203).
+// Demonstrates that daemon poll loops using `try? await Task.sleep`
+// exit promptly when the task is cancelled, instead of spinning until
+// the deadline expires.
+//
+// This reproduces the exact pattern from DaemonLaunchPolicy.swift:
+// three poll loops (socket availability, launch readiness, shutdown)
+// each with `try? await Task.sleep(nanoseconds:)` that swallows
+// CancellationError.
+//
+// Usage: swiftc -parse-as-library -o /tmp/prove-daemon scripts/prove-daemon-poll-cancellation.swift && /tmp/prove-daemon
+
+import Foundation
+
+// --- Unfixed pattern: poll loop ignores cancellation ---
+func unfixedDaemonPoll(timeoutSec: TimeInterval) async -> (loopCount: Int, elapsed: TimeInterval) {
+    var count = 0
+    let start = Date()
+    let deadline = Date().addingTimeInterval(timeoutSec)
+
+    while Date() < deadline {
+        count += 1
+        // Simulated daemon check (always returns nil = not ready)
+        try? await Task.sleep(nanoseconds: 100_000_000) // 100ms
+        // No cancellation check — loop runs until deadline
+    }
+    return (count, Date().timeIntervalSince(start))
+}
+
+// --- Fixed pattern: poll loop checks Task.isCancelled ---
+func fixedDaemonPoll(timeoutSec: TimeInterval) async -> (loopCount: Int, elapsed: TimeInterval) {
+    var count = 0
+    let start = Date()
+    let deadline = Date().addingTimeInterval(timeoutSec)
+
+    while Date() < deadline {
+        count += 1
+        // Simulated daemon check (always returns nil = not ready)
+        try? await Task.sleep(nanoseconds: 100_000_000) // 100ms
+        guard !Task.isCancelled else { break }
+    }
+    return (count, Date().timeIntervalSince(start))
+}
+
+@main
+struct Proof {
+    static func main() async {
+        print("=== Daemon poll-loop cancellation proof ===")
+        print("Reproduces DaemonLaunchPolicy.swift poll pattern")
+        print()
+
+        let timeout: TimeInterval = 3.0 // 3-second deadline (matches launchDaemon default)
+
+        // Test 1: Unfixed — loop runs until deadline despite cancellation
+        print("Test 1: Unfixed pattern (try? swallows CancellationError)")
+        print("  Timeout: \(String(format: "%.0f", timeout))s, cancel after 200ms")
+        let unfixedTask = Task {
+            await unfixedDaemonPoll(timeoutSec: timeout)
+        }
+        try? await Task.sleep(nanoseconds: 200_000_000) // cancel after 200ms
+        unfixedTask.cancel()
+        let unfixed = await unfixedTask.value
+        print("  Loops executed: \(unfixed.loopCount)")
+        print("  Elapsed: \(String(format: "%.0f", unfixed.elapsed * 1000))ms (ran until \(String(format: "%.0f", timeout))s deadline)")
+        print()
+
+        // Test 2: Fixed — loop exits after first sleep post-cancellation
+        print("Test 2: Fixed pattern (Task.isCancelled guard after sleep)")
+        print("  Timeout: \(String(format: "%.0f", timeout))s, cancel after 200ms")
+        let fixedTask = Task {
+            await fixedDaemonPoll(timeoutSec: timeout)
+        }
+        try? await Task.sleep(nanoseconds: 200_000_000) // cancel after 200ms
+        fixedTask.cancel()
+        let fixed = await fixedTask.value
+        print("  Loops executed: \(fixed.loopCount)")
+        print("  Elapsed: \(String(format: "%.0f", fixed.elapsed * 1000))ms (exited promptly)")
+        print()
+
+        // Verdict
+        let unfixedRanFull = unfixed.elapsed > 2.0
+        let fixedExitedEarly = fixed.elapsed < 1.0 && fixed.loopCount <= 5
+        if unfixedRanFull && fixedExitedEarly {
+            print("✅ PASS: Unfixed loop ran \(String(format: "%.1f", unfixed.elapsed))s (full timeout, ignores cancel)")
+            print("✅ PASS: Fixed loop ran \(String(format: "%.0f", fixed.elapsed * 1000))ms (exits on cancel)")
+            print("✅ The Task.isCancelled guard prevents daemon poll loops from wasting")
+            print("   \(String(format: "%.0f", (unfixed.elapsed - fixed.elapsed) * 1000))ms of blocked time after cancellation.")
+        } else {
+            print("❌ FAIL: unexpected behavior")
+            print("  unfixed: \(String(format: "%.1f", unfixed.elapsed))s, fixed: \(String(format: "%.0f", fixed.elapsed * 1000))ms")
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Three daemon management poll loops in `DaemonLaunchPolicy.swift` use `try? await Task.sleep(nanoseconds:)` to throttle polling. The `try?` silently discards `CancellationError`, causing the loops to continue running until their timeout expires even after the parent task has been cancelled.

## Problem

When a CLI operation is cancelled (e.g., Ctrl+C or timeout), tasks polling for daemon socket availability, launch readiness, or shutdown completion ignore the cancellation signal. Each loop continues for up to its full timeout period (typically 3 seconds per loop), delaying process cleanup and exit.

The `try? await Task.sleep` pattern swallows `CancellationError` along with other errors. Without an explicit cancellation check, the cooperative cancellation contract of Swift Structured Concurrency is broken.

Affected loops:
- `waitForDaemonSocketAvailability` (line 520): polls socket lock status
- `launchDaemon` (line 570): polls for daemon readiness after launch
- `stopReplacement` (line 595): polls for daemon shutdown completion

## Fix

Add `guard !Task.isCancelled else { break }` after each `try? await Task.sleep` call. This is the standard Swift pattern for honoring cooperative cancellation in poll loops that use `try?`.

The guard is a no-op during normal execution and only triggers when the task has been explicitly cancelled by its parent.

## Origin

The poll loops were introduced in #187 (2026-06-12, Peter Steinberger). The `try?` pattern was carried over from the original implementation without a cancellation guard.

## Real behavior proof

- **Behavior addressed:** Three daemon poll loops in `DaemonLaunchPolicy.swift` ignore task cancellation because `try? await Task.sleep` silently discards `CancellationError`. Cancelling a CLI operation leaves these loops running until their full timeout expires (up to 3s per loop).
- **Real environment tested:** macOS 26, Swift 6.3.3 (swiftlang-6.3.3.1.3), built from patched source on `fix/daemon-poll-cancellation` branch.
- **Exact steps or command run after this patch:**

  ```bash
  cd /Users/sebastientardif/Peekaboo
  git checkout fix/daemon-poll-cancellation

  # Step 1. Compile standalone proof script
  swiftc -parse-as-library -o /tmp/prove-daemon \
    scripts/prove-daemon-poll-cancellation.swift

  # Step 2. Run proof
  /tmp/prove-daemon

  # Step 3. Verify guard placement in source
  grep -n 'Task.isCancelled' \
    Apps/CLI/Sources/PeekabooCLI/Commands/Base/Runtime/DaemonLaunchPolicy.swift
  ```

- **Evidence after fix:** terminal output from the standalone cancellation proof:

  ```console
  $ swiftc -parse-as-library -o /tmp/prove-daemon scripts/prove-daemon-poll-cancellation.swift && /tmp/prove-daemon
  === Daemon poll-loop cancellation proof ===
  Reproduces DaemonLaunchPolicy.swift poll pattern

  Test 1: Unfixed pattern (try? swallows CancellationError)
    Timeout: 3s, cancel after 200ms
    Loops executed: 32655077
    Elapsed: 3000ms (ran until 3s deadline)

  Test 2: Fixed pattern (Task.isCancelled guard after sleep)
    Timeout: 3s, cancel after 200ms
    Loops executed: 3
    Elapsed: 213ms (exited promptly)

  ✅ PASS: Unfixed loop ran 3.0s (full timeout, ignores cancel)
  ✅ PASS: Fixed loop ran 213ms (exits on cancel)
  ✅ The Task.isCancelled guard prevents daemon poll loops from wasting
     2787ms of blocked time after cancellation.
  ```

  Guard placement verified at all three poll sites:

  ```console
  $ grep -n 'Task.isCancelled' Apps/CLI/Sources/PeekabooCLI/Commands/Base/Runtime/DaemonLaunchPolicy.swift
  521:            guard !Task.isCancelled else { break }
  571:            guard !Task.isCancelled else { break }
  596:            guard !Task.isCancelled else { break }
  ```

- **Observed result after fix:** The unfixed pattern runs the full 3-second deadline (32M+ tight-loop iterations) after cancellation because `try?` causes `Task.sleep` to return instantly on a cancelled task without throwing. The fixed pattern exits after 3 iterations (~213ms) because `Task.isCancelled` catches the cancellation state. Each guard saves up to 2.8 seconds of wasted polling per loop.
- **What was not tested:** Live cancellation with a running daemon process (requires daemon to be actively running and a timed Ctrl+C scenario). The standalone proof reproduces the exact poll-loop pattern from DaemonLaunchPolicy.swift.

## Related

- Same bug class fixed in #193 (merged): `fix(capture): honor stop during watch transient backoff`
- Cancellation guards in `waitForImage`: commits `dd6d47fd`, `dc75fe4f`

