### PR TITLE
fix(watermark): do not report recovered orphans as live mutations

### DIFF
--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Support/DesktopMutationWatermarkStore.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Support/DesktopMutationWatermarkStore.swift
@@ -372,6 +372,8 @@ public final class DesktopMutationWatermarkStore: @unchecked Sendable {
             at: self.pendingDirectoryURL,
             includingPropertiesForKeys: nil,
             options: [.skipsHiddenFiles])
+        // Match `hasPendingMutationUnlocked`: only live owner processes count as pending.
+        // Orphans are recovered and must not keep blocking observation preservation.
         var foundOtherMutation = false
         for url in urls where url.standardizedFileURL != ownURL.standardizedFileURL {
             guard let record = self.readPendingRecordUnlocked(at: url) else {
@@ -382,14 +384,24 @@ public final class DesktopMutationWatermarkStore: @unchecked Sendable {
                 self.removeResolvedPendingRecordBestEffort(at: url)
                 continue
             }
-            foundOtherMutation = true
-            guard !self.processMatches(record) else { continue }
+            if self.processMatches(record) {
+                foundOtherMutation = true
+                continue
+            }
             try self.resolveOrphanedPendingRecordUnlocked(
                 record,
                 at: url,
                 recoveredAt: Date())
         }
         return foundOtherMutation
+    }
+
+    /// Whether other *live* pending mutations exist after orphan recovery (test seam).
+    /// Uses the same lock and rules as `completeMutation`.
+    func hasOtherLivePendingMutation(excluding mutation: PendingMutation) throws -> Bool {
+        try self.withLock(operation: LOCK_EX) {
+            try self.hasOtherPendingMutationUnlocked(excluding: mutation)
+        }
     }
 
     private func resolveOrphanedPendingRecordUnlocked(

--- a/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/DesktopMutationWatermarkStoreTests.swift
+++ b/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/DesktopMutationWatermarkStoreTests.swift
@@ -314,11 +314,10 @@ struct DesktopMutationWatermarkStoreTests {
         #expect(hasOther == false)
 
         let pendingDirectory = root.appendingPathComponent("desktop-mutation-pending", isDirectory: true)
-        let peerFiles = try FileManager.default.contentsOfDirectory(
+        let pendingFiles = try FileManager.default.contentsOfDirectory(
             at: pendingDirectory,
             includingPropertiesForKeys: nil)
-            .filter { $0.deletingPathExtension().lastPathComponent.lowercased() != live.id.uuidString.lowercased() }
-        #expect(peerFiles.isEmpty)
+        #expect(pendingFiles.count == 1)
     }
 
     @Test

--- a/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/DesktopMutationWatermarkStoreTests.swift
+++ b/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/DesktopMutationWatermarkStoreTests.swift
@@ -293,9 +293,32 @@ struct DesktopMutationWatermarkStoreTests {
             completingMutation,
             through: olderCompletionCutoff)
 
+        // Orphan recovery advances the completion generation, so preservation is still denied
+        // for a different reason than "peer still pending".
         #expect(!completion.allowsObservationPreservation)
         #expect(completion.cutoff >= beforeRecovery)
         #expect(store.effectiveWatermark() == completion.cutoff)
+    }
+
+    @Test
+    func `orphan peers are not counted as other live pending mutations`() throws {
+        let root = Self.temporaryDirectory(named: "orphan-not-live-peer")
+        defer { try? FileManager.default.removeItem(at: root) }
+        let store = DesktopMutationWatermarkStore(directoryURL: root)
+        let live = try store.beginMutation()
+        _ = try store.beginMutation(at: Date(), ownerProcessIdentifier: pid_t.max)
+
+        // Before the fix, hasOtherPendingMutationUnlocked set foundOtherMutation=true before
+        // resolving the orphan, so this returned true even after cleanup.
+        let hasOther = try store.hasOtherLivePendingMutation(excluding: live)
+        #expect(hasOther == false)
+
+        let pendingDirectory = root.appendingPathComponent("desktop-mutation-pending", isDirectory: true)
+        let peerFiles = try FileManager.default.contentsOfDirectory(
+            at: pendingDirectory,
+            includingPropertiesForKeys: nil)
+            .filter { $0.deletingPathExtension().lastPathComponent.lowercased() != live.id.uuidString.lowercased() }
+        #expect(peerFiles.isEmpty)
     }
 
     @Test

--- a/scripts/prove-orphan-pending-mutation.swift
+++ b/scripts/prove-orphan-pending-mutation.swift
@@ -1,7 +1,7 @@
 #!/usr/bin/env swift
 import Foundation
 
-// Minimal model of the pending-mutation peer scan.
+/// Minimal model of the pending-mutation peer scan.
 struct Record { let processMatches: Bool; var resolved: Bool = false }
 
 func buggyHasOther(peers: inout [Record]) -> Bool {

--- a/scripts/prove-orphan-pending-mutation.swift
+++ b/scripts/prove-orphan-pending-mutation.swift
@@ -1,0 +1,58 @@
+#!/usr/bin/env swift
+import Foundation
+
+// Minimal model of the pending-mutation peer scan.
+struct Record { let processMatches: Bool; var resolved: Bool = false }
+
+func buggyHasOther(peers: inout [Record]) -> Bool {
+    var found = false
+    for i in peers.indices {
+        if peers[i].resolved { continue }
+        // BUG: set found before orphan resolution
+        found = true
+        if peers[i].processMatches { continue }
+        peers[i].resolved = true // orphan recovered
+    }
+    return found
+}
+
+func fixedHasOther(peers: inout [Record]) -> Bool {
+    var found = false
+    for i in peers.indices {
+        if peers[i].resolved { continue }
+        if peers[i].processMatches {
+            found = true
+            continue
+        }
+        peers[i].resolved = true // orphan recovered, do not count as live pending
+    }
+    return found
+}
+
+var orphanOnlyBuggy = [Record(processMatches: false)]
+var orphanOnlyFixed = [Record(processMatches: false)]
+let buggy = buggyHasOther(peers: &orphanOnlyBuggy)
+let fixed = fixedHasOther(peers: &orphanOnlyFixed)
+
+print("orphan-only peer scan")
+print("  buggy returns hasOther=\(buggy) (expected true — incorrect after orphan cleanup)")
+print("  fixed returns hasOther=\(fixed) (expected false — orphan recovered, not live)")
+print("  orphan resolved buggy=\(orphanOnlyBuggy[0].resolved) fixed=\(orphanOnlyFixed[0].resolved)")
+
+var liveBuggy = [Record(processMatches: true)]
+var liveFixed = [Record(processMatches: true)]
+let buggyLive = buggyHasOther(peers: &liveBuggy)
+let fixedLive = fixedHasOther(peers: &liveFixed)
+print("live peer scan")
+print("  buggy returns hasOther=\(buggyLive) fixed=\(fixedLive) (both expected true)")
+
+var mixedBuggy = [Record(processMatches: false), Record(processMatches: true)]
+var mixedFixed = [Record(processMatches: false), Record(processMatches: true)]
+let buggyMixed = buggyHasOther(peers: &mixedBuggy)
+let fixedMixed = fixedHasOther(peers: &mixedFixed)
+print("mixed orphan+live")
+print("  buggy=\(buggyMixed) fixed=\(fixedMixed) (both expected true because live remains)")
+
+let ok = (buggy == true && fixed == false && buggyLive && fixedLive && buggyMixed && fixedMixed)
+print(ok ? "PROOF_OK" : "PROOF_FAIL")
+exit(ok ? 0 : 1)


### PR DESCRIPTION
## Summary

Corrects the desktop mutation watermark peer scan so recovered orphan records are not reported as live competing mutations. This aligns `hasOtherPendingMutationUnlocked` with the sibling `hasPendingMutationUnlocked` policy: unreadable records remain fail-closed, live owners count as pending, and dead owners are recovered without remaining in the live-peer result.

Orphan recovery still advances the completion generation, so `completeMutation` currently denies observation preservation for that independent generation-mismatch reason. This PR corrects the internal live-peer invariant and protects it directly; it does not claim a new user-visible preservation outcome.

## Changes

- Set `foundOtherMutation` only for unreadable records and owners that still match a live process.
- Recover dead-owner records without counting them as live competitors.
- Add a locked internal test seam and regression coverage that verifies the orphan is removed while the caller's live record remains.
- Keep the standalone decision-loop proof for the orphan-only, live-only, and mixed cases.

## Maintainer fixup

The original regression test did not compile because it accessed the `fileprivate` mutation ID from another file. Head `3c65e498ce6582470039721790b10ad0d288f805` verifies the observable directory invariant instead: exactly the caller's live record remains after orphan recovery.

## Proof

- `pnpm run format`
- `pnpm run lint` (0 serious violations; existing warnings only)
- Focused orphan regression: 1 test passed
- `swift test --package-path Core/PeekabooAutomationKit --no-parallel`: 199 tests passed, 1 environment-dependent skip
- `pnpm run test:safe`: 633 tests passed
- `swift scripts/prove-orphan-pending-mutation.swift`: `PROOF_OK`
- Full branch and maintainer-fix Codex autoreviews: clean, no accepted/actionable findings
