### PR TITLE
fix(mac): hide sessions when agent mode is disabled

### DIFF
--- a/Apps/Mac/Peekaboo/Features/StatusBar/MenuBarStatusView.swift
+++ b/Apps/Mac/Peekaboo/Features/StatusBar/MenuBarStatusView.swift
@@ -8,6 +8,7 @@ struct MenuBarStatusView: View {
 
     @Environment(PeekabooAgent.self) private var agent
     @Environment(SessionStore.self) private var sessionStore
+    @Environment(PeekabooSettings.self) private var settings
     @Environment(\.openWindow) private var openWindow
 
     @State private var inputText = ""
@@ -116,6 +117,8 @@ struct MenuBarStatusView: View {
     }
 
     private func openMainWindow() {
+        guard AgentSessionUI.isAvailable(agentModeEnabled: self.settings.agentModeEnabled) else { return }
+
         DockIconManager.shared.temporarilyShowDock()
         NSApp.activate(ignoringOtherApps: true)
         self.openWindow(id: "main")
@@ -132,6 +135,8 @@ struct MenuBarStatusView: View {
     }
 
     private func createNewSession() {
+        guard AgentSessionUI.isAvailable(agentModeEnabled: self.settings.agentModeEnabled) else { return }
+
         _ = self.sessionStore.createSession(title: "New Session")
         self.detailsExpanded = true
     }

--- a/Apps/Mac/Peekaboo/Features/StatusBar/StatusBarController.swift
+++ b/Apps/Mac/Peekaboo/Features/StatusBar/StatusBarController.swift
@@ -3,6 +3,26 @@ import os.log
 import PeekabooCore
 import SwiftUI
 
+enum AgentSessionUI {
+    static let mainWindowIdentifier = "main"
+    static let mainWindowTitle = "Peekaboo Sessions"
+    private static let detailWindowIdentifierPrefix = "agent-session:"
+
+    static func isAvailable(agentModeEnabled: Bool) -> Bool {
+        agentModeEnabled
+    }
+
+    static func detailWindowIdentifier(sessionID: String) -> String {
+        "\(self.detailWindowIdentifierPrefix)\(sessionID)"
+    }
+
+    static func identifiesSessionWindow(identifier: String?, title: String) -> Bool {
+        identifier == self.mainWindowIdentifier ||
+            identifier?.hasPrefix(self.detailWindowIdentifierPrefix) == true ||
+            title == self.mainWindowTitle
+    }
+}
+
 /// Controls the Peekaboo status bar item and popover interface.
 ///
 /// Manages the macOS status bar integration with animated icon states and popover UI.
@@ -112,6 +132,7 @@ final class StatusBarController: NSObject, NSMenuDelegate {
         let baseView = MenuBarStatusView()
             .environment(self.agent)
             .environment(self.sessionStore)
+            .environment(self.settings)
 
         self.popover.contentViewController = NSHostingController(rootView: baseView)
     }
@@ -134,11 +155,22 @@ final class StatusBarController: NSObject, NSMenuDelegate {
     }
 
     func togglePopover() {
+        guard AgentSessionUI.isAvailable(agentModeEnabled: self.settings.agentModeEnabled) else {
+            self.dismissAgentUI()
+            return
+        }
+
         if self.popover.isShown {
             self.popover.performClose(nil)
         } else {
             guard let button = statusItem.button else { return }
             self.popover.show(relativeTo: button.bounds, of: button, preferredEdge: .minY)
+        }
+    }
+
+    func dismissAgentUI() {
+        if self.popover.isShown {
+            self.popover.performClose(nil)
         }
     }
 
@@ -261,7 +293,8 @@ final class StatusBarController: NSObject, NSMenuDelegate {
     }
 
     @objc private func openSession(_ sender: NSMenuItem) {
-        guard let sessionId = sender.representedObject as? String,
+        guard AgentSessionUI.isAvailable(agentModeEnabled: self.settings.agentModeEnabled),
+              let sessionId = sender.representedObject as? String,
               let session = sessionStore.sessions.first(where: { $0.id == sessionId }) else { return }
 
         // Open session detail window
@@ -274,6 +307,7 @@ final class StatusBarController: NSObject, NSMenuDelegate {
             defer: false)
 
         window.title = session.title
+        window.identifier = NSUserInterfaceItemIdentifier(AgentSessionUI.detailWindowIdentifier(sessionID: session.id))
         window.center()
         let rootView = SessionMainWindow()
             .environment(self.sessionStore)
@@ -285,6 +319,8 @@ final class StatusBarController: NSObject, NSMenuDelegate {
     }
 
     @objc private func openMainWindow() {
+        guard AgentSessionUI.isAvailable(agentModeEnabled: self.settings.agentModeEnabled) else { return }
+
         self.logger.info("openMainWindow action triggered from menu")
 
         // First ensure the app is active

--- a/Apps/Mac/Peekaboo/PeekabooApp.swift
+++ b/Apps/Mac/Peekaboo/PeekabooApp.swift
@@ -1,5 +1,6 @@
 import AppKit
 import KeyboardShortcuts
+import Observation
 import os.log
 import PeekabooAutomationKit
 import PeekabooBridge
@@ -84,6 +85,9 @@ struct PeekabooApp: App {
                     // Set up window opening handler
                     self.appDelegate.windowOpener = { windowId in
                         Task { @MainActor in
+                            guard windowId != AgentSessionUI.mainWindowIdentifier ||
+                                AgentSessionUI.isAvailable(agentModeEnabled: self.settings.agentModeEnabled)
+                            else { return }
                             self.openWindow(id: windowId)
                         }
                     }
@@ -109,31 +113,42 @@ struct PeekabooApp: App {
 
         // Main window - Powerful debugging and development interface
         WindowGroup("Peekaboo Sessions", id: "main") {
-            SessionMainWindow()
-                .environment(self.settings)
-                .environment(self.sessionStore)
-                .environment(self.permissions)
-                .environment(
-                    self.agent ?? PeekabooAgent(
-                        settings: self.settings,
-                        sessionStore: self.sessionStore,
-                        services: self.services))
-                .onReceive(NotificationCenter.default.publisher(for: .openMainWindow)) { _ in
-                    // Window will automatically open when this notification is received
-                    DispatchQueue.main.async {
-                        self.openWindow(id: "main")
+            if AgentSessionUI.isAvailable(agentModeEnabled: self.settings.agentModeEnabled) {
+                SessionMainWindow()
+                    .environment(self.settings)
+                    .environment(self.sessionStore)
+                    .environment(self.permissions)
+                    .environment(
+                        self.agent ?? PeekabooAgent(
+                            settings: self.settings,
+                            sessionStore: self.sessionStore,
+                            services: self.services))
+                    .onReceive(NotificationCenter.default.publisher(for: .openMainWindow)) { _ in
+                        guard AgentSessionUI.isAvailable(agentModeEnabled: self.settings.agentModeEnabled) else {
+                            return
+                        }
+                        DispatchQueue.main.async {
+                            guard AgentSessionUI.isAvailable(agentModeEnabled: self.settings.agentModeEnabled) else {
+                                return
+                            }
+                            self.openWindow(id: AgentSessionUI.mainWindowIdentifier)
+                        }
                     }
-                }
-                .onReceive(NotificationCenter.default.publisher(for: .startNewSession)) { _ in
-                    // Handle new session request
-                    _ = self.sessionStore.createSession(title: "New Session")
-                }
-                .onAppear {
-                    // Make sure window has proper identifier
-                    if let window = NSApp.keyWindow {
-                        window.identifier = NSUserInterfaceItemIdentifier("main")
+                    .onReceive(NotificationCenter.default.publisher(for: .startNewSession)) { _ in
+                        _ = self.sessionStore.createSession(title: "New Session")
                     }
-                }
+                    .onAppear {
+                        if let window = NSApp.keyWindow {
+                            window.identifier = NSUserInterfaceItemIdentifier(AgentSessionUI.mainWindowIdentifier)
+                        }
+                    }
+            } else {
+                Color.clear
+                    .frame(width: 1, height: 1)
+                    .onAppear {
+                        self.appDelegate.dismissAgentSessionUI()
+                    }
+            }
         }
         .windowResizability(.automatic)
         .defaultSize(width: 900, height: 700)
@@ -212,6 +227,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private var didConnectVisualizerSettings = false
     private var didSetupKeyboardShortcuts = false
     private var didSetupNotificationObservers = false
+    private var didObserveAgentMode = false
 
     func applicationDidFinishLaunching(_: Notification) {
         self.logger.info("Peekaboo launching...")
@@ -266,6 +282,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             self.setupNotificationObservers()
             self.didSetupNotificationObservers = true
         }
+
+        if !self.didObserveAgentMode {
+            self.didObserveAgentMode = true
+            self.observeAgentMode()
+        }
+
+        self.updateAgentSessionUIVisibility()
 
         if self.bridgeHost == nil, self.bridgeStartTask == nil {
             self.startBridgeHost(services: context.services)
@@ -337,6 +360,14 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     // MARK: - Window Management
 
     func showMainWindow() {
+        guard let settings = self.settings,
+              AgentSessionUI.isAvailable(agentModeEnabled: settings.agentModeEnabled)
+        else {
+            self.logger.info("Ignoring main window request because agent mode is disabled")
+            self.dismissAgentSessionUI()
+            return
+        }
+
         self.logger.info("showMainWindow called")
 
         // Ensure dock icon is visible
@@ -347,17 +378,24 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
         // Find or create the main window
         DispatchQueue.main.async {
+            guard AgentSessionUI.isAvailable(agentModeEnabled: settings.agentModeEnabled) else {
+                self.dismissAgentSessionUI()
+                return
+            }
+
             self.logger.info("Looking for existing main window...")
 
             // First try to find an existing main window by identifier
-            if let existingWindow = NSApp.windows.first(where: { $0.identifier?.rawValue == "main" }) {
+            if let existingWindow = NSApp.windows.first(where: {
+                $0.identifier?.rawValue == AgentSessionUI.mainWindowIdentifier
+            }) {
                 self.logger.info("Found existing main window by identifier, bringing to front")
                 existingWindow.makeKeyAndOrderFront(nil)
                 return
             }
 
             // Also check by title as fallback
-            if let existingWindow = NSApp.windows.first(where: { $0.title == "Peekaboo Sessions" }) {
+            if let existingWindow = NSApp.windows.first(where: { $0.title == AgentSessionUI.mainWindowTitle }) {
                 self.logger.info("Found existing main window by title, bringing to front")
                 existingWindow.makeKeyAndOrderFront(nil)
                 return
@@ -368,7 +406,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             // Use the window opener if available
             if let opener = self.windowOpener {
                 self.logger.info("Using windowOpener to create main window")
-                opener("main")
+                opener(AgentSessionUI.mainWindowIdentifier)
             } else {
                 self.logger.info("No windowOpener available, posting notification")
                 // Post notification to open window
@@ -392,6 +430,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     private func openWindow(id: String) {
+        guard id != AgentSessionUI.mainWindowIdentifier ||
+            AgentSessionUI.isAvailable(agentModeEnabled: self.settings?.agentModeEnabled == true)
+        else {
+            self.dismissAgentSessionUI()
+            return
+        }
+
         self.logger.info("openWindow called with id: \(id)")
 
         // Ensure dock icon is visible
@@ -423,6 +468,36 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
         // Listen for keyboard shortcut changes
         // Keyboard shortcuts are now handled automatically by the KeyboardShortcuts library
+    }
+
+    private func observeAgentMode() {
+        guard let settings = self.settings else { return }
+
+        withObservationTracking {
+            _ = settings.agentModeEnabled
+        } onChange: { [weak self] in
+            Task { @MainActor [weak self] in
+                guard let self else { return }
+                self.updateAgentSessionUIVisibility()
+                self.observeAgentMode()
+            }
+        }
+    }
+
+    private func updateAgentSessionUIVisibility() {
+        guard !AgentSessionUI.isAvailable(agentModeEnabled: self.settings?.agentModeEnabled == true) else { return }
+        self.dismissAgentSessionUI()
+    }
+
+    func dismissAgentSessionUI() {
+        self.statusBarController?.dismissAgentUI()
+
+        for window in NSApp.windows where AgentSessionUI.identifiesSessionWindow(
+            identifier: window.identifier?.rawValue,
+            title: window.title)
+        {
+            window.close()
+        }
     }
 
     @objc private func handleShowInspector() {

--- a/Apps/Mac/PeekabooTests/Controllers/StatusBarControllerTests.swift
+++ b/Apps/Mac/PeekabooTests/Controllers/StatusBarControllerTests.swift
@@ -21,6 +21,22 @@ struct StatusBarControllerTests {
     }
 
     @Test
+    func `Agent session UI follows agent mode`() {
+        #expect(AgentSessionUI.isAvailable(agentModeEnabled: true))
+        #expect(!AgentSessionUI.isAvailable(agentModeEnabled: false))
+    }
+
+    @Test
+    func `Agent session windows have stable identities`() {
+        #expect(AgentSessionUI.identifiesSessionWindow(identifier: "main", title: ""))
+        #expect(AgentSessionUI.identifiesSessionWindow(
+            identifier: AgentSessionUI.detailWindowIdentifier(sessionID: "test-session"),
+            title: "Test Session"))
+        #expect(AgentSessionUI.identifiesSessionWindow(identifier: nil, title: "Peekaboo Sessions"))
+        #expect(!AgentSessionUI.identifiesSessionWindow(identifier: "inspector", title: "Inspector"))
+    }
+
+    @Test
     func `Controller initializes with status item`() {
         _ = self.makeController()
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+### Fixed
+- The macOS Sessions window and agent popover stay unavailable while Agent mode is disabled, including Dock reopens, global shortcuts, notifications, and windows already open when the setting is turned off.
+
 ## [3.7.1] - 2026-07-05
 
 ### Changed


### PR DESCRIPTION
## Summary

- gate every Sessions window and agent-popover entry point on Agent mode
- close open session windows and the popover when Agent mode is turned off
- keep stable identifiers for main/detail session windows so teardown is precise
- add regression coverage and an Unreleased changelog entry

## Validation

- `pnpm run format`
- `swift test --package-path Apps/Mac --filter StatusBarControllerTests`
- `./scripts/build-mac-debug.sh`
- `pnpm run lint` (passes; 19 existing warnings)
- `pnpm run test:safe` (633 tests passed)
- autoreview: clean, no accepted/actionable findings
- live app: disabled launch, global shortcut, and PID-targeted reopen showed no Sessions UI; enabled positive control opened Sessions; disabling Agent mode live closed the existing Sessions window
