### PR TITLE
docs: define macOS computer-use vision

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,7 @@ Agent generation settings live under `agent.temperature` and `agent.maxTokens` i
 macOS Settings UI reads and writes the same values.
 
 ## Learn more
+- Project direction: [VISION.md](VISION.md)
 - Command reference: [docs/commands/](docs/commands/)
 - Platform support: [docs/platform-support.md](docs/platform-support.md)
 - Architecture: [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md)

--- a/VISION.md
+++ b/VISION.md
@@ -1,0 +1,9 @@
+# Vision
+
+Peekaboo makes computer use on macOS more capable, reliable, and inspectable.
+
+We land focused bug fixes and practical improvements for screen understanding, native UI automation, and agent-driven computer use. We favor deep integration with macOS frameworks and behavior over broad platform abstractions.
+
+## Platform scope
+
+Peekaboo is deliberately macOS-only. No cross-platform port is planned, and portability layers are out of scope when they dilute the quality of the macOS implementation. Independent platform-specific projects can evolve separately.


### PR DESCRIPTION
## Summary

- define Peekaboo's product direction around reliable computer use on macOS
- make the macOS-only platform scope explicit
- document that cross-platform ports and portability layers are not planned
- link the vision from the README

## Validation

- `pnpm run lint:docs`
- autoreview clean with no actionable findings
