### PR TITLE
chore(deps): update chrome-devtools-mcp to 1.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,6 +90,6 @@
     "x64"
   ],
   "devDependencies": {
-    "chrome-devtools-mcp": "1.2.0"
+    "chrome-devtools-mcp": "1.4.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,16 +13,16 @@ importers:
   .:
     devDependencies:
       chrome-devtools-mcp:
-        specifier: 1.2.0
-        version: 1.2.0
+        specifier: 1.4.0
+        version: 1.4.0
 
 packages:
 
-  chrome-devtools-mcp@1.2.0:
-    resolution: {integrity: sha512-xHd8hoLZQArDsYhu8OUHvKBIiihx1Co9DgAPHWaM4kzRf41TpZ0IuxKioIWTEGzFKpRqQzIxpFqydY4AKqP5sQ==}
+  chrome-devtools-mcp@1.4.0:
+    resolution: {integrity: sha512-OOT5mYMUbqqgpIGx0s0TgxnlicRSDm3yhZWzK3pWkB6TUPb+WdpI0j6OQoTnNZ9mqn9rwXiCOLzY4UALp+XsiQ==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=23}
     hasBin: true
 
 snapshots:
 
-  chrome-devtools-mcp@1.2.0: {}
+  chrome-devtools-mcp@1.4.0: {}


### PR DESCRIPTION
## Summary

- update the direct `chrome-devtools-mcp` development dependency from 1.2.0 to 1.4.0
- refresh the exact pnpm lockfile entry and integrity
- preserve Peekaboo runtime behavior, which continues to launch `chrome-devtools-mcp@latest`

## Compatibility

- 1.4.0 is the current stable release
- Node engine constraints and binary names are unchanged
- the Chrome connection, isolation, privacy, and channel flags used by Peekaboo remain supported
- upstream 1.3.0 and 1.4.0 changes are additive tooling and bug fixes

Upstream releases: [1.3.0](https://github.com/ChromeDevTools/chrome-devtools-mcp/releases/tag/chrome-devtools-mcp-v1.3.0), [1.4.0](https://github.com/ChromeDevTools/chrome-devtools-mcp/releases/tag/chrome-devtools-mcp-v1.4.0).

## Verification

- `pnpm install --frozen-lockfile`
- `pnpm exec chrome-devtools-mcp --version` → 1.4.0
- live MCP initialize, `tools/list`, and `list_pages` against stable Chrome: 29 tools; every Peekaboo-mapped tool and expected schema key present; page listing succeeded
- `swift test --package-path Core/PeekabooCore --filter BrowserToolTests --no-parallel` → 8 passed
- `pnpm run test:safe` → 628 tests across 71 suites passed
- `pnpm run build:cli`
- `node scripts/docs-lint.mjs`
- `pnpm audit --json` → zero vulnerabilities
- autoreview clean; public identifier audit passed

`pnpm run lint` retains one pre-existing file-length failure in an untouched test file; this dependency-only diff introduces no Swift changes.
