### PR TITLE
feat(mac): redesign Sessions window with native Liquid Glass and a new ghost

### DIFF
--- a/Apps/Mac/Peekaboo/Features/Main/SessionChatView.swift
+++ b/Apps/Mac/Peekaboo/Features/Main/SessionChatView.swift
@@ -329,27 +329,53 @@ struct ConnectionErrorBanner: View {
 
 struct EmptySessionView: View {
     @Environment(SessionStore.self) private var sessionStore
+    @Environment(\.colorScheme) private var colorScheme
 
     var body: some View {
-        VStack(spacing: 20) {
-            GhostImageView(state: .idle, size: CGSize(width: 80, height: 80))
-                .opacity(0.5)
+        VStack(spacing: 0) {
+            AnimatedGhostView(size: 108)
+                .padding(.bottom, 28)
 
             Text("No Session Selected")
-                .font(.title2)
-                .foregroundColor(.secondary)
+                .font(.title2.weight(.semibold))
 
-            Text("Select a session from the sidebar or create a new one")
-                .font(.body)
-                .foregroundColor(.secondary)
+            Text("Choose a session from the sidebar, or start a new conversation with Peekaboo.")
+                .font(.callout)
+                .foregroundStyle(.secondary)
                 .multilineTextAlignment(.center)
+                .frame(maxWidth: 320)
+                .padding(.top, 8)
 
-            Button(action: { _ = self.sessionStore.createSession(title: "New Session") }, label: {
-                Label("New Session", systemImage: "plus.circle")
-            })
-            .buttonStyle(.borderedProminent)
-            .controlSize(.large)
+            self.newSessionButton
+                .padding(.top, 28)
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background {
+            // Soft accent glow behind the ghost gives the glass something to refract.
+            RadialGradient(
+                colors: [Color.accentColor.opacity(self.colorScheme == .dark ? 0.16 : 0.10), .clear],
+                center: UnitPoint(x: 0.5, y: 0.35),
+                startRadius: 20,
+                endRadius: 340)
+                .ignoresSafeArea()
+        }
+    }
+
+    @ViewBuilder
+    private var newSessionButton: some View {
+        let button = Button {
+            _ = self.sessionStore.createSession(title: "New Session")
+        } label: {
+            Label("New Session", systemImage: "plus")
+                .padding(.horizontal, 6)
+                .padding(.vertical, 2)
+        }
+        .controlSize(.large)
+
+        if #available(macOS 26.0, *) {
+            button.buttonStyle(.glassProminent)
+        } else {
+            button.buttonStyle(.borderedProminent)
+        }
     }
 }

--- a/Apps/Mac/Peekaboo/Features/Main/SessionSidebar.swift
+++ b/Apps/Mac/Peekaboo/Features/Main/SessionSidebar.swift
@@ -26,92 +26,66 @@ struct SessionSidebar: View {
     }
 
     var body: some View {
-        VStack(spacing: 0) {
-            // Header
-            HStack {
-                Text("Sessions")
-                    .font(.headline)
-
-                Spacer()
-
-                Button(action: self.createNewSession, label: {
-                    Image(systemName: "plus")
-                })
-                .buttonStyle(.plain)
-                .help("New Session")
-            }
-            .padding(.horizontal)
-            .padding(.vertical, 8)
-
-            // Search
-            HStack {
-                Image(systemName: "magnifyingglass")
-                    .foregroundColor(.secondary)
-                TextField("Search sessions...", text: self.$searchText)
-                    .textFieldStyle(.plain)
-                if !self.searchText.isEmpty {
-                    Button(action: { self.searchText = "" }, label: {
-                        Image(systemName: "xmark.circle.fill")
-                            .foregroundColor(.secondary)
-                    })
-                    .buttonStyle(.plain)
+        List(self.filteredSessions, selection: self.$selectedSessionId) { session in
+            SessionRow(
+                session: session,
+                isActive: self.agent.currentSession?.id == session.id)
+                .tag(session.id)
+                .swipeActions(edge: .trailing, allowsFullSwipe: true) {
+                    Button(role: .destructive) {
+                        self.deleteSession(session)
+                    } label: {
+                        Label("Delete", systemImage: "trash")
+                    }
+                }
+                .contextMenu {
+                    Button("Duplicate") {
+                        self.duplicateSession(session)
+                    }
+                    Button("Export…") {
+                        self.exportSession(session)
+                    }
+                    Divider()
+                    Button("Delete", role: .destructive) {
+                        self.deleteSession(session)
+                    }
+                }
+        }
+        .listStyle(.sidebar)
+        .searchable(text: self.$searchText, prompt: "Search Sessions")
+        .overlay {
+            if self.filteredSessions.isEmpty {
+                if self.searchText.isEmpty {
+                    ContentUnavailableView {
+                        Label {
+                            Text("No Sessions")
+                        } icon: {
+                            GhostImageView(state: .idle, size: CGSize(width: 56, height: 56))
+                        }
+                    } description: {
+                        Text("Conversations with Peekaboo will appear here.")
+                    }
+                } else {
+                    ContentUnavailableView.search(text: self.searchText)
                 }
             }
-            .padding(6)
-            .background(Color(NSColor.controlBackgroundColor))
-            .cornerRadius(6)
-            .padding(.horizontal)
-            .padding(.bottom, 8)
-
-            Divider()
-
-            // Session list
-            List(self.filteredSessions, selection: self.$selectedSessionId) { session in
-                SessionRow(
-                    session: session,
-                    isActive: self.agent.currentSession?.id == session.id,
-                    onDelete: { self.deleteSession(session) })
-                    .tag(session.id)
-                    .transition(.asymmetric(
-                        insertion: .slide.combined(with: .opacity),
-                        removal: .opacity))
-                    .animation(.spring(response: 0.3, dampingFraction: 0.8), value: self.filteredSessions.count)
-                    .swipeActions(edge: .trailing, allowsFullSwipe: true) {
-                        Button(role: .destructive) {
-                            self.deleteSession(session)
-                        } label: {
-                            Label("Delete", systemImage: "trash")
-                        }
-                        .tint(.red)
-                    }
-                    .contextMenu {
-                        Button("Delete") {
-                            self.deleteSession(session)
-                        }
-                        Button("Duplicate") {
-                            self.duplicateSession(session)
-                        }
-                        Divider()
-                        Button("Export...") {
-                            self.exportSession(session)
-                        }
-                    }
-            }
-            .listStyle(.sidebar)
-            .scrollContentBackground(.hidden)
-            .safeAreaInset(edge: .top) {
-                // Add padding at the top of the list content
-                Color.clear
-                    .frame(height: 8)
-            }
-            .onDeleteCommand {
-                // Delete the currently selected session
-                if let selectedId = selectedSessionId,
-                   let session = sessionStore.sessions.first(where: { $0.id == selectedId }),
-                   session.id != agent.currentSession?.id
-                {
-                    self.deleteSession(session)
+        }
+        .toolbar {
+            ToolbarItem {
+                Button(action: self.createNewSession) {
+                    Label("New Session", systemImage: "square.and.pencil")
                 }
+                .keyboardShortcut("n", modifiers: .command)
+                .help("New Session (⌘N)")
+            }
+        }
+        .onDeleteCommand {
+            // Delete the currently selected session
+            if let selectedId = selectedSessionId,
+               let session = sessionStore.sessions.first(where: { $0.id == selectedId }),
+               session.id != agent.currentSession?.id
+            {
+                self.deleteSession(session)
             }
         }
     }
@@ -179,71 +153,56 @@ struct SessionSidebar: View {
 struct SessionRow: View {
     let session: ConversationSession
     let isActive: Bool
-    let onDelete: () -> Void
-    @State private var isHovering = false
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 4) {
-            HStack {
-                Text(self.session.title)
-                    .font(.body)
-                    .fontWeight(self.isActive ? .semibold : .regular)
-                    .lineLimit(1)
-
+        VStack(alignment: .leading, spacing: 3) {
+            HStack(alignment: .firstTextBaseline, spacing: 6) {
                 if self.isActive {
                     Image(systemName: "circle.fill")
-                        .font(.system(size: 8))
-                        .foregroundColor(.green)
+                        .font(.system(size: 7))
+                        .foregroundStyle(.green)
                         .symbolEffect(.pulse, options: .repeating)
                 }
 
-                Spacer()
+                Text(self.session.title)
+                    .fontWeight(self.isActive ? .semibold : .regular)
+                    .lineLimit(1)
 
-                // Delete button on hover
-                if self.isHovering, !self.isActive {
-                    Button(action: self.onDelete) {
-                        Image(systemName: "trash")
-                            .font(.caption)
-                            .foregroundColor(.secondary)
-                    }
-                    .buttonStyle(.plain)
-                    .help("Delete session")
-                }
-            }
+                Spacer(minLength: 8)
 
-            HStack {
-                Text(self.session.startTime, style: .relative)
+                Text(
+                    self.session.startTime,
+                    format: .relative(presentation: .named, unitsStyle: .abbreviated))
                     .font(.caption)
-                    .foregroundColor(.secondary)
-
-                if !self.session.messages.isEmpty {
-                    Text("•")
-                        .foregroundColor(.secondary)
-                    Text("\(self.session.messages.count) messages")
-                        .font(.caption)
-                        .foregroundColor(.secondary)
-                }
-
-                if !self.session.modelName.isEmpty {
-                    Text("•")
-                        .foregroundColor(.secondary)
-                    Text(formatModelName(self.session.modelName))
-                        .font(.caption)
-                        .foregroundColor(.secondary)
-                }
+                    .foregroundStyle(.tertiary)
+                    .lineLimit(1)
             }
 
             if !self.session.summary.isEmpty {
                 Text(self.session.summary)
                     .font(.caption)
-                    .foregroundColor(.secondary)
+                    .foregroundStyle(.secondary)
                     .lineLimit(2)
-                    .padding(.top, 2)
             }
+
+            HStack(spacing: 6) {
+                if !self.session.messages.isEmpty {
+                    Text("^[\(self.session.messages.count) message](inflect: true)")
+                        .font(.caption2)
+                        .foregroundStyle(.tertiary)
+                }
+
+                if !self.session.modelName.isEmpty {
+                    Text(formatModelName(self.session.modelName))
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                        .padding(.horizontal, 6)
+                        .padding(.vertical, 1.5)
+                        .background(.quaternary.opacity(0.6), in: Capsule())
+                }
+            }
+            .padding(.top, 2)
         }
         .padding(.vertical, 4)
-        .onHover { hovering in
-            self.isHovering = hovering
-        }
     }
 }

--- a/Apps/Mac/Peekaboo/Features/StatusBar/GhostImageView.swift
+++ b/Apps/Mac/Peekaboo/Features/StatusBar/GhostImageView.swift
@@ -1,5 +1,66 @@
 import SwiftUI
 
+// MARK: - Ghost Silhouette
+
+/// The Peekaboo ghost silhouette: a smooth dome with gently flared sides and a
+/// three-scoop scalloped hem. Drawn in normalized coordinates so it scales from
+/// menu-bar sizes up to the empty-state hero.
+struct GhostShape: Shape {
+    func path(in rect: CGRect) -> Path {
+        let width = rect.width
+        let height = rect.height
+
+        func point(_ x: CGFloat, _ y: CGFloat) -> CGPoint {
+            CGPoint(x: rect.minX + x * width, y: rect.minY + y * height)
+        }
+
+        var path = Path()
+        path.move(to: point(0.5, 0.02))
+        // Dome, right half
+        path.addCurve(to: point(0.94, 0.40), control1: point(0.76, 0.02), control2: point(0.94, 0.18))
+        // Right side, flaring gently into the hem
+        path.addCurve(to: point(0.92, 0.965), control1: point(0.945, 0.60), control2: point(0.975, 0.84))
+        // Scalloped hem: three scoops between four tips
+        path.addCurve(to: point(0.64, 0.965), control1: point(0.85, 0.845), control2: point(0.71, 0.845))
+        path.addCurve(to: point(0.36, 0.965), control1: point(0.57, 0.845), control2: point(0.43, 0.845))
+        path.addCurve(to: point(0.08, 0.965), control1: point(0.29, 0.845), control2: point(0.15, 0.845))
+        // Left side back up to the dome
+        path.addCurve(to: point(0.06, 0.40), control1: point(0.025, 0.84), control2: point(0.055, 0.60))
+        path.addCurve(to: point(0.5, 0.02), control1: point(0.06, 0.18), control2: point(0.24, 0.02))
+        path.closeSubpath()
+        return path
+    }
+}
+
+// MARK: - Ghost Eyes
+
+/// Capsule eyes positioned relative to the ghost silhouette. `glance` shifts
+/// both pupils sideways (-1 left … 1 right); `wide` is the startled look.
+/// Color comes from the environment foreground style.
+struct GhostEyesView: View {
+    var glance: CGFloat = 0
+    var wide = false
+
+    var body: some View {
+        GeometryReader { geometry in
+            let width = geometry.size.width
+            let height = geometry.size.height
+            let eyeWidth = width * (self.wide ? 0.115 : 0.10)
+            let eyeHeight = height * (self.wide ? 0.20 : 0.17)
+            let shift = self.glance * width * 0.045
+
+            Capsule(style: .continuous)
+                .frame(width: eyeWidth, height: eyeHeight)
+                .position(x: width * 0.38 + shift, y: height * 0.40)
+            Capsule(style: .continuous)
+                .frame(width: eyeWidth, height: eyeHeight)
+                .position(x: width * 0.62 + shift, y: height * 0.40)
+        }
+    }
+}
+
+// MARK: - Ghost Image
+
 /// A SwiftUI view that provides ghost images for different states
 struct GhostImageView: View {
     enum GhostState {
@@ -19,116 +80,115 @@ struct GhostImageView: View {
     }
 
     var body: some View {
-        Canvas { context, canvasSize in
-            // Center point for drawing (for future use)
-            _ = CGPoint(x: canvasSize.width / 2, y: canvasSize.height / 2)
-
-            // Scale to fit the requested size
-            let scale = min(canvasSize.width / 20, canvasSize.height / 20)
-            context.scaleBy(x: scale, y: scale)
-
-            // Ghost color based on appearance
-            let ghostColor = self.colorScheme == .dark ? Color.white : Color.black
-
-            // Draw ghost body
-            let bodyPath = Path { path in
-                // Circular top
-                path.addArc(
-                    center: CGPoint(x: 10, y: 10),
-                    radius: 6,
-                    startAngle: .radians(.pi),
-                    endAngle: .radians(0),
-                    clockwise: false)
-
-                // Body sides
-                path.addLine(to: CGPoint(x: 16, y: 14))
-
-                // Bottom waves
-                path.addLine(to: CGPoint(x: 16, y: 16))
-
-                // Wave pattern at bottom
-                path.addCurve(
-                    to: CGPoint(x: 14, y: 17),
-                    control1: CGPoint(x: 16, y: 17),
-                    control2: CGPoint(x: 15, y: 17))
-                path.addCurve(
-                    to: CGPoint(x: 12, y: 16),
-                    control1: CGPoint(x: 13, y: 17),
-                    control2: CGPoint(x: 12, y: 17))
-                path.addCurve(
-                    to: CGPoint(x: 10, y: 17),
-                    control1: CGPoint(x: 12, y: 17),
-                    control2: CGPoint(x: 11, y: 17))
-                path.addCurve(
-                    to: CGPoint(x: 8, y: 16),
-                    control1: CGPoint(x: 9, y: 17),
-                    control2: CGPoint(x: 8, y: 17))
-                path.addCurve(
-                    to: CGPoint(x: 6, y: 17),
-                    control1: CGPoint(x: 8, y: 17),
-                    control2: CGPoint(x: 7, y: 17))
-                path.addCurve(
-                    to: CGPoint(x: 4, y: 16),
-                    control1: CGPoint(x: 5, y: 17),
-                    control2: CGPoint(x: 4, y: 17))
-
-                // Complete the body
-                path.addLine(to: CGPoint(x: 4, y: 14))
-                path.addLine(to: CGPoint(x: 4, y: 10))
-                path.closeSubpath()
+        ZStack {
+            GhostShape()
+                .fill(self.bodyGradient)
+            if self.colorScheme == .light {
+                GhostShape()
+                    .stroke(Color.black.opacity(0.07), lineWidth: 0.5)
             }
-
-            // Draw the ghost body
-            context.fill(bodyPath, with: .color(ghostColor.opacity(self.state == .idle ? 0.9 : 1.0)))
-
-            // Draw eyes based on state
-            switch self.state {
-            case .idle:
-                // Normal eyes
-                context.fill(
-                    Circle().path(in: CGRect(x: 6.5, y: 8, width: 1.5, height: 1.5)),
-                    with: .color(self.colorScheme == .dark ? .black : .white))
-                context.fill(
-                    Circle().path(in: CGRect(x: 11.5, y: 8, width: 1.5, height: 1.5)),
-                    with: .color(self.colorScheme == .dark ? .black : .white))
-
-            case .peek1:
-                // Looking to the side
-                context.fill(
-                    Circle().path(in: CGRect(x: 7.5, y: 8, width: 1.5, height: 1.5)),
-                    with: .color(self.colorScheme == .dark ? .black : .white))
-                context.fill(
-                    Circle().path(in: CGRect(x: 12.5, y: 8, width: 1.5, height: 1.5)),
-                    with: .color(self.colorScheme == .dark ? .black : .white))
-
-            case .peek2:
-                // Wide eyes
-                context.fill(
-                    Circle().path(in: CGRect(x: 6, y: 7.5, width: 2, height: 2)),
-                    with: .color(self.colorScheme == .dark ? .black : .white))
-                context.fill(
-                    Circle().path(in: CGRect(x: 11, y: 7.5, width: 2, height: 2)),
-                    with: .color(self.colorScheme == .dark ? .black : .white))
-            }
+            GhostEyesView(glance: self.state == .peek1 ? 1 : 0, wide: self.state == .peek2)
+                .foregroundStyle(Color.black.opacity(0.82))
         }
+        .compositingGroup()
+        .shadow(
+            color: .black.opacity(self.colorScheme == .dark ? 0.30 : 0.14),
+            radius: self.size.height * 0.05,
+            y: self.size.height * 0.03)
         .frame(width: self.size.width, height: self.size.height)
+        .accessibilityHidden(true)
+    }
+
+    private var bodyGradient: LinearGradient {
+        LinearGradient(
+            stops: [
+                .init(color: .white, location: 0.0),
+                .init(color: Color(white: self.colorScheme == .dark ? 0.78 : 0.90), location: 1.0),
+            ],
+            startPoint: .top,
+            endPoint: .bottom)
     }
 }
 
-/// Create a view modifier to replace Image("ghost.idle") etc.
-extension Image {
-    @MainActor
-    static var ghostIdle: some View {
-        GhostImageView(state: .idle)
+// MARK: - Animated Glass Ghost
+
+/// The hero ghost for empty states: a Liquid Glass surface on macOS 26+,
+/// gently floating above a soft shadow while occasionally glancing around.
+/// Falls back to a translucent material ghost on older systems.
+struct AnimatedGhostView: View {
+    var size: CGFloat = 108
+
+    @State private var isFloating = false
+    @State private var glance: CGFloat = 0
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
+    var body: some View {
+        VStack(spacing: self.size * 0.13) {
+            self.ghostBody
+                .frame(width: self.size, height: self.size * 1.06)
+                .offset(y: self.isFloating ? -self.size * 0.04 : self.size * 0.04)
+
+            Ellipse()
+                .fill(.black.opacity(0.20))
+                .frame(width: self.size * 0.52, height: self.size * 0.075)
+                .blur(radius: self.size * 0.04)
+                .scaleEffect(self.isFloating ? 0.78 : 1.02)
+                .opacity(self.isFloating ? 0.65 : 1)
+        }
+        .onAppear {
+            guard !self.reduceMotion else { return }
+            withAnimation(.easeInOut(duration: 2.8).repeatForever(autoreverses: true)) {
+                self.isFloating = true
+            }
+        }
+        .task { await self.glanceAround() }
+        .accessibilityHidden(true)
     }
 
-    @MainActor
-    static var ghostPeek1: some View {
-        GhostImageView(state: .peek1)
+    @ViewBuilder
+    private var ghostBody: some View {
+        if #available(macOS 26.0, *) {
+            GhostEyesView(glance: self.glance)
+                .foregroundStyle(.primary.opacity(0.70))
+                .glassEffect(.regular.tint(.white.opacity(0.25)).interactive(), in: GhostShape())
+        } else {
+            ZStack {
+                GhostShape()
+                    .fill(.ultraThinMaterial)
+                GhostShape()
+                    .fill(LinearGradient(
+                        colors: [.white.opacity(0.45), .white.opacity(0.12)],
+                        startPoint: .top,
+                        endPoint: .bottom))
+                GhostEyesView(glance: self.glance)
+                    .foregroundStyle(.primary.opacity(0.70))
+            }
+        }
     }
 
-    @MainActor
-    static var ghostPeek2: some View {
-        GhostImageView(state: .peek2)
+    /// Peekaboo! Glance to a random side every few seconds, then back.
+    private func glanceAround() async {
+        guard !self.reduceMotion else { return }
+        let spring = Animation.spring(response: 0.35, dampingFraction: 0.7)
+        while !Task.isCancelled {
+            try? await Task.sleep(for: .seconds(Double.random(in: 2.4...4.4)))
+            guard !Task.isCancelled else { return }
+            let direction: CGFloat = Bool.random() ? 1 : -1
+            withAnimation(spring) { self.glance = direction }
+
+            try? await Task.sleep(for: .seconds(Double.random(in: 0.8...1.3)))
+            guard !Task.isCancelled else { return }
+            withAnimation(spring) { self.glance = 0 }
+        }
     }
+}
+
+#Preview("Ghost states") {
+    HStack(spacing: 24) {
+        GhostImageView(state: .idle, size: CGSize(width: 80, height: 80))
+        GhostImageView(state: .peek1, size: CGSize(width: 80, height: 80))
+        GhostImageView(state: .peek2, size: CGSize(width: 80, height: 80))
+        AnimatedGhostView(size: 108)
+    }
+    .padding(40)
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+### Changed
+- The Sessions window was redesigned around native Liquid Glass: the empty-state ghost is now a smooth vector silhouette rendered as a real glass surface that floats over a soft shadow and occasionally glances around, the sidebar swaps its hand-rolled header and search box for the native toolbar search field plus a compose button (⌘N), session rows show tidier metadata with a model badge, and empty search results use the standard "No Results" view. The refreshed ghost (white with a soft gradient in both light and dark mode) also carries over to the status-bar popover and onboarding screens.
+
 ## [3.6.0] - 2026-07-04
 
 ### Changed


### PR DESCRIPTION
Redesigns the Peekaboo Sessions window around native Liquid Glass (macOS 26) with graceful fallbacks for macOS 15.

## What changed

**Ghost**
- Replaced the 20-unit-grid Canvas blob with a proper vector `GhostShape` (smooth dome, gently flared sides, three-scoop scalloped hem) plus capsule eyes.
- New `AnimatedGhostView` hero for the empty state: the ghost body is a real Liquid Glass surface (`glassEffect(.regular.tint(…).interactive(), in: GhostShape())`) that floats over a soft ground shadow and occasionally glances left or right. Honors Reduce Motion; falls back to a translucent material ghost pre-26.
- `GhostImageView` keeps its `(state:size:)` API, so the status-bar popover and onboarding screens pick up the new ghost automatically — a white gradient ghost in both appearances instead of the old black silhouette in light mode.

**Empty state**
- Proper hierarchy: primary semibold title, secondary subtitle, and a glass-prominent New Session button (`.glassProminent`, `.borderedProminent` fallback).
- A subtle accent radial glow behind the ghost gives the glass something to refract.

**Sidebar**
- The hand-rolled "Sessions" header and search box are gone; search is a native `.searchable` toolbar field and New Session is a toolbar compose button (`square.and.pencil`, ⌘N).
- Session rows: title with active-session pulse, abbreviated relative time, 2-line summary, message count with automatic pluralization, and a model badge capsule.
- `ContentUnavailableView` for the "no sessions" and "no search results" states.
- Row deletion stays available via swipe, context menu, and the delete key (the hover trash button is gone).

## Before / After

| | Before | After |
|---|---|---|
| **Dark** | ![before dark](https://raw.githubusercontent.com/openclaw/Peekaboo/pr-assets/sessions-redesign/before-dark.png) | ![after dark](https://raw.githubusercontent.com/openclaw/Peekaboo/pr-assets/sessions-redesign/after-dark.png) |
| **Light** | ![before light](https://raw.githubusercontent.com/openclaw/Peekaboo/pr-assets/sessions-redesign/before-light.png) | ![after light](https://raw.githubusercontent.com/openclaw/Peekaboo/pr-assets/sessions-redesign/after-light.png) |

Screenshots are live captures of the debug build, hosted on the `pr-assets/sessions-redesign` branch.

## Testing
- `./scripts/build-mac-debug.sh` — clean build (Xcode 26 SDK, macOS 26.1)
- `pnpm run format` — no changes needed; `pnpm run lint` — no violations in touched files
- Autoreview (Codex, gpt-5.5): clean, no actionable findings
- Manual: launched the debug app and verified empty state, sidebar rows, search field, and toolbar in light and dark mode (captures above)
