### PR TITLE
fix(capture): bound action process wait so kill failure cannot hang forever

### DIFF
--- a/Apps/CLI/CHANGELOG.md
+++ b/Apps/CLI/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+- `peekaboo capture action` now returns within a bounded interval when a child survives termination attempts, preserves graceful TERM handling for timeouts and cancellation, and eventually reaps an abandoned child. Thanks @SebTardif for #215.
+
 ## [3.6.0] - 2026-07-04
 
 ### Changed

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Core/CaptureActionProcessRunner.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Core/CaptureActionProcessRunner.swift
@@ -108,20 +108,19 @@ private final class CaptureActionProcessBox: @unchecked Sendable {
 
     /// Reaps the child without blocking forever.
     ///
-    /// Uses `WNOHANG` so timeout/cancellation can observe progress. Escalates to
-    /// `SIGKILL` only after an effective hard deadline (or during the post-SIGKILL
-    /// reap grace), never immediately when timeout/cancel is first observed.
+    /// Uses `WNOHANG` so timeout/cancellation can observe progress. The deadline is
+    /// the final abandon time, not the first SIGKILL time.
     ///
     /// Timeout and cancellation send `SIGTERM` and schedule `SIGKILL` after 500 ms
     /// (`terminateAfterTimeout` / `terminateProcessGroupForCancellation`). The wait
-    /// loop must not race that grace. For cancellation, the effective deadline is
-    /// also capped to cancelTime + ~1.6s so a long configured timeout cannot leave
-    /// the caller blocked near the original deadline if the child survives signals.
+    /// loop must not race that grace. For cancellation, the final deadline is also
+    /// capped to cancelTime + ~1.6s so a long configured timeout cannot leave the
+    /// caller blocked near the original deadline if the child survives signals.
     nonisolated func waitUntilExit(deadline: Date) -> Int32 {
         guard let pid = self.currentProcessIdentifier() else { return -1 }
 
         var status: Int32 = 0
-        var escalationStartedAt: Date?
+        var didSendWaitLoopKill = false
         while true {
             let result = Darwin.waitpid(pid, &status, WNOHANG)
             if result == pid {
@@ -137,24 +136,19 @@ private final class CaptureActionProcessBox: @unchecked Sendable {
             }
 
             let now = Date()
-            // Preserve TERM grace for timeout and cancellation. Escalate only after:
-            // - the original hard deadline (timeout + margin), or
-            // - a cancel-relative hard deadline (cancel time + TERM grace + SIGKILL grace)
-            //   so a cancelled long-timeout run cannot sit until the full original timeout.
-            let effectiveDeadline = self.effectiveWaitDeadline(original: deadline)
-            let shouldEscalate = now >= effectiveDeadline
-            if shouldEscalate {
-                if let started = escalationStartedAt {
-                    if now.timeIntervalSince(started) >= 1.0 {
-                        // Child ignored or survived SIGKILL (or is stuck in uninterruptible sleep).
-                        // Return rather than hanging the capture-action caller indefinitely.
-                        self.markExited()
-                        return 128 + SIGKILL
-                    }
-                } else {
-                    escalationStartedAt = now
-                    self.killProcessGroup(pid: pid, signal: SIGKILL)
-                }
+            // Preserve TERM grace. The timeout/cancellation tasks send the normal SIGKILL
+            // after 500 ms; this is only a redundant last-chance kill before giving up.
+            let effectiveDeadline = self.effectiveWaitAbandonDeadline(original: deadline)
+            let waitLoopKillDeadline = effectiveDeadline.addingTimeInterval(-1.0)
+            if !didSendWaitLoopKill, now >= waitLoopKillDeadline {
+                didSendWaitLoopKill = true
+                self.killProcessGroup(pid: pid, signal: SIGKILL)
+            }
+            if now >= effectiveDeadline {
+                // Child ignored or survived SIGKILL (or is stuck in uninterruptible sleep).
+                // Return rather than hanging the capture-action caller indefinitely.
+                self.markExited()
+                return 128 + SIGKILL
             }
 
             usleep(10000)
@@ -182,15 +176,9 @@ private final class CaptureActionProcessBox: @unchecked Sendable {
         return self.timedOut
     }
 
-    nonisolated func wasForceStopped() -> Bool {
-        self.lock.lock()
-        defer { self.lock.unlock() }
-        return self.forceStop
-    }
-
-    /// Hard deadline used by the wait loop. On cancellation, shrink to
+    /// Final abandon deadline used by the wait loop. On cancellation, shrink to
     /// cancelTime + 0.5s TERM grace + 1.0s SIGKILL reap grace (+ margin).
-    private nonisolated func effectiveWaitDeadline(original: Date) -> Date {
+    private nonisolated func effectiveWaitAbandonDeadline(original: Date) -> Date {
         self.lock.lock()
         let forceStop = self.forceStop
         let requestedAt = self.forceStopRequestedAt

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Core/CaptureActionProcessRunner.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Core/CaptureActionProcessRunner.swift
@@ -108,10 +108,11 @@ private final class CaptureActionProcessBox: @unchecked Sendable {
     /// Reaps the child without blocking forever.
     ///
     /// Uses `WNOHANG` so timeout/cancellation can observe progress. Escalates to
-    /// `SIGKILL` only for cancellation (`forceStop`) or the hard `deadline`.
+    /// `SIGKILL` only at the hard `deadline` (or during the post-SIGKILL reap grace).
     ///
-    /// Timeout alone must **not** trigger SIGKILL here: `terminateAfterTimeout`
-    /// already sends `SIGTERM` and waits 500 ms before `killTimedOutProcessGroup()`.
+    /// Timeout and cancellation must **not** trigger SIGKILL here: both paths already
+    /// send `SIGTERM` and schedule `SIGKILL` after 500 ms
+    /// (`terminateAfterTimeout` / `terminateProcessGroupForCancellation`).
     /// Racing that grace would kill children that trap TERM and exit cleanly.
     nonisolated func waitUntilExit(deadline: Date) -> Int32 {
         guard let pid = self.currentProcessIdentifier() else { return -1 }
@@ -133,8 +134,9 @@ private final class CaptureActionProcessBox: @unchecked Sendable {
             }
 
             let now = Date()
-            // Preserve timeout TERM grace: do not escalate solely because timedOut is set.
-            let shouldEscalate = self.wasForceStopped() || now >= deadline
+            // Preserve TERM grace for timeout and cancellation; only the hard deadline
+            // forces wait-loop SIGKILL if the child is still alive.
+            let shouldEscalate = now >= deadline
             if shouldEscalate {
                 if let started = escalationStartedAt {
                     if now.timeIntervalSince(started) >= 1.0 {

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Core/CaptureActionProcessRunner.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Core/CaptureActionProcessRunner.swift
@@ -91,12 +91,17 @@ private final class CaptureActionProcessBox: @unchecked Sendable {
     private let stderrPipe = Pipe()
     private let stdoutOutput = BoundedPipeOutput()
     private let stderrOutput = BoundedPipeOutput()
+    private let signalProcessGroup: @Sendable (pid_t, Int32) -> Void
     private let lock = NSLock()
     private nonisolated(unsafe) var processIdentifier: pid_t?
     private nonisolated(unsafe) var timedOut = false
     private nonisolated(unsafe) var forceStop = false
     private nonisolated(unsafe) var forceStopRequestedAt: Date?
-    private nonisolated(unsafe) var didExit = false
+    private nonisolated(unsafe) var didFinishWaiting = false
+
+    nonisolated init(signalProcessGroup: @escaping @Sendable (pid_t, Int32) -> Void) {
+        self.signalProcessGroup = signalProcessGroup
+    }
 
     nonisolated func start(command: [String]) throws {
         guard let executable = command.first else {
@@ -124,14 +129,14 @@ private final class CaptureActionProcessBox: @unchecked Sendable {
         while true {
             let result = Darwin.waitpid(pid, &status, WNOHANG)
             if result == pid {
-                self.markExited()
+                self.markFinishedWaiting()
                 return Self.exitCode(fromWaitStatus: status)
             }
             if result == -1 {
                 if errno == EINTR {
                     continue
                 }
-                self.markExited()
+                self.markFinishedWaiting()
                 return -1
             }
 
@@ -146,8 +151,9 @@ private final class CaptureActionProcessBox: @unchecked Sendable {
             }
             if now >= effectiveDeadline {
                 // Child ignored or survived SIGKILL (or is stuck in uninterruptible sleep).
-                // Return rather than hanging the capture-action caller indefinitely.
-                self.markExited()
+                // Transfer reaping to an asynchronous poller before unblocking the caller.
+                self.startBackgroundReaper(pid: pid)
+                self.markFinishedWaiting()
                 return 128 + SIGKILL
             }
 
@@ -301,7 +307,7 @@ private final class CaptureActionProcessBox: @unchecked Sendable {
     private nonisolated func requestTimeoutTermination() -> Bool {
         self.lock.lock()
         defer { self.lock.unlock() }
-        guard let pid = self.processIdentifier, !self.didExit else { return false }
+        guard let pid = self.processIdentifier, !self.didFinishWaiting else { return false }
         self.timedOut = true
         self.killProcessGroup(pid: pid, signal: SIGTERM)
         return true
@@ -313,14 +319,37 @@ private final class CaptureActionProcessBox: @unchecked Sendable {
         return self.processIdentifier
     }
 
-    private nonisolated func markExited() {
+    private nonisolated func markFinishedWaiting() {
         self.lock.lock()
-        self.didExit = true
+        self.didFinishWaiting = true
         self.lock.unlock()
     }
 
     private nonisolated func killProcessGroup(pid: pid_t, signal: Int32) {
-        _ = Darwin.kill(-pid, signal)
+        self.signalProcessGroup(pid, signal)
+    }
+
+    private nonisolated func startBackgroundReaper(pid: pid_t) {
+        Task.detached(priority: .utility) {
+            var status: Int32 = 0
+            while true {
+                let result = Darwin.waitpid(pid, &status, WNOHANG)
+                if result == pid {
+                    return
+                }
+                if result == -1 {
+                    if errno == EINTR {
+                        continue
+                    }
+                    return
+                }
+                do {
+                    try await Task.sleep(nanoseconds: 1_000_000_000)
+                } catch {
+                    return
+                }
+            }
+        }
     }
 
     private nonisolated func drainAvailableNonBlocking(from handle: FileHandle, into output: BoundedPipeOutput) {
@@ -380,7 +409,21 @@ enum CaptureActionProcessRunner {
         command: [String],
         timeoutSeconds: TimeInterval
     ) async throws -> CaptureActionProcessResult {
-        let box = CaptureActionProcessBox()
+        try await self.run(
+            command: command,
+            timeoutSeconds: timeoutSeconds,
+            signalProcessGroup: { pid, signal in
+                _ = Darwin.kill(-pid, signal)
+            }
+        )
+    }
+
+    nonisolated static func run(
+        command: [String],
+        timeoutSeconds: TimeInterval,
+        signalProcessGroup: @escaping @Sendable (pid_t, Int32) -> Void
+    ) async throws -> CaptureActionProcessResult {
+        let box = CaptureActionProcessBox(signalProcessGroup: signalProcessGroup)
         let started = Date()
         try box.start(command: command)
         let signalForwarder = CaptureActionSignalForwarder { signalNumber in

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Core/CaptureActionProcessRunner.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Core/CaptureActionProcessRunner.swift
@@ -94,6 +94,7 @@ private final class CaptureActionProcessBox: @unchecked Sendable {
     private let lock = NSLock()
     private nonisolated(unsafe) var processIdentifier: pid_t?
     private nonisolated(unsafe) var timedOut = false
+    private nonisolated(unsafe) var forceStop = false
     private nonisolated(unsafe) var didExit = false
 
     nonisolated func start(command: [String]) throws {
@@ -104,21 +105,47 @@ private final class CaptureActionProcessBox: @unchecked Sendable {
         try self.spawn(executable: executable, arguments: command)
     }
 
-    nonisolated func waitUntilExit() -> Int32 {
+    /// Reaps the child without blocking forever.
+    ///
+    /// Uses `WNOHANG` so timeout/cancellation can observe progress. After the configured
+    /// deadline (or once timeout/force-stop is requested), escalates to `SIGKILL` and
+    /// returns within a short grace period even if the child cannot be reaped.
+    nonisolated func waitUntilExit(deadline: Date) -> Int32 {
         guard let pid = self.currentProcessIdentifier() else { return -1 }
 
         var status: Int32 = 0
+        var escalationStartedAt: Date?
         while true {
-            let result = Darwin.waitpid(pid, &status, 0)
+            let result = Darwin.waitpid(pid, &status, WNOHANG)
             if result == pid {
                 self.markExited()
                 return Self.exitCode(fromWaitStatus: status)
             }
-            if result == -1, errno == EINTR {
-                continue
+            if result == -1 {
+                if errno == EINTR {
+                    continue
+                }
+                self.markExited()
+                return -1
             }
-            self.markExited()
-            return -1
+
+            let now = Date()
+            let shouldEscalate = self.wasTimedOut() || self.wasForceStopped() || now >= deadline
+            if shouldEscalate {
+                if let started = escalationStartedAt {
+                    if now.timeIntervalSince(started) >= 1.0 {
+                        // Child ignored or survived SIGKILL (or is stuck in uninterruptible sleep).
+                        // Return rather than hanging the capture-action caller indefinitely.
+                        self.markExited()
+                        return 128 + SIGKILL
+                    }
+                } else {
+                    escalationStartedAt = now
+                    self.killProcessGroup(pid: pid, signal: SIGKILL)
+                }
+            }
+
+            usleep(10000)
         }
     }
 
@@ -143,6 +170,12 @@ private final class CaptureActionProcessBox: @unchecked Sendable {
         return self.timedOut
     }
 
+    nonisolated func wasForceStopped() -> Bool {
+        self.lock.lock()
+        defer { self.lock.unlock() }
+        return self.forceStop
+    }
+
     nonisolated func finishOutput() -> (stdout: (String, Bool), stderr: (String, Bool)) {
         let stdoutHandle = self.stdoutPipe.fileHandleForReading
         let stderrHandle = self.stderrPipe.fileHandleForReading
@@ -161,7 +194,11 @@ private final class CaptureActionProcessBox: @unchecked Sendable {
     }
 
     nonisolated func terminateProcessGroupForCancellation() {
-        guard let pid = self.currentProcessIdentifier() else { return }
+        self.lock.lock()
+        self.forceStop = true
+        let pid = self.processIdentifier
+        self.lock.unlock()
+        guard let pid else { return }
         self.killProcessGroup(pid: pid, signal: SIGTERM)
         Task.detached {
             do {
@@ -337,7 +374,10 @@ enum CaptureActionProcessRunner {
         defer { signalForwarder.cancel() }
 
         return await withTaskCancellationHandler {
-            let waitTask = Task.detached { box.waitUntilExit() }
+            // Hard ceiling: configured timeout + TERM grace (0.5s) + SIGKILL grace (1s) + margin.
+            // Prevents indefinite hang if the child survives kill attempts.
+            let deadline = Date().addingTimeInterval(timeoutSeconds + 2.0)
+            let waitTask = Task.detached { box.waitUntilExit(deadline: deadline) }
             let timeoutTask = Task.detached { await box.terminateAfterTimeout(seconds: timeoutSeconds) }
 
             let exitCode = await waitTask.value

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Core/CaptureActionProcessRunner.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Core/CaptureActionProcessRunner.swift
@@ -107,9 +107,12 @@ private final class CaptureActionProcessBox: @unchecked Sendable {
 
     /// Reaps the child without blocking forever.
     ///
-    /// Uses `WNOHANG` so timeout/cancellation can observe progress. After the configured
-    /// deadline (or once timeout/force-stop is requested), escalates to `SIGKILL` and
-    /// returns within a short grace period even if the child cannot be reaped.
+    /// Uses `WNOHANG` so timeout/cancellation can observe progress. Escalates to
+    /// `SIGKILL` only for cancellation (`forceStop`) or the hard `deadline`.
+    ///
+    /// Timeout alone must **not** trigger SIGKILL here: `terminateAfterTimeout`
+    /// already sends `SIGTERM` and waits 500 ms before `killTimedOutProcessGroup()`.
+    /// Racing that grace would kill children that trap TERM and exit cleanly.
     nonisolated func waitUntilExit(deadline: Date) -> Int32 {
         guard let pid = self.currentProcessIdentifier() else { return -1 }
 
@@ -130,7 +133,8 @@ private final class CaptureActionProcessBox: @unchecked Sendable {
             }
 
             let now = Date()
-            let shouldEscalate = self.wasTimedOut() || self.wasForceStopped() || now >= deadline
+            // Preserve timeout TERM grace: do not escalate solely because timedOut is set.
+            let shouldEscalate = self.wasForceStopped() || now >= deadline
             if shouldEscalate {
                 if let started = escalationStartedAt {
                     if now.timeIntervalSince(started) >= 1.0 {

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Core/CaptureActionProcessRunner.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Core/CaptureActionProcessRunner.swift
@@ -95,6 +95,7 @@ private final class CaptureActionProcessBox: @unchecked Sendable {
     private nonisolated(unsafe) var processIdentifier: pid_t?
     private nonisolated(unsafe) var timedOut = false
     private nonisolated(unsafe) var forceStop = false
+    private nonisolated(unsafe) var forceStopRequestedAt: Date?
     private nonisolated(unsafe) var didExit = false
 
     nonisolated func start(command: [String]) throws {
@@ -108,12 +109,14 @@ private final class CaptureActionProcessBox: @unchecked Sendable {
     /// Reaps the child without blocking forever.
     ///
     /// Uses `WNOHANG` so timeout/cancellation can observe progress. Escalates to
-    /// `SIGKILL` only at the hard `deadline` (or during the post-SIGKILL reap grace).
+    /// `SIGKILL` only after an effective hard deadline (or during the post-SIGKILL
+    /// reap grace), never immediately when timeout/cancel is first observed.
     ///
-    /// Timeout and cancellation must **not** trigger SIGKILL here: both paths already
-    /// send `SIGTERM` and schedule `SIGKILL` after 500 ms
-    /// (`terminateAfterTimeout` / `terminateProcessGroupForCancellation`).
-    /// Racing that grace would kill children that trap TERM and exit cleanly.
+    /// Timeout and cancellation send `SIGTERM` and schedule `SIGKILL` after 500 ms
+    /// (`terminateAfterTimeout` / `terminateProcessGroupForCancellation`). The wait
+    /// loop must not race that grace. For cancellation, the effective deadline is
+    /// also capped to cancelTime + ~1.6s so a long configured timeout cannot leave
+    /// the caller blocked near the original deadline if the child survives signals.
     nonisolated func waitUntilExit(deadline: Date) -> Int32 {
         guard let pid = self.currentProcessIdentifier() else { return -1 }
 
@@ -134,9 +137,12 @@ private final class CaptureActionProcessBox: @unchecked Sendable {
             }
 
             let now = Date()
-            // Preserve TERM grace for timeout and cancellation; only the hard deadline
-            // forces wait-loop SIGKILL if the child is still alive.
-            let shouldEscalate = now >= deadline
+            // Preserve TERM grace for timeout and cancellation. Escalate only after:
+            // - the original hard deadline (timeout + margin), or
+            // - a cancel-relative hard deadline (cancel time + TERM grace + SIGKILL grace)
+            //   so a cancelled long-timeout run cannot sit until the full original timeout.
+            let effectiveDeadline = self.effectiveWaitDeadline(original: deadline)
+            let shouldEscalate = now >= effectiveDeadline
             if shouldEscalate {
                 if let started = escalationStartedAt {
                     if now.timeIntervalSince(started) >= 1.0 {
@@ -182,6 +188,18 @@ private final class CaptureActionProcessBox: @unchecked Sendable {
         return self.forceStop
     }
 
+    /// Hard deadline used by the wait loop. On cancellation, shrink to
+    /// cancelTime + 0.5s TERM grace + 1.0s SIGKILL reap grace (+ margin).
+    private nonisolated func effectiveWaitDeadline(original: Date) -> Date {
+        self.lock.lock()
+        let forceStop = self.forceStop
+        let requestedAt = self.forceStopRequestedAt
+        self.lock.unlock()
+        guard forceStop, let requestedAt else { return original }
+        let cancelRelative = requestedAt.addingTimeInterval(1.6)
+        return min(original, cancelRelative)
+    }
+
     nonisolated func finishOutput() -> (stdout: (String, Bool), stderr: (String, Bool)) {
         let stdoutHandle = self.stdoutPipe.fileHandleForReading
         let stderrHandle = self.stderrPipe.fileHandleForReading
@@ -202,6 +220,9 @@ private final class CaptureActionProcessBox: @unchecked Sendable {
     nonisolated func terminateProcessGroupForCancellation() {
         self.lock.lock()
         self.forceStop = true
+        if self.forceStopRequestedAt == nil {
+            self.forceStopRequestedAt = Date()
+        }
         let pid = self.processIdentifier
         self.lock.unlock()
         guard let pid else { return }

--- a/Apps/CLI/Tests/CoreCLITests/CaptureActionProcessRunnerTests.swift
+++ b/Apps/CLI/Tests/CoreCLITests/CaptureActionProcessRunnerTests.swift
@@ -84,6 +84,7 @@ struct CaptureActionProcessRunnerTests {
         }
     }
 
+    @Test
     func `runner returns by hard deadline for long running child`() async throws {
         // Even if the child outlives normal timeout handling, waitUntilExit must not block
         // forever: the hard deadline (timeout + 2s) plus SIGKILL grace bounds the wait.

--- a/Apps/CLI/Tests/CoreCLITests/CaptureActionProcessRunnerTests.swift
+++ b/Apps/CLI/Tests/CoreCLITests/CaptureActionProcessRunnerTests.swift
@@ -49,6 +49,43 @@ struct CaptureActionProcessRunnerTests {
     }
 
     @Test
+
+    @Test
+    func `cancellation preserves TERM grace so graceful children can exit`() async throws {
+        // Same grace contract as timeout: cancel sends SIGTERM, then 500 ms before SIGKILL.
+        // waitUntilExit must not SIGKILL immediately on forceStop.
+        let root = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+            .appendingPathComponent("peekaboo-action-cancel-grace-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let marker = root.appendingPathComponent("cancel-graceful-exit")
+        let task = Task {
+            try await CaptureActionProcessRunner.run(
+                command: [
+                    "/bin/sh",
+                    "-c",
+                    "trap 'touch \"$1\"; exit 0' TERM; while true; do sleep 0.05; done",
+                    "sh",
+                    marker.path,
+                ],
+                timeoutSeconds: 5
+            )
+        }
+
+        try await Task.sleep(nanoseconds: 100_000_000)
+        task.cancel()
+        let result = try? await task.value
+
+        // Allow the 500 ms cancellation TERM grace to complete.
+        try await Task.sleep(nanoseconds: 700_000_000)
+        #expect(FileManager.default.fileExists(atPath: marker.path) == true)
+        if let result {
+            #expect(result.exitCode == 0)
+            #expect(result.timedOut == false)
+        }
+    }
+
     func `runner returns by hard deadline for long running child`() async throws {
         // Even if the child outlives normal timeout handling, waitUntilExit must not block
         // forever: the hard deadline (timeout + 2s) plus SIGKILL grace bounds the wait.

--- a/Apps/CLI/Tests/CoreCLITests/CaptureActionProcessRunnerTests.swift
+++ b/Apps/CLI/Tests/CoreCLITests/CaptureActionProcessRunnerTests.swift
@@ -27,25 +27,27 @@ struct CaptureActionProcessRunnerTests {
         defer { try? FileManager.default.removeItem(at: root) }
 
         let marker = root.appendingPathComponent("graceful-exit")
+        let ready = root.appendingPathComponent("ready")
         let started = Date()
         let result = try await CaptureActionProcessRunner.run(
             command: [
-                "/bin/sh",
-                "-c",
-                "trap 'touch \"$1\"; exit 0' TERM; while true; do sleep 0.05; done",
-                "sh",
+                "/usr/bin/perl",
+                "-e",
+                Self.gracefulTermHandlerScript,
                 marker.path,
+                ready.path,
             ],
-            timeoutSeconds: 0.15
+            timeoutSeconds: 0.5
         )
 
         let elapsed = Date().timeIntervalSince(started)
+        #expect(FileManager.default.fileExists(atPath: ready.path) == true)
         #expect(result.timedOut == true)
         #expect(result.exitCode == 0)
         #expect(FileManager.default.fileExists(atPath: marker.path) == true)
         // timeout + TERM handling should finish well under hard deadline; grace is 500ms
-        #expect(elapsed < 1.5)
-        #expect(elapsed >= 0.15)
+        #expect(elapsed < 2)
+        #expect(elapsed >= 0.5)
     }
 
     @Test
@@ -58,20 +60,21 @@ struct CaptureActionProcessRunnerTests {
         defer { try? FileManager.default.removeItem(at: root) }
 
         let marker = root.appendingPathComponent("cancel-graceful-exit")
+        let ready = root.appendingPathComponent("ready")
         let task = Task {
             try await CaptureActionProcessRunner.run(
                 command: [
-                    "/bin/sh",
-                    "-c",
-                    "trap 'touch \"$1\"; exit 0' TERM; while true; do sleep 0.05; done",
-                    "sh",
+                    "/usr/bin/perl",
+                    "-e",
+                    Self.gracefulTermHandlerScript,
                     marker.path,
+                    ready.path,
                 ],
                 timeoutSeconds: 5
             )
         }
 
-        try await Task.sleep(nanoseconds: 100_000_000)
+        try await Self.waitUntilFileExists(ready)
         task.cancel()
         let result = try? await task.value
 
@@ -85,9 +88,41 @@ struct CaptureActionProcessRunnerTests {
     }
 
     @Test
+    func `cancellation returns quickly for TERM ignoring child with long timeout`() async throws {
+        let root = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+            .appendingPathComponent("peekaboo-action-cancel-ignore-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let ready = root.appendingPathComponent("ready")
+        let started = Date()
+        let task = Task {
+            try await CaptureActionProcessRunner.run(
+                command: [
+                    "/bin/sh",
+                    "-c",
+                    "trap '' TERM; touch \"$1\"; while true; do sleep 1; done",
+                    "sh",
+                    ready.path
+                ],
+                timeoutSeconds: 30
+            )
+        }
+
+        try await Self.waitUntilFileExists(ready)
+        task.cancel()
+        let result = try await task.value
+        let elapsed = Date().timeIntervalSince(started)
+
+        #expect(result.timedOut == false)
+        #expect(result.exitCode != 0)
+        #expect(elapsed < 2.5)
+    }
+
+    @Test
     func `runner returns by hard deadline for long running child`() async throws {
         // Even if the child outlives normal timeout handling, waitUntilExit must not block
-        // forever: the hard deadline (timeout + 2s) plus SIGKILL grace bounds the wait.
+        // forever: timeout + TERM grace + SIGKILL reap grace + margin bounds the wait.
         let started = Date()
         let result = try await CaptureActionProcessRunner.run(
             command: ["/bin/sh", "-c", "trap '' TERM; while true; do sleep 1; done"],
@@ -181,4 +216,29 @@ struct CaptureActionProcessRunnerTests {
         try await Task.sleep(nanoseconds: 1_200_000_000)
         #expect(FileManager.default.fileExists(atPath: marker.path) == false)
     }
+
+    private static func waitUntilFileExists(_ url: URL, timeoutSeconds: TimeInterval = 2.0) async throws {
+        let deadline = Date().addingTimeInterval(timeoutSeconds)
+        while Date() < deadline {
+            if FileManager.default.fileExists(atPath: url.path) {
+                return
+            }
+            try await Task.sleep(nanoseconds: 10_000_000)
+        }
+        Issue.record("Timed out waiting for \(url.path)")
+    }
+
+    private static let gracefulTermHandlerScript = """
+    my ($marker, $ready) = @ARGV;
+    $SIG{TERM} = sub {
+        open(my $fh, '>', $marker) or die "marker: $!";
+        print $fh "ok\\n";
+        close($fh);
+        exit 0;
+    };
+    open(my $fh, '>', $ready) or die "ready: $!";
+    print $fh "ready\\n";
+    close($fh);
+    sleep 30;
+    """
 }

--- a/Apps/CLI/Tests/CoreCLITests/CaptureActionProcessRunnerTests.swift
+++ b/Apps/CLI/Tests/CoreCLITests/CaptureActionProcessRunnerTests.swift
@@ -17,6 +17,38 @@ struct CaptureActionProcessRunnerTests {
     }
 
     @Test
+    func `runner preserves TERM grace so graceful children can exit`() async throws {
+        // Child traps TERM, writes a marker, and exits 0 within the 500 ms grace window.
+        // waitUntilExit must not SIGKILL immediately when timedOut becomes true, or the
+        // trap never runs and we observe a SIGKILL exit status instead.
+        let root = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+            .appendingPathComponent("peekaboo-action-term-grace-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let marker = root.appendingPathComponent("graceful-exit")
+        let started = Date()
+        let result = try await CaptureActionProcessRunner.run(
+            command: [
+                "/bin/sh",
+                "-c",
+                "trap 'touch \"$1\"; exit 0' TERM; while true; do sleep 0.05; done",
+                "sh",
+                marker.path,
+            ],
+            timeoutSeconds: 0.15
+        )
+
+        let elapsed = Date().timeIntervalSince(started)
+        #expect(result.timedOut == true)
+        #expect(result.exitCode == 0)
+        #expect(FileManager.default.fileExists(atPath: marker.path) == true)
+        // timeout + TERM handling should finish well under hard deadline; grace is 500ms
+        #expect(elapsed < 1.5)
+        #expect(elapsed >= 0.15)
+    }
+
+    @Test
     func `runner returns by hard deadline for long running child`() async throws {
         // Even if the child outlives normal timeout handling, waitUntilExit must not block
         // forever: the hard deadline (timeout + 2s) plus SIGKILL grace bounds the wait.

--- a/Apps/CLI/Tests/CoreCLITests/CaptureActionProcessRunnerTests.swift
+++ b/Apps/CLI/Tests/CoreCLITests/CaptureActionProcessRunnerTests.swift
@@ -49,8 +49,6 @@ struct CaptureActionProcessRunnerTests {
     }
 
     @Test
-
-    @Test
     func `cancellation preserves TERM grace so graceful children can exit`() async throws {
         // Same grace contract as timeout: cancel sends SIGTERM, then 500 ms before SIGKILL.
         // waitUntilExit must not SIGKILL immediately on forceStop.

--- a/Apps/CLI/Tests/CoreCLITests/CaptureActionProcessRunnerTests.swift
+++ b/Apps/CLI/Tests/CoreCLITests/CaptureActionProcessRunnerTests.swift
@@ -17,6 +17,24 @@ struct CaptureActionProcessRunnerTests {
     }
 
     @Test
+    func `runner returns by hard deadline for long running child`() async throws {
+        // Even if the child outlives normal timeout handling, waitUntilExit must not block
+        // forever: the hard deadline (timeout + 2s) plus SIGKILL grace bounds the wait.
+        let started = Date()
+        let result = try await CaptureActionProcessRunner.run(
+            command: ["/bin/sh", "-c", "trap '' TERM; while true; do sleep 1; done"],
+            timeoutSeconds: 0.2
+        )
+
+        let elapsed = Date().timeIntervalSince(started)
+        #expect(result.timedOut == true)
+        #expect(result.exitCode != 0)
+        // timeout (0.2) + TERM grace (0.5) + SIGKILL grace (1.0) + margin must stay under 4s
+        #expect(elapsed < 4)
+        #expect(elapsed >= 0.2)
+    }
+
+    @Test
     func `runner drains output while retaining bounded text`() async throws {
         let result = try await CaptureActionProcessRunner.run(
             command: ["/bin/sh", "-c", "yes x | head -c 70000; yes e | head -c 70000 >&2"],

--- a/Apps/CLI/Tests/CoreCLITests/CaptureActionProcessRunnerTests.swift
+++ b/Apps/CLI/Tests/CoreCLITests/CaptureActionProcessRunnerTests.swift
@@ -1,3 +1,4 @@
+import Darwin
 import Foundation
 import Testing
 @testable import PeekabooCLI
@@ -120,21 +121,28 @@ struct CaptureActionProcessRunnerTests {
     }
 
     @Test
-    func `runner returns by hard deadline for long running child`() async throws {
-        // Even if the child outlives normal timeout handling, waitUntilExit must not block
-        // forever: timeout + TERM grace + SIGKILL reap grace + margin bounds the wait.
+    func `runner abandons deadline then eventually reaps child when signal delivery fails`() async throws {
+        let ignoredSignals = IgnoredProcessGroupSignals()
         let started = Date()
         let result = try await CaptureActionProcessRunner.run(
-            command: ["/bin/sh", "-c", "trap '' TERM; while true; do sleep 1; done"],
-            timeoutSeconds: 0.2
+            command: ["/bin/sleep", "30"],
+            timeoutSeconds: 0.1,
+            signalProcessGroup: { pid, signal in
+                ignoredSignals.record(pid: pid, signal: signal)
+            }
         )
 
         let elapsed = Date().timeIntervalSince(started)
         #expect(result.timedOut == true)
-        #expect(result.exitCode != 0)
-        // timeout (0.2) + TERM grace (0.5) + SIGKILL grace (1.0) + margin must stay under 4s
-        #expect(elapsed < 4)
-        #expect(elapsed >= 0.2)
+        #expect(result.exitCode == 128 + SIGKILL)
+        #expect(elapsed < 3)
+        #expect(elapsed >= 2)
+        #expect(ignoredSignals.signals.contains(SIGTERM))
+        #expect(ignoredSignals.signals.contains(SIGKILL))
+
+        let pid = try #require(ignoredSignals.processIdentifier)
+        _ = Darwin.kill(-pid, SIGKILL)
+        try await Self.waitUntilProcessIsGone(pid)
     }
 
     @Test
@@ -228,6 +236,17 @@ struct CaptureActionProcessRunnerTests {
         Issue.record("Timed out waiting for \(url.path)")
     }
 
+    private static func waitUntilProcessIsGone(_ pid: pid_t, timeoutSeconds: TimeInterval = 2.0) async throws {
+        let deadline = Date().addingTimeInterval(timeoutSeconds)
+        while Date() < deadline {
+            if Darwin.kill(pid, 0) == -1, errno == ESRCH {
+                return
+            }
+            try await Task.sleep(nanoseconds: 20_000_000)
+        }
+        Issue.record("Timed out waiting for process \(pid) to be reaped")
+    }
+
     private static let gracefulTermHandlerScript = """
     my ($marker, $ready) = @ARGV;
     $SIG{TERM} = sub {
@@ -241,4 +260,25 @@ struct CaptureActionProcessRunnerTests {
     close($fh);
     sleep 30;
     """
+}
+
+private final class IgnoredProcessGroupSignals: @unchecked Sendable {
+    private nonisolated let lock = NSLock()
+    private nonisolated(unsafe) var recordedProcessIdentifier: pid_t?
+    private nonisolated(unsafe) var recordedSignals: [Int32] = []
+
+    nonisolated var processIdentifier: pid_t? {
+        self.lock.withLock { self.recordedProcessIdentifier }
+    }
+
+    nonisolated var signals: [Int32] {
+        self.lock.withLock { self.recordedSignals }
+    }
+
+    nonisolated func record(pid: pid_t, signal: Int32) {
+        self.lock.withLock {
+            self.recordedProcessIdentifier = pid
+            self.recordedSignals.append(signal)
+        }
+    }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+### Fixed
+- `peekaboo capture action` now returns within a bounded interval when a child survives termination attempts, preserves graceful TERM handling for timeouts and cancellation, and eventually reaps an abandoned child. Thanks @SebTardif for #215.
+
 ## [3.6.0] - 2026-07-04
 
 ### Changed

--- a/scripts/prove-action-process-deadline.swift
+++ b/scripts/prove-action-process-deadline.swift
@@ -1,0 +1,75 @@
+#!/usr/bin/env swift
+import Darwin
+import Foundation
+
+func spawnSleepForever() -> pid_t {
+    var pid: pid_t = 0
+    var fileActions: posix_spawn_file_actions_t?
+    posix_spawn_file_actions_init(&fileActions)
+    defer { posix_spawn_file_actions_destroy(&fileActions) }
+    var attrs: posix_spawnattr_t?
+    posix_spawnattr_init(&attrs)
+    defer { posix_spawnattr_destroy(&attrs) }
+    posix_spawnattr_setflags(&attrs, Int16(POSIX_SPAWN_SETPGROUP))
+    posix_spawnattr_setpgroup(&attrs, 0)
+    let args = ["/bin/sh", "-c", "trap '' TERM; while true; do sleep 1; done"]
+    var argv = args.map { strdup($0) } + [nil]
+    defer { for p in argv { free(p) } }
+    let rc = "/bin/sh".withCString { path in
+        posix_spawnp(&pid, path, &fileActions, &attrs, &argv, environ)
+    }
+    precondition(rc == 0, "spawn failed \(rc)")
+    return pid
+}
+
+func waitBlockingNoDeadline(pid: pid_t, maxSeconds: Double) -> (reaped: Bool, elapsed: Double) {
+    // Simulate old behavior: blocking waitpid cannot observe a deadline while blocked.
+    // We approximate by attempting a timed race: if still not reaped after maxSeconds, hang risk.
+    let started = Date()
+    var status: Int32 = 0
+    // Use a short alarm-like approach: poll WNOHANG only after "would have blocked"
+    // For demonstration of FIXED path only.
+    while Date().timeIntervalSince(started) < maxSeconds {
+        let r = waitpid(pid, &status, WNOHANG)
+        if r == pid { return (true, Date().timeIntervalSince(started)) }
+        usleep(10_000)
+    }
+    return (false, Date().timeIntervalSince(started))
+}
+
+func waitWithDeadline(pid: pid_t, deadline: Date) -> (code: Int32, elapsed: Double) {
+    let started = Date()
+    var status: Int32 = 0
+    var escalationStartedAt: Date?
+    while true {
+        let r = waitpid(pid, &status, WNOHANG)
+        if r == pid {
+            return (status, Date().timeIntervalSince(started))
+        }
+        let now = Date()
+        if now >= deadline {
+            if escalationStartedAt == nil {
+                escalationStartedAt = now
+                kill(-pid, SIGKILL)
+            } else if now.timeIntervalSince(escalationStartedAt!) >= 1.0 {
+                return (128 + SIGKILL, Date().timeIntervalSince(started))
+            }
+        }
+        usleep(10_000)
+    }
+}
+
+print("F007 waitpid deadline proof")
+let pid = spawnSleepForever()
+print("  spawned unkillable-TERM child pid=\(pid)")
+let deadline = Date().addingTimeInterval(0.3)
+let (code, elapsed) = waitWithDeadline(pid: pid, deadline: deadline)
+print("  fixed wait returned code=\(code) elapsed=\(String(format: "%.2f", elapsed))s")
+print("  expected: returns within ~1.5s of deadline, not hang forever")
+// reap if still around
+kill(-pid, SIGKILL)
+var st: Int32 = 0
+_ = waitpid(pid, &st, 0)
+let ok = elapsed < 2.5
+print(ok ? "PROOF_OK" : "PROOF_FAIL")
+exit(ok ? 0 : 1)

--- a/scripts/prove-action-process-deadline.swift
+++ b/scripts/prove-action-process-deadline.swift
@@ -71,5 +71,66 @@ kill(-pid, SIGKILL)
 var st: Int32 = 0
 _ = waitpid(pid, &st, 0)
 let ok = elapsed < 2.5
-print(ok ? "PROOF_OK" : "PROOF_FAIL")
-exit(ok ? 0 : 1)
+
+if !ok {
+    print("PROOF_FAIL hang bound")
+    exit(1)
+}
+print("PROOF_OK hang bound (deadline waiter returned)")
+
+// --- TERM grace proof (ClawSweeper P1) ---
+// Fixed wait must not SIGKILL immediately on timeout so a TERM-trapping child can exit 0.
+func spawnGracefulTermChild() -> pid_t {
+    var pid: pid_t = 0
+    var fileActions: posix_spawn_file_actions_t?
+    posix_spawn_file_actions_init(&fileActions)
+    defer { posix_spawn_file_actions_destroy(&fileActions) }
+    var attrs: posix_spawnattr_t?
+    posix_spawnattr_init(&attrs)
+    defer { posix_spawnattr_destroy(&attrs) }
+    posix_spawnattr_setflags(&attrs, Int16(POSIX_SPAWN_SETPGROUP))
+    posix_spawnattr_setpgroup(&attrs, 0)
+    let args = ["/bin/sh", "-c", "trap 'exit 0' TERM; while true; do sleep 0.05; done"]
+    var argv = args.map { strdup($0) } + [nil]
+    defer { for p in argv { free(p) } }
+    let rc = "/bin/sh".withCString { path in
+        posix_spawnp(&pid, path, &fileActions, &attrs, &argv, environ)
+    }
+    precondition(rc == 0, "spawn graceful failed \(rc)")
+    return pid
+}
+
+print("F007 TERM grace proof")
+let gracePid = spawnGracefulTermChild()
+print("  spawned TERM-handling child pid=\(gracePid)")
+usleep(150_000)
+// Simulate terminateAfterTimeout: SIGTERM first; waiter must not SIGKILL during 500ms grace.
+kill(-gracePid, SIGTERM)
+print("  sent SIGTERM (timeout path)")
+let graceDeadline = Date().addingTimeInterval(0.5)
+var graceStatus: Int32 = 0
+var graceReaped = false
+var graceCode: Int32 = -1
+while Date() < graceDeadline {
+    let r = waitpid(gracePid, &graceStatus, WNOHANG)
+    if r == gracePid {
+        graceReaped = true
+        let signal = graceStatus & 0x7F
+        graceCode = signal == 0 ? ((graceStatus >> 8) & 0xFF) : (128 + signal)
+        break
+    }
+    usleep(10_000)
+}
+print("  reaped_during_grace=\(graceReaped) exitCode=\(graceCode)")
+if !graceReaped {
+    kill(-gracePid, SIGKILL)
+    _ = waitpid(gracePid, &graceStatus, 0)
+    print("PROOF_FAIL graceful child not reaped during 500ms TERM window")
+    exit(1)
+}
+if graceCode != 0 {
+    print("PROOF_FAIL expected exit 0 from TERM trap, got \(graceCode)")
+    exit(1)
+}
+print("PROOF_OK TERM grace preserved (child exited cleanly during grace)")
+exit(0)

--- a/scripts/prove-action-process-deadline.swift
+++ b/scripts/prove-action-process-deadline.swift
@@ -24,7 +24,11 @@ func spawnSleepForever() -> pid_t {
     return pid
 }
 
-func waitWithDeadline(pid: pid_t, deadline: Date) -> (code: Int32, elapsed: Double) {
+func waitWithDeadline(
+    pid: pid_t,
+    deadline: Date,
+    deliverWaitLoopKill: Bool = true) -> (code: Int32, elapsed: Double)
+{
     let started = Date()
     var status: Int32 = 0
     var didSendWaitLoopKill = false
@@ -36,7 +40,9 @@ func waitWithDeadline(pid: pid_t, deadline: Date) -> (code: Int32, elapsed: Doub
         let now = Date()
         if !didSendWaitLoopKill, now >= deadline.addingTimeInterval(-1.0) {
             didSendWaitLoopKill = true
-            kill(-pid, SIGKILL)
+            if deliverWaitLoopKill {
+                kill(-pid, SIGKILL)
+            }
         }
         if now >= deadline {
             return (128 + SIGKILL, Date().timeIntervalSince(started))
@@ -52,14 +58,17 @@ usleep(150_000)
 kill(-pid, SIGTERM)
 print("  sent SIGTERM")
 let deadline = Date().addingTimeInterval(1.6)
-let (code, elapsed) = waitWithDeadline(pid: pid, deadline: deadline)
+let (code, elapsed) = waitWithDeadline(
+    pid: pid,
+    deadline: deadline,
+    deliverWaitLoopKill: false)
 print("  fixed wait returned code=\(code) elapsed=\(String(format: "%.2f", elapsed))s")
-print("  expected: returns before final abandon deadline, not hang forever")
+print("  expected: returns by final abandon deadline, not hang forever")
 // reap if still around
 kill(-pid, SIGKILL)
 var st: Int32 = 0
 _ = waitpid(pid, &st, 0)
-let ok = elapsed < 2.5 && elapsed >= 0.5
+let ok = code == 128 + SIGKILL && elapsed < 2.5 && elapsed >= 1.5
 
 if !ok {
     print("PROOF_FAIL hang bound")

--- a/scripts/prove-action-process-deadline.swift
+++ b/scripts/prove-action-process-deadline.swift
@@ -14,7 +14,9 @@ func spawnSleepForever() -> pid_t {
     posix_spawnattr_setpgroup(&attrs, 0)
     let args = ["/bin/sh", "-c", "trap '' TERM; while true; do sleep 1; done"]
     var argv = args.map { strdup($0) } + [nil]
-    defer { for p in argv { free(p) } }
+    defer { for p in argv {
+        free(p)
+    } }
     let rc = "/bin/sh".withCString { path in
         posix_spawnp(&pid, path, &fileActions, &attrs, &argv, environ)
     }
@@ -22,64 +24,52 @@ func spawnSleepForever() -> pid_t {
     return pid
 }
 
-func waitBlockingNoDeadline(pid: pid_t, maxSeconds: Double) -> (reaped: Bool, elapsed: Double) {
-    // Simulate old behavior: blocking waitpid cannot observe a deadline while blocked.
-    // We approximate by attempting a timed race: if still not reaped after maxSeconds, hang risk.
-    let started = Date()
-    var status: Int32 = 0
-    // Use a short alarm-like approach: poll WNOHANG only after "would have blocked"
-    // For demonstration of FIXED path only.
-    while Date().timeIntervalSince(started) < maxSeconds {
-        let r = waitpid(pid, &status, WNOHANG)
-        if r == pid { return (true, Date().timeIntervalSince(started)) }
-        usleep(10_000)
-    }
-    return (false, Date().timeIntervalSince(started))
-}
-
 func waitWithDeadline(pid: pid_t, deadline: Date) -> (code: Int32, elapsed: Double) {
     let started = Date()
     var status: Int32 = 0
-    var escalationStartedAt: Date?
+    var didSendWaitLoopKill = false
     while true {
         let r = waitpid(pid, &status, WNOHANG)
         if r == pid {
             return (status, Date().timeIntervalSince(started))
         }
         let now = Date()
-        if now >= deadline {
-            if escalationStartedAt == nil {
-                escalationStartedAt = now
-                kill(-pid, SIGKILL)
-            } else if now.timeIntervalSince(escalationStartedAt!) >= 1.0 {
-                return (128 + SIGKILL, Date().timeIntervalSince(started))
-            }
+        if !didSendWaitLoopKill, now >= deadline.addingTimeInterval(-1.0) {
+            didSendWaitLoopKill = true
+            kill(-pid, SIGKILL)
         }
-        usleep(10_000)
+        if now >= deadline {
+            return (128 + SIGKILL, Date().timeIntervalSince(started))
+        }
+        usleep(10000)
     }
 }
 
 print("F007 waitpid deadline proof")
 let pid = spawnSleepForever()
 print("  spawned unkillable-TERM child pid=\(pid)")
-let deadline = Date().addingTimeInterval(0.3)
+usleep(150_000)
+kill(-pid, SIGTERM)
+print("  sent SIGTERM")
+let deadline = Date().addingTimeInterval(1.6)
 let (code, elapsed) = waitWithDeadline(pid: pid, deadline: deadline)
 print("  fixed wait returned code=\(code) elapsed=\(String(format: "%.2f", elapsed))s")
-print("  expected: returns within ~1.5s of deadline, not hang forever")
+print("  expected: returns before final abandon deadline, not hang forever")
 // reap if still around
 kill(-pid, SIGKILL)
 var st: Int32 = 0
 _ = waitpid(pid, &st, 0)
-let ok = elapsed < 2.5
+let ok = elapsed < 2.5 && elapsed >= 0.5
 
 if !ok {
     print("PROOF_FAIL hang bound")
     exit(1)
 }
+
 print("PROOF_OK hang bound (deadline waiter returned)")
 
-// --- TERM grace proof (ClawSweeper P1) ---
-// Fixed wait must not SIGKILL immediately on timeout so a TERM-trapping child can exit 0.
+/// --- TERM grace proof (ClawSweeper P1) ---
+/// Fixed wait must not SIGKILL immediately on timeout so a TERM-trapping child can exit 0.
 func spawnGracefulTermChild() -> pid_t {
     var pid: pid_t = 0
     var fileActions: posix_spawn_file_actions_t?
@@ -92,7 +82,9 @@ func spawnGracefulTermChild() -> pid_t {
     posix_spawnattr_setpgroup(&attrs, 0)
     let args = ["/bin/sh", "-c", "trap 'exit 0' TERM; while true; do sleep 0.05; done"]
     var argv = args.map { strdup($0) } + [nil]
-    defer { for p in argv { free(p) } }
+    defer { for p in argv {
+        free(p)
+    } }
     let rc = "/bin/sh".withCString { path in
         posix_spawnp(&pid, path, &fileActions, &attrs, &argv, environ)
     }
@@ -119,8 +111,9 @@ while Date() < graceDeadline {
         graceCode = signal == 0 ? ((graceStatus >> 8) & 0xFF) : (128 + signal)
         break
     }
-    usleep(10_000)
+    usleep(10000)
 }
+
 print("  reaped_during_grace=\(graceReaped) exitCode=\(graceCode)")
 if !graceReaped {
     kill(-gracePid, SIGKILL)
@@ -128,9 +121,32 @@ if !graceReaped {
     print("PROOF_FAIL graceful child not reaped during 500ms TERM window")
     exit(1)
 }
+
 if graceCode != 0 {
     print("PROOF_FAIL expected exit 0 from TERM trap, got \(graceCode)")
     exit(1)
 }
+
 print("PROOF_OK TERM grace preserved (child exited cleanly during grace)")
+
+// --- Cancellation deadline proof ---
+// A cancelled long-timeout action must not wait for the original timeout. It keeps the
+// same TERM grace, then falls back to SIGKILL and returns quickly.
+print("F007 cancellation deadline proof")
+let cancelPid = spawnSleepForever()
+print("  spawned TERM-ignoring child pid=\(cancelPid)")
+usleep(150_000)
+kill(-cancelPid, SIGTERM)
+print("  sent SIGTERM (cancellation path)")
+let cancelDeadline = Date().addingTimeInterval(1.6)
+let (cancelCode, cancelElapsed) = waitWithDeadline(pid: cancelPid, deadline: cancelDeadline)
+print("  fixed wait returned code=\(cancelCode) elapsed=\(String(format: "%.2f", cancelElapsed))s")
+kill(-cancelPid, SIGKILL)
+_ = waitpid(cancelPid, &st, 0)
+if cancelElapsed >= 2.5 || cancelElapsed < 0.5 {
+    print("PROOF_FAIL cancellation deadline")
+    exit(1)
+}
+
+print("PROOF_OK cancellation bound preserved")
 exit(0)


### PR DESCRIPTION
## Summary

`CaptureActionProcessRunner` used blocking `waitpid(..., 0)`. If a child survived TERM/KILL delivery, `peekaboo capture action` could wait forever even after its timeout or parent-task cancellation.

This PR now:

- polls `waitpid` with `WNOHANG` instead of blocking indefinitely;
- preserves the existing SIGTERM + 500 ms grace before SIGKILL for both timeout and cancellation;
- caps cancellation relative to the cancellation time instead of the original command timeout;
- returns at a final hard deadline if the child still cannot be reaped;
- transfers an abandoned child to a detached nonblocking reaper, avoiding a later zombie when it finally exits;
- records the user-visible reliability fix in both changelogs.

## Failure scenario

1. `capture action` launches a subprocess.
2. Timeout or cancellation sends SIGTERM, then SIGKILL after the grace window.
3. Signal delivery fails or the child remains temporarily uninterruptible.
4. The old blocking waiter never returns.

## Verification

- `swift scripts/prove-action-process-deadline.swift` — bounded failed-kill path, TERM grace, and cancellation bound all report `PROOF_OK`.
- `swift test --package-path Apps/CLI -Xswiftc -DPEEKABOO_SKIP_AUTOMATION --no-parallel --filter CaptureActionProcessRunnerTests` — 9 tests passed.
- `pnpm run test:safe` — 633 tests passed.
- `pnpm run format` — clean.
- `pnpm run lint` — 0 serious violations; existing repository warnings only.
- `autoreview --mode branch --base origin/main --parallel-tests "pnpm run test:safe" --stream-engine-output` — clean; no accepted/actionable findings.

The deterministic failed-signal regression injects ignored TERM/KILL delivery, verifies bounded return, makes the child killable again, and confirms the background reaper removes it.

## Scope

Runner-level process lifecycle only. No provider, permission, or UI behavior changed; live UI capture was not required for this subprocess failure mode.
