### PR TITLE
feat: support native image downscaling via CGImageSource thumbnailing in ImageTool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+### Added
+- The MCP image tool now supports native `max_dimension` downscaling, with inline `format: "data"` captures capped at 1500 pixels by default to reduce payload and model-context overhead. Thanks @jacobjove for #219.
+
 ### Changed
 - The Sessions window was redesigned around native Liquid Glass: the empty-state ghost is now a smooth vector silhouette rendered as a real glass surface that floats over a soft shadow and occasionally glances around, the sidebar swaps its hand-rolled header and search box for the native toolbar search field plus a compose button (⌘N), session rows show tidier metadata with a model badge, and empty search results use the standard "No Results" view. The refreshed ghost (white with a soft gradient in both light and dark mode) also carries over to the status-bar popover and onboarding screens.
 

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/ImageTool+Capture.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/ImageTool+Capture.swift
@@ -1,9 +1,12 @@
+import CoreGraphics
 import Foundation
+import ImageIO
 import MCP
 import PeekabooAutomation
 import PeekabooAutomationKit
 import PeekabooFoundation
 import TachikomaMCP
+import UniformTypeIdentifiers
 
 struct ImageCaptureSet {
     let captures: [CaptureResult]
@@ -72,6 +75,43 @@ extension ImageTool {
             .path
     }
 
+    func downscaledCaptureSetIfNeeded(_ captureSet: ImageCaptureSet, request: ImageRequest) throws -> ImageCaptureSet {
+        guard let maxDimension = request.effectiveMaxDimension else {
+            return captureSet
+        }
+
+        var downscaledCaptures: [CaptureResult] = []
+        downscaledCaptures.reserveCapacity(captureSet.captures.count)
+
+        for capture in captureSet.captures {
+            guard !capture.imageData.isEmpty else {
+                downscaledCaptures.append(capture)
+                continue
+            }
+
+            guard let result = self.downscale(
+                imageData: capture.imageData,
+                maxDimension: maxDimension,
+                format: request.format)
+            else {
+                throw OperationError.captureFailed(
+                    reason: "Failed to downscale image to max_dimension \(maxDimension)")
+            }
+
+            if result.resized, let savedPath = capture.savedPath ?? captureSet.observation?.files.rawScreenshotPath {
+                try result.data.write(to: URL(fileURLWithPath: savedPath), options: .atomic)
+            }
+
+            downscaledCaptures.append(CaptureResult(
+                imageData: result.data,
+                savedPath: capture.savedPath,
+                metadata: capture.metadata,
+                warning: capture.warning))
+        }
+
+        return ImageCaptureSet(captures: downscaledCaptures, observation: captureSet.observation)
+    }
+
     func performAnalysis(
         question: String,
         savedFiles: [MCPSavedFile],
@@ -136,5 +176,58 @@ extension ImageTool {
         return ToolResponse.text(
             buildImageSummary(savedFiles: savedFiles, captureCount: captureResults.count),
             meta: meta)
+    }
+
+    private func encode(cgImage: CGImage, format: ImageFormatOption) -> Data? {
+        let data = NSMutableData()
+        let uti: CFString = switch format {
+        case .png, .data: UTType.png.identifier as CFString
+        case .jpg: UTType.jpeg.identifier as CFString
+        }
+        guard let destination = CGImageDestinationCreateWithData(
+            data,
+            uti,
+            1,
+            nil)
+        else {
+            return nil
+        }
+        CGImageDestinationAddImage(destination, cgImage, nil)
+        guard CGImageDestinationFinalize(destination) else {
+            return nil
+        }
+        return data as Data
+    }
+
+    func downscale(imageData: Data, maxDimension: Int, format: ImageFormatOption) -> (data: Data, resized: Bool)? {
+        guard let source = CGImageSourceCreateWithData(imageData as CFData, nil) else { return nil }
+
+        guard let properties = CGImageSourceCopyPropertiesAtIndex(source, 0, nil) as? [CFString: Any],
+              let width = properties[kCGImagePropertyPixelWidth] as? CGFloat,
+              let height = properties[kCGImagePropertyPixelHeight] as? CGFloat
+        else {
+            return nil
+        }
+
+        let longest = max(width, height)
+        guard longest > CGFloat(maxDimension) else {
+            return (imageData, false)
+        }
+
+        let options: [CFString: Any] = [
+            kCGImageSourceCreateThumbnailFromImageAlways: true,
+            kCGImageSourceCreateThumbnailWithTransform: true,
+            kCGImageSourceThumbnailMaxPixelSize: maxDimension,
+        ]
+
+        guard let thumbnail = CGImageSourceCreateThumbnailAtIndex(source, 0, options as CFDictionary) else {
+            return nil
+        }
+
+        guard let encodedData = self.encode(cgImage: thumbnail, format: format) else {
+            return nil
+        }
+
+        return (encodedData, true)
     }
 }

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/ImageTool+Capture.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/ImageTool+Capture.swift
@@ -84,13 +84,20 @@ extension ImageTool {
         downscaledCaptures.reserveCapacity(captureSet.captures.count)
 
         for capture in captureSet.captures {
-            guard !capture.imageData.isEmpty else {
+            let savedPath = capture.savedPath ?? captureSet.observation?.files.rawScreenshotPath
+            let imageData = if capture.imageData.isEmpty, let savedPath {
+                (try? Data(contentsOf: URL(fileURLWithPath: savedPath))) ?? capture.imageData
+            } else {
+                capture.imageData
+            }
+
+            guard !imageData.isEmpty else {
                 downscaledCaptures.append(capture)
                 continue
             }
 
             guard let result = self.downscale(
-                imageData: capture.imageData,
+                imageData: imageData,
                 maxDimension: maxDimension,
                 format: request.format)
             else {
@@ -98,7 +105,7 @@ extension ImageTool {
                     reason: "Failed to downscale image to max_dimension \(maxDimension)")
             }
 
-            if result.resized, let savedPath = capture.savedPath ?? captureSet.observation?.files.rawScreenshotPath {
+            if result.resized, let savedPath {
                 try result.data.write(to: URL(fileURLWithPath: savedPath), options: .atomic)
             }
 

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/ImageTool+Types.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/ImageTool+Types.swift
@@ -19,11 +19,13 @@ struct ImageInput: Codable {
     let captureFocus: CaptureFocus?
     let scale: String?
     let retina: Bool?
+    let maxDimension: Int?
 
     enum CodingKeys: String, CodingKey {
         case path, format, question, scale, retina
         case appTarget = "app_target"
         case captureFocus = "capture_focus"
+        case maxDimension = "max_dimension"
     }
 }
 
@@ -34,6 +36,7 @@ struct ImageRequest {
     let question: String?
     let captureFocus: CaptureFocus
     let scale: CaptureScalePreference
+    let maxDimension: Int?
 
     init(arguments: ToolArguments) throws {
         let input = try arguments.decode(ImageInput.self)
@@ -43,6 +46,14 @@ struct ImageRequest {
         self.format = input.format ?? .png
         self.target = try ObservationTargetArgument.parse(input.appTarget)
         self.scale = try Self.captureScale(scale: input.scale, retina: input.retina)
+        if let maxDim = input.maxDimension {
+            guard maxDim > 0 else {
+                throw PeekabooError.invalidInput("max_dimension must be a positive integer.")
+            }
+            self.maxDimension = maxDim
+        } else {
+            self.maxDimension = nil
+        }
     }
 
     private static func captureScale(scale: String?, retina: Bool?) throws -> CaptureScalePreference {
@@ -66,6 +77,10 @@ struct ImageRequest {
 }
 
 extension ImageRequest {
+    var effectiveMaxDimension: Int? {
+        self.maxDimension ?? (self.format == .data ? 1500 : nil)
+    }
+
     var focusIdentifier: String? {
         self.target.focusIdentifier
     }

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/ImageTool.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/ImageTool.swift
@@ -45,6 +45,11 @@ public struct ImageTool: MCPTool {
                 "retina": SchemaBuilder.boolean(
                     description: "Optional. Shorthand for scale=native.",
                     default: false),
+                "max_dimension": SchemaBuilder.integer(
+                    description: """
+                    Optional. Downscales the captured image so its longest side does not exceed this value.
+                    Defaults to 1500 when format is "data".
+                    """),
             ],
             required: [])
     }
@@ -60,12 +65,14 @@ public struct ImageTool: MCPTool {
             return self.screenRecordingPermissionError()
         }
 
-        let captureSet: ImageCaptureSet
+        var captureSet: ImageCaptureSet
         do {
             captureSet = try await self.captureImages(for: request)
         } catch PeekabooError.permissionDeniedScreenRecording {
             return self.screenRecordingPermissionError()
         }
+
+        captureSet = try self.downscaledCaptureSetIfNeeded(captureSet, request: request)
         let captureResults = captureSet.captures
         let savedFiles = try self.savedFiles(for: captureSet, request: request)
 

--- a/Core/PeekabooCore/Tests/PeekabooTests/MCP/MCPToolExecutionTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/MCP/MCPToolExecutionTests.swift
@@ -278,6 +278,35 @@ struct MCPToolExecutionTests {
     }
 
     @Test
+    func `Image tool downscales saved fallback when capture data is empty`() async throws {
+        let highResPNG = Self.makePNGData(width: 3000, height: 2000)
+        let context = await MCPToolTestHelpers.makeContext()
+        let tool = ImageTool(context: context)
+        let outputPath = FileManager.default.temporaryDirectory
+            .appendingPathComponent("peekaboo-mcp-downscaled-fallback-\(UUID().uuidString).png")
+            .path
+        defer { try? FileManager.default.removeItem(atPath: outputPath) }
+        try highResPNG.write(to: URL(fileURLWithPath: outputPath))
+        let captureSet = ImageCaptureSet(
+            captures: [CaptureResult(
+                imageData: Data(),
+                savedPath: outputPath,
+                metadata: CaptureMetadata(size: CGSize(width: 3000, height: 2000), mode: .screen))],
+            observation: nil)
+        let request = try ImageRequest(arguments: ToolArguments(raw: [
+            "format": "data",
+            "max_dimension": 600,
+        ]))
+
+        let result = try tool.downscaledCaptureSetIfNeeded(captureSet, request: request)
+
+        let capture = try #require(result.captures.first)
+        #expect(Self.imageDimensions(from: capture.imageData) == CGSize(width: 600, height: 400))
+        let savedData = try Data(contentsOf: URL(fileURLWithPath: outputPath))
+        #expect(Self.imageDimensions(from: savedData) == CGSize(width: 600, height: 400))
+    }
+
+    @Test
     func `Image tool rejects nonpositive max_dimension`() async throws {
         let screenCapture = await MainActor.run { MockScreenCaptureService(screenRecordingGranted: true) }
         let context = await MCPToolTestHelpers.makeContext(screenCapture: screenCapture)

--- a/Core/PeekabooCore/Tests/PeekabooTests/MCP/MCPToolExecutionTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/MCP/MCPToolExecutionTests.swift
@@ -1,10 +1,12 @@
 import AppKit
 import Foundation
+import ImageIO
 import MCP
 import PeekabooAutomationKit
 import PeekabooFoundation
 import TachikomaMCP
 import Testing
+import UniformTypeIdentifiers
 @testable import PeekabooAgentRuntime
 @testable import PeekabooAutomation
 @testable import PeekabooCore
@@ -191,6 +193,102 @@ struct MCPToolExecutionTests {
             return
         }
         #expect(output == "Capture produced no image data and no saved file could be read")
+    }
+
+    @Test
+    func `Image tool downscales high-res image when format is data`() async throws {
+        let highResPNG = Self.makePNGData(width: 3000, height: 2000)
+        let screenCapture = await MainActor.run {
+            MockScreenCaptureService(screenRecordingGranted: true, imageData: highResPNG)
+        }
+        let context = await MCPToolTestHelpers.makeContext(screenCapture: screenCapture)
+        let tool = ImageTool(context: context)
+
+        let response = try await tool.execute(arguments: ToolArguments(raw: [
+            "format": "data",
+        ]))
+
+        #expect(response.isError == false)
+        guard case let .image(data: responseBase64, mimeType: mimeType, annotations: _, _meta: _) = response.content
+            .first
+        else {
+            Issue.record("Expected image response")
+            return
+        }
+        guard let responseData = Data(base64Encoded: responseBase64) else {
+            Issue.record("Expected Base64 image data")
+            return
+        }
+
+        #expect(mimeType == "image/png")
+        #expect(Self.imageDimensions(from: responseData) == CGSize(width: 1500, height: 1000))
+    }
+
+    @Test
+    func `Image tool downscales high-res inline image to custom max_dimension`() async throws {
+        let highResPNG = Self.makePNGData(width: 3000, height: 2000)
+        let screenCapture = await MainActor.run {
+            MockScreenCaptureService(screenRecordingGranted: true, imageData: highResPNG)
+        }
+        let context = await MCPToolTestHelpers.makeContext(screenCapture: screenCapture)
+        let tool = ImageTool(context: context)
+
+        let response = try await tool.execute(arguments: ToolArguments(raw: [
+            "format": "data",
+            "max_dimension": 600,
+        ]))
+
+        #expect(response.isError == false)
+        guard case let .image(data: responseBase64, mimeType: _, annotations: _, _meta: _) = response.content.first
+        else {
+            Issue.record("Expected image response")
+            return
+        }
+        guard let responseData = Data(base64Encoded: responseBase64) else {
+            Issue.record("Expected Base64 image data")
+            return
+        }
+
+        #expect(Self.imageDimensions(from: responseData) == CGSize(width: 600, height: 400))
+    }
+
+    @Test
+    func `Image tool downscales saved image when max_dimension is set`() async throws {
+        let highResPNG = Self.makePNGData(width: 3000, height: 2000)
+        let screenCapture = await MainActor.run {
+            MockScreenCaptureService(screenRecordingGranted: true, imageData: highResPNG)
+        }
+        let context = await MCPToolTestHelpers.makeContext(screenCapture: screenCapture)
+        let tool = ImageTool(context: context)
+        let outputPath = FileManager.default.temporaryDirectory
+            .appendingPathComponent("peekaboo-mcp-downscaled-\(UUID().uuidString).png")
+            .path
+        defer { try? FileManager.default.removeItem(atPath: outputPath) }
+
+        let response = try await tool.execute(arguments: ToolArguments(raw: [
+            "path": outputPath,
+            "format": "png",
+            "max_dimension": 600,
+        ]))
+
+        #expect(response.isError == false)
+        #expect(FileManager.default.fileExists(atPath: outputPath))
+        let savedData = try Data(contentsOf: URL(fileURLWithPath: outputPath))
+        #expect(Self.imageDimensions(from: savedData) == CGSize(width: 600, height: 400))
+    }
+
+    @Test
+    func `Image tool rejects nonpositive max_dimension`() async throws {
+        let screenCapture = await MainActor.run { MockScreenCaptureService(screenRecordingGranted: true) }
+        let context = await MCPToolTestHelpers.makeContext(screenCapture: screenCapture)
+        let tool = ImageTool(context: context)
+
+        await #expect(throws: PeekabooError.self) {
+            _ = try await tool.execute(arguments: ToolArguments(raw: [
+                "format": "data",
+                "max_dimension": 0,
+            ]))
+        }
     }
 
     // MARK: - List Tool Tests
@@ -986,6 +1084,50 @@ struct MCPToolExecutionTests {
             return nil
         }
         return Int32(pid)
+    }
+
+    private static func makePNGData(width: Int, height: Int) -> Data {
+        let bytesPerRow = width * 4
+        var pixels = [UInt8](repeating: 0, count: bytesPerRow * height)
+        guard let context = CGContext(
+            data: &pixels,
+            width: width,
+            height: height,
+            bitsPerComponent: 8,
+            bytesPerRow: bytesPerRow,
+            space: CGColorSpaceCreateDeviceRGB(),
+            bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue)
+        else {
+            fatalError("Failed to generate test image")
+        }
+
+        context.setFillColor(CGColor(red: 1, green: 0, blue: 0, alpha: 1))
+        context.fill(CGRect(x: 0, y: 0, width: width, height: height))
+        guard let image = context.makeImage() else {
+            fatalError("Failed to generate test image")
+        }
+
+        let data = NSMutableData()
+        guard let destination = CGImageDestinationCreateWithData(
+            data,
+            UTType.png.identifier as CFString,
+            1,
+            nil)
+        else {
+            fatalError("Failed to create test PNG destination")
+        }
+        CGImageDestinationAddImage(destination, image, nil)
+        guard CGImageDestinationFinalize(destination) else {
+            fatalError("Failed to encode test PNG")
+        }
+        return data as Data
+    }
+
+    private static func imageDimensions(from data: Data) -> CGSize? {
+        guard let rep = NSBitmapImageRep(data: data) else {
+            return nil
+        }
+        return CGSize(width: rep.pixelsWide, height: rep.pixelsHigh)
     }
 }
 

--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -129,7 +129,7 @@ The MCP `image` and `see` tools share target parsing with the desktop observatio
 - pass `menubar` for menu-bar capture;
 - pass `PID:1234`, `PID:1234:2`, `App Name`, `App Name:2`, or `App Name:Window Title` for app/window capture.
 
-The MCP `image` tool stores logical 1x captures by default. Pass `scale: "native"` or `retina: true` to request native display pixels.
+The MCP `image` tool stores logical 1x captures by default. Pass `scale: "native"` or `retina: true` to request native display pixels. Set `max_dimension` to a positive integer to cap the longest output edge while preserving aspect ratio; inline `format: "data"` captures default to 1500 pixels when no cap is supplied.
 
 ## Troubleshooting
 


### PR DESCRIPTION
Closes #218

### Description

Adds native output downscaling to the MCP `image` tool with ImageIO thumbnailing, reducing inline payload and model-context overhead without requiring clients to post-process captures.

### Key changes

- Adds the optional positive-integer `max_dimension` tool argument.
- Defaults inline `format: "data"` captures to a 1500-pixel longest edge; other formats retain their existing size unless a cap is supplied.
- Uses `CGImageSourceCreateThumbnailAtIndex` to preserve aspect ratio and orientation while avoiding a full bitmap resize pass.
- Keeps inline response data and saved capture files consistent, including captures that arrive through the saved-file fallback path.
- Documents the behavior and adds regression coverage for default, custom, saved-file, fallback, and invalid-value cases.
- Leaves release-signing behavior unchanged.

### Proof

- `pnpm run format`
- `pnpm run lint` (0 serious violations; existing warnings only)
- `pnpm run test:safe` (633 tests passed)
- Focused fallback regression: 1 test passed
- Live stdio MCP capture through `mcporter`: explicit cap returned and saved 600×338; default inline cap returned 1500×844
- Full-branch Codex autoreview: clean, no accepted/actionable findings
