### PR TITLE
feat(models): support Sonnet 5 and GPT-5.6

### DIFF
--- a/Apps/CLI/Sources/PeekabooCLI/Commands/AI/AgentCommand+ModelParsing.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/AI/AgentCommand+ModelParsing.swift
@@ -22,6 +22,9 @@ extension AgentCommand {
             trimmed.caseInsensitiveCompare("anthropic") == .orderedSame {
             return .anthropic(.opus48)
         }
+        if trimmed.caseInsensitiveCompare("sonnet") == .orderedSame {
+            return .anthropic(.sonnet5)
+        }
 
         if let configuration {
             switch self.parseConfiguredCustomModel(
@@ -48,6 +51,9 @@ extension AgentCommand {
         switch parsed {
         case let .openai(model):
             if Self.supportedOpenAIInputs.contains(model) {
+                if Self.gpt56Models.contains(model) {
+                    return .openai(model)
+                }
                 return .openai(.gpt55)
             }
         case let .anthropic(model):
@@ -124,6 +130,9 @@ extension AgentCommand {
     }
 
     private static let supportedOpenAIInputs: Set<LanguageModel.OpenAI> = [
+        .gpt56Sol,
+        .gpt56Terra,
+        .gpt56Luna,
         .gpt55,
         .gpt54,
         .gpt54Mini,
@@ -134,8 +143,15 @@ extension AgentCommand {
         .gpt5Nano,
     ]
 
+    private static let gpt56Models: Set<LanguageModel.OpenAI> = [
+        .gpt56Sol,
+        .gpt56Terra,
+        .gpt56Luna,
+    ]
+
     private static let supportedAnthropicInputs: Set<LanguageModel.Anthropic> = [
         .fable5,
+        .sonnet5,
         .opus48,
         .opus47,
         .opus45,

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/AI/AgentCommand.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/AI/AgentCommand.swift
@@ -89,7 +89,7 @@ struct AgentCommand: RuntimeOptionsConfigurable {
     @Option(
         name: .long,
         help: """
-        AI model to use (for example: gpt-5.5, claude-fable-5, \
+        AI model to use (for example: gpt-5.6, gpt-5.5, claude-fable-5, claude-sonnet-5, \
         gemini-3.5-flash, grok-4.3, minimax-m2.7, minimax-cn/m2.7, \
         ollama/<model>, lmstudio/<model>, or <custom-provider>/<model>)
         """

--- a/Apps/CLI/Tests/CoreCLITests/AgentCommandModelParsingTests.swift
+++ b/Apps/CLI/Tests/CoreCLITests/AgentCommandModelParsingTests.swift
@@ -28,11 +28,24 @@ struct AgentCommandTests {
     }
 
     @Test
+    func `GPT-5_6 aliases preserve the selected tier`() throws {
+        let command = try AgentCommand.parse([])
+
+        #expect(command.parseModelString("gpt-5.6") == .openai(.gpt56Sol))
+        #expect(command.parseModelString("gpt-5.6-sol") == .openai(.gpt56Sol))
+        #expect(command.parseModelString("gpt-5.6-terra") == .openai(.gpt56Terra))
+        #expect(command.parseModelString("gpt-5.6-luna") == .openai(.gpt56Luna))
+        #expect(command.parseModelString("gpt-5.6-mars") == nil)
+    }
+
+    @Test
     func `Supported Anthropic aliases parse current models`() throws {
         let command = try AgentCommand.parse([])
 
         #expect(command.parseModelString("claude-fable-5") == .anthropic(.fable5))
         #expect(command.parseModelString("fable") == .anthropic(.fable5))
+        #expect(command.parseModelString("claude-sonnet-5") == .anthropic(.sonnet5))
+        #expect(command.parseModelString("sonnet") == .anthropic(.sonnet5))
         #expect(command.parseModelString("claude-opus-4.8") == .anthropic(.opus48))
         #expect(command.parseModelString("claude-opus-4.7") == .anthropic(.opus47))
         #expect(command.parseModelString("claude-sonnet-4.6") == .anthropic(.sonnet46))

--- a/Apps/Mac/Peekaboo/Features/AI/AIAssistantWindow.swift
+++ b/Apps/Mac/Peekaboo/Features/AI/AIAssistantWindow.swift
@@ -39,7 +39,12 @@ public struct AIAssistantWindow: View {
                         .font(.headline)
 
                     Picker("Model", selection: self.$selectedModel) {
+                        Text("GPT-5.6 Sol").tag(Model.openai(.gpt56Sol))
+                        Text("GPT-5.6 Terra").tag(Model.openai(.gpt56Terra))
+                        Text("GPT-5.6 Luna").tag(Model.openai(.gpt56Luna))
                         Text("GPT-5.5").tag(Model.openai(.gpt55))
+                        Text("Claude Fable 5").tag(Model.anthropic(.fable5))
+                        Text("Claude Sonnet 5").tag(Model.anthropic(.sonnet5))
                         Text("Claude Opus 4.8").tag(Model.anthropic(.opus48))
                     }
                     .pickerStyle(.menu)
@@ -139,7 +144,12 @@ public struct CompactAIAssistant: View {
                 Spacer()
 
                 Picker("Model", selection: self.$model) {
+                    Text("GPT-5.6 Sol").tag(Model.openai(.gpt56Sol))
+                    Text("GPT-5.6 Terra").tag(Model.openai(.gpt56Terra))
+                    Text("GPT-5.6 Luna").tag(Model.openai(.gpt56Luna))
                     Text("GPT-5.5").tag(Model.openai(.gpt55))
+                    Text("Claude Fable 5").tag(Model.anthropic(.fable5))
+                    Text("Claude Sonnet 5").tag(Model.anthropic(.sonnet5))
                     Text("Claude Opus 4.8").tag(Model.anthropic(.opus48))
                 }
                 .pickerStyle(.menu)

--- a/Apps/Mac/Peekaboo/Features/Main/SessionHelpers.swift
+++ b/Apps/Mac/Peekaboo/Features/Main/SessionHelpers.swift
@@ -7,6 +7,9 @@ import SwiftUI
 func formatModelName(_ model: String) -> String {
     // Shorten common model names for display
     switch model {
+    case "gpt-5.6-sol": "GPT-5.6 Sol"
+    case "gpt-5.6-terra": "GPT-5.6 Terra"
+    case "gpt-5.6-luna": "GPT-5.6 Luna"
     case "gpt-5.5": "GPT-5.5"
     case "gpt-5.4": "GPT-5.4"
     case "gpt-5.4-mini": "GPT-5.4 mini"
@@ -14,6 +17,7 @@ func formatModelName(_ model: String) -> String {
     case "gpt-5": "GPT-5"
     case "gpt-5-mini": "GPT-5 mini"
     case "claude-fable-5": "Claude Fable 5"
+    case "claude-sonnet-5": "Claude Sonnet 5"
     case "claude-opus-4-8": "Claude Opus 4.8"
     case "claude-opus-4-7": "Claude Opus 4.7"
     case "claude-sonnet-4-6": "Claude Sonnet 4.6"

--- a/Apps/Mac/Peekaboo/Features/Settings/SettingsWindow.swift
+++ b/Apps/Mac/Peekaboo/Features/Settings/SettingsWindow.swift
@@ -227,6 +227,9 @@ struct AISettingsView: View {
 
     static let builtinProviderCatalog: [(provider: String, models: [(id: String, name: String)])] = [
         ("openai", [
+            ("gpt-5.6-sol", "GPT-5.6 Sol"),
+            ("gpt-5.6-terra", "GPT-5.6 Terra"),
+            ("gpt-5.6-luna", "GPT-5.6 Luna"),
             ("gpt-5.5", "GPT-5.5"),
             ("gpt-5.4", "GPT-5.4"),
             ("gpt-5.4-mini", "GPT-5.4 mini"),
@@ -236,6 +239,7 @@ struct AISettingsView: View {
         ]),
         ("anthropic", [
             ("claude-fable-5", "Claude Fable 5"),
+            ("claude-sonnet-5", "Claude Sonnet 5"),
             ("claude-opus-4-8", "Claude Opus 4.8"),
             ("claude-opus-4-7", "Claude Opus 4.7"),
             ("claude-sonnet-4-6", "Claude Sonnet 4.6"),
@@ -360,6 +364,9 @@ struct AISettingsView: View {
     private var modelDescriptions: [String: String] {
         [
             // OpenAI models
+            "gpt-5.6-sol": "GPT-5.6 Sol, the flagship GPT-5.6 model for demanding agent tasks.",
+            "gpt-5.6-terra": "GPT-5.6 Terra, a balanced GPT-5.6 model for everyday agent work.",
+            "gpt-5.6-luna": "GPT-5.6 Luna, the fastest and most cost-efficient GPT-5.6 model.",
             "gpt-5.5": "Flagship GPT-5.5 model with 400K context and upgraded tool " +
                 "usage + reasoning.",
             "gpt-5.4": "GPT-5.4 model with 400K context and upgraded tool " +
@@ -375,6 +382,7 @@ struct AISettingsView: View {
             // Anthropic models
             "claude-fable-5": "Claude Fable 5 with 1M context for demanding " +
                 "reasoning and long-horizon agent tasks.",
+            "claude-sonnet-5": "Claude Sonnet 5 with 1M context for fast, capable agent tasks.",
             "claude-opus-4-8": "Claude Opus 4.8 with 1M context for long-running " +
                 "automation and computer-use tasks.",
             "claude-sonnet-4-6": "Claude Sonnet 4.6 with new tools + computer use, " +

--- a/Apps/Mac/PeekabooTests/Models/SessionTests.swift
+++ b/Apps/Mac/PeekabooTests/Models/SessionTests.swift
@@ -27,8 +27,17 @@ struct ConversationSessionTests {
 
     @Test
     func `Supported Anthropic model names remain human readable`() {
+        #expect(formatModelName("claude-fable-5") == "Claude Fable 5")
+        #expect(formatModelName("claude-sonnet-5") == "Claude Sonnet 5")
         #expect(formatModelName("claude-opus-4-7") == "Claude Opus 4.7")
         #expect(formatModelName("claude-sonnet-4-5-20250929") == "Claude Sonnet 4.5")
+    }
+
+    @Test
+    func `GPT-5_6 model names remain human readable`() {
+        #expect(formatModelName("gpt-5.6-sol") == "GPT-5.6 Sol")
+        #expect(formatModelName("gpt-5.6-terra") == "GPT-5.6 Terra")
+        #expect(formatModelName("gpt-5.6-luna") == "GPT-5.6 Luna")
     }
 
     @Test

--- a/Apps/Mac/PeekabooTests/Services/SettingsServiceTests.swift
+++ b/Apps/Mac/PeekabooTests/Services/SettingsServiceTests.swift
@@ -818,6 +818,15 @@ struct PeekabooSettingsConfigHydrationTests {
     }
 
     @Test
+    func `Built-in model picker includes current frontier models`() {
+        #expect(AISettingsView.builtinName(forModelId: "gpt-5.6-sol") == "GPT-5.6 Sol")
+        #expect(AISettingsView.builtinName(forModelId: "gpt-5.6-terra") == "GPT-5.6 Terra")
+        #expect(AISettingsView.builtinName(forModelId: "gpt-5.6-luna") == "GPT-5.6 Luna")
+        #expect(AISettingsView.builtinName(forModelId: "claude-fable-5") == "Claude Fable 5")
+        #expect(AISettingsView.builtinName(forModelId: "claude-sonnet-5") == "Claude Sonnet 5")
+    }
+
+    @Test
     func `Hydrated OpenRouter model remains available in model picker`() {
         let modelGroups = AISettingsView.appendingSelectedOpenRouterModel(
             to: [("openai", [(id: "gpt-5.5", name: "GPT-5.5")])],

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+### Added
+- The agent, CLI, macOS model pickers, and session UI now support Claude Fable 5, Claude Sonnet 5, and the GPT-5.6 Sol, Terra, and Luna preview models, including their current context, output, effort, pricing, and non-streaming safety behavior.
+
 ### Fixed
 - The macOS Sessions window and agent popover stay unavailable while Agent mode is disabled, including Dock reopens, global shortcuts, notifications, and windows already open when the setting is turned off.
 

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/Agent/PeekabooAgentService+Execution.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/Agent/PeekabooAgentService+Execution.swift
@@ -14,7 +14,8 @@ extension PeekabooAgentService {
         let temperature = self.shouldOmitTemperature(for: model) ? nil : self.configuredTemperature(for: model)
 
         return switch model {
-        case .openai(.gpt55), .openai(.gpt54), .openai(.gpt54Mini), .openai(.gpt54Nano), .openai(.gpt5):
+        case .openai(.gpt56Sol), .openai(.gpt56Terra), .openai(.gpt56Luna),
+             .openai(.gpt55), .openai(.gpt54), .openai(.gpt54Mini), .openai(.gpt54Nano), .openai(.gpt5):
             GenerationSettings(
                 maxTokens: maxTokens,
                 temperature: temperature,
@@ -88,6 +89,9 @@ extension PeekabooAgentService {
     private func isOpenAIGPT5TemperatureExcludedModel(_ modelId: String) -> Bool {
         switch self.normalizedOpenAIModelID(modelId) {
         case "chat-latest",
+             "gpt-5.6-sol",
+             "gpt-5.6-terra",
+             "gpt-5.6-luna",
              "gpt-5.5",
              "gpt-5.4",
              "gpt-5.4-mini",
@@ -121,6 +125,9 @@ extension PeekabooAgentService {
         case let .openai(openAIModel):
             switch openAIModel {
             case .chatLatest,
+                 .gpt56Sol,
+                 .gpt56Terra,
+                 .gpt56Luna,
                  .gpt55,
                  .gpt54,
                  .gpt54Mini,
@@ -148,7 +155,11 @@ extension PeekabooAgentService {
         case .mistral, .groq, .grok, .ollama, .lmstudio, .azureOpenAI, .replicate:
             4096
         case let .openRouter(modelId), let .together(modelId), let .openaiCompatible(modelId, _):
-            AnthropicModelCapabilityInference.capabilities(for: modelId)?.maxOutputTokens ?? 4096
+            if let maxOutputTokens = AnthropicModelCapabilityInference.capabilities(for: modelId)?.maxOutputTokens {
+                maxOutputTokens
+            } else {
+                LanguageModel.OpenAI.gpt56Model(for: modelId) == nil ? 4096 : 128_000
+            }
         case let .anthropicCompatible(modelId, _):
             AnthropicModelCapabilityInference.capabilities(for: modelId)?.maxOutputTokens ?? 8192
         }

--- a/Core/PeekabooCore/Sources/PeekabooAutomation/Services/AI/PeekabooAIService.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAutomation/Services/AI/PeekabooAIService.swift
@@ -80,14 +80,18 @@ private final class PeekabooCustomProviderModel: ModelProvider, @unchecked Senda
         let inferredAnthropicCapabilities = kind == .anthropic
             ? AnthropicModelCapabilityInference.capabilities(for: resolvedModelID)
             : nil
-        let inferredMaxOutputTokens = inferredAnthropicCapabilities?.maxOutputTokens ?? 4096
+        let inferredGPT56Model = kind == .openai
+            ? LanguageModel.OpenAI.gpt56Model(for: resolvedModelID)
+            : nil
+        let inferredMaxOutputTokens = inferredAnthropicCapabilities?.maxOutputTokens ??
+            (inferredGPT56Model == nil ? 4096 : 128_000)
         let hasStreamingRefusalRisk = inferredAnthropicCapabilities.map { !$0.supportsStreaming } ??
             LanguageModel.Anthropic.hasStreamingRefusalRisk(modelId: resolvedModelID)
         self.capabilities = ModelCapabilities(
             supportsVision: supportsVision,
             supportsTools: supportsTools,
             supportsStreaming: !hasStreamingRefusalRisk,
-            contextLength: inferredAnthropicCapabilities?.contextLength ?? 128_000,
+            contextLength: inferredAnthropicCapabilities?.contextLength ?? inferredGPT56Model?.contextLength ?? 128_000,
             maxOutputTokens: maxOutputTokens ?? inferredMaxOutputTokens)
     }
 

--- a/Core/PeekabooCore/Tests/PeekabooTests/AnthropicModelTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/AnthropicModelTests.swift
@@ -83,6 +83,7 @@ struct AnthropicModelTests {
     func `Anthropic vision model capabilities`() {
         let visionCapableModels = [
             Model.anthropic(.fable5),
+            Model.anthropic(.sonnet5),
             Model.anthropic(.opus45),
             Model.anthropic(.sonnet46),
             Model.anthropic(.haiku45),
@@ -111,6 +112,7 @@ struct AnthropicModelTests {
 
         // Current Anthropic context windows are model-specific, not a simple family hierarchy.
         #expect(Model.anthropic(.fable5).contextLength == 1_000_000)
+        #expect(Model.anthropic(.sonnet5).contextLength == 1_000_000)
         #expect(Model.anthropic(.opus48).contextLength == 1_000_000)
         #expect(sonnet46.contextLength == 1_000_000)
         #expect(opus45.contextLength == 500_000)
@@ -121,10 +123,12 @@ struct AnthropicModelTests {
     @Test
     func `Anthropic current models support tools`() {
         let fable5 = Model.anthropic(.fable5)
+        let sonnet5 = Model.anthropic(.sonnet5)
         let opus48 = Model.anthropic(.opus48)
         let sonnet46 = Model.anthropic(.sonnet46)
 
         #expect(fable5.providerName == "Anthropic")
+        #expect(sonnet5.providerName == "Anthropic")
         #expect(opus48.providerName == "Anthropic")
         #expect(sonnet46.providerName == "Anthropic")
 
@@ -134,6 +138,8 @@ struct AnthropicModelTests {
 
         #expect(fable5.supportsTools == true)
         #expect(fable5.supportsStreaming == false)
+        #expect(sonnet5.supportsTools == true)
+        #expect(sonnet5.supportsStreaming == false)
         #expect(opus48.supportsTools == true)
         #expect(sonnet46.supportsTools == true)
     }

--- a/Core/PeekabooCore/Tests/PeekabooTests/PeekabooAgentGenerationSettingsTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/PeekabooAgentGenerationSettingsTests.swift
@@ -72,7 +72,7 @@ struct PeekabooAgentGenerationSettingsTests {
         try self.withTemporaryConfig(
             """
             {
-              "agent": { "temperature": 0.7 }
+              "agent": { "temperature": 0.7, "maxTokens": 128000 }
             }
             """) {
                 let agentService = try PeekabooAgentService(services: PeekabooServices())
@@ -81,6 +81,66 @@ struct PeekabooAgentGenerationSettingsTests {
                     baseURL: "https://openai-compatible.example"))
 
                 #expect(settings.temperature == nil)
+            }
+    }
+
+    @Test
+    @MainActor
+    func `OpenAI compatible GPT-5_6 models omit unsupported temperature`() throws {
+        try self.withTemporaryConfig(
+            """
+            {
+              "agent": { "temperature": 0.7, "maxTokens": 128000 }
+            }
+            """) {
+                let agentService = try PeekabooAgentService(services: PeekabooServices())
+
+                for modelId in ["gpt-5.6-sol", "openai/gpt-5.6-terra", "gpt-5.6-luna"] {
+                    let settings = agentService.generationSettings(for: .openaiCompatible(
+                        modelId: modelId,
+                        baseURL: "https://openai-compatible.example"))
+                    #expect(settings.temperature == nil)
+                    #expect(settings.maxTokens == 128_000)
+                }
+            }
+    }
+
+    @Test
+    @MainActor
+    func `Configured custom OpenAI GPT-5_6 model infers large output limit`() throws {
+        try self.withTemporaryConfig(
+            """
+            {
+              "aiProviders": { "providers": "local-openai/gpt-5.6-sol" },
+              "agent": { "maxTokens": 128000 },
+              "customProviders": {
+                "local-openai": {
+                  "name": "Local OpenAI",
+                  "type": "openai",
+                  "enabled": true,
+                  "options": {
+                    "baseURL": "https://openai-compatible.example",
+                    "apiKey": "test-key"
+                  },
+                  "models": {
+                    "gpt-5.6-sol": {
+                      "name": "GPT-5.6 Sol",
+                      "supportsTools": true
+                    }
+                  }
+                }
+              }
+            }
+            """) {
+                let configuration = ConfigurationManager.shared
+                _ = configuration.loadConfiguration()
+                let aiService = PeekabooAIService(configuration: configuration)
+                let model = try #require(aiService.availableModels().first)
+                let agentService = try PeekabooAgentService(services: PeekabooServices())
+
+                #expect(model.modelId == "local-openai/gpt-5.6-sol")
+                #expect(model.contextLength == 372_000)
+                #expect(agentService.generationSettings(for: model).maxTokens == 128_000)
             }
     }
 

--- a/Core/PeekabooCore/Tests/PeekabooTests/PeekabooAgentServiceModelTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/PeekabooAgentServiceModelTests.swift
@@ -71,6 +71,37 @@ extension PeekabooAgentServiceTests {
 
     @Test
     @MainActor
+    func `Sonnet 5 and GPT-5_6 generation settings preserve current model capabilities`() throws {
+        try self.withIsolatedAgentEnvironment(
+            [:],
+            configurationJSON: """
+            {
+              "agent": {
+                "maxTokens": 128000,
+                "temperature": 0.2
+              }
+            }
+            """) {
+                let agentService = try PeekabooAgentService(services: self.makeServices())
+                let sonnetSettings = agentService.generationSettings(for: .anthropic(.sonnet5))
+
+                #expect(sonnetSettings.maxTokens == 128_000)
+                #expect(sonnetSettings.temperature == 0.2)
+
+                for model in [
+                    LanguageModel.openai(.gpt56Sol),
+                    .openai(.gpt56Terra),
+                    .openai(.gpt56Luna),
+                ] {
+                    let settings = agentService.generationSettings(for: model)
+                    #expect(settings.maxTokens == 128_000)
+                    #expect(settings.providerOptions.openai?.verbosity == .medium)
+                }
+            }
+    }
+
+    @Test
+    @MainActor
     func `Generation settings clamp max tokens to provider capabilities`() throws {
         try self.withIsolatedAgentEnvironment(
             [:],
@@ -1862,6 +1893,7 @@ extension PeekabooAgentServiceTests {
             "PEEKABOO_MISSING_PROVIDER_KEY",
             "MINIMAX_API_KEY",
             "MINIMAX_CN_API_KEY",
+            "MOONSHOT_API_KEY",
             "PEEKABOO_OLLAMA_BASE_URL",
             "OLLAMA_BASE_URL",
         ]
@@ -1905,6 +1937,7 @@ extension PeekabooAgentServiceTests {
         unsetenv("PEEKABOO_MISSING_PROVIDER_KEY")
         unsetenv("MINIMAX_API_KEY")
         unsetenv("MINIMAX_CN_API_KEY")
+        unsetenv("MOONSHOT_API_KEY")
         unsetenv("PEEKABOO_OLLAMA_BASE_URL")
         unsetenv("OLLAMA_BASE_URL")
         TachikomaConfiguration.current.removeAPIKey(for: .grok)
@@ -1936,6 +1969,7 @@ extension PeekabooAgentServiceTests {
             "PEEKABOO_MISSING_PROVIDER_KEY",
             "MINIMAX_API_KEY",
             "MINIMAX_CN_API_KEY",
+            "MOONSHOT_API_KEY",
             "PEEKABOO_OLLAMA_BASE_URL",
             "OLLAMA_BASE_URL",
         ]
@@ -1979,6 +2013,7 @@ extension PeekabooAgentServiceTests {
         unsetenv("PEEKABOO_MISSING_PROVIDER_KEY")
         unsetenv("MINIMAX_API_KEY")
         unsetenv("MINIMAX_CN_API_KEY")
+        unsetenv("MOONSHOT_API_KEY")
         unsetenv("PEEKABOO_OLLAMA_BASE_URL")
         unsetenv("OLLAMA_BASE_URL")
         for (key, value) in overrides {

--- a/Core/PeekabooCore/Tests/PeekabooTests/PeekabooAgentStreamingContentFilterTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/PeekabooAgentStreamingContentFilterTests.swift
@@ -43,6 +43,7 @@ struct PeekabooAgentStreamingContentFilterTests {
             defaultModel: .anthropic(.opus48))
 
         #expect(agentService.buffersAgentTextStreamUntilDone(for: .anthropic(.fable5)))
+        #expect(agentService.buffersAgentTextStreamUntilDone(for: .anthropic(.sonnet5)))
         #expect(agentService.buffersAgentTextStreamUntilDone(for: .anthropic(.opus48)))
         #expect(!agentService.buffersAgentTextStreamUntilDone(for: .anthropic(.opus47)))
         #expect(!agentService.buffersAgentTextStreamUntilDone(for: .anthropic(.sonnet46)))

--- a/docs/commands/agent.md
+++ b/docs/commands/agent.md
@@ -16,7 +16,7 @@ read_when:
 | `--chat` | Force the interactive chat loop even when stdin/stdout are not TTYs. |
 | `--dry-run` | Emit the planned steps without actually invoking tools. |
 | `--max-steps <n>` | Cap how many tool invocations the agent may issue before aborting (default: 100). |
-| `--model gpt-5.5|claude-fable-5|gemini-3-flash|minimax|minimax-cn/<model>|openrouter/<provider>/<model>|ollama/<model>|lmstudio/<model>` | Override the default model (`gpt-5.5`). Input is validated against supported hosted providers and local model providers. |
+| `--model gpt-5.6|gpt-5.5|claude-fable-5|claude-sonnet-5|gemini-3-flash|minimax|minimax-cn/<model>|openrouter/<provider>/<model>|ollama/<model>|lmstudio/<model>` | Override the default model (`gpt-5.5`). Input is validated against supported hosted providers and local model providers. |
 | `--resume` / `--resume-session <id>` | Continue the most recent session or a specific session ID. |
 | `--list-sessions` | Print cached sessions (id, task, timestamps, message count) instead of running anything. |
 | `--no-cache` | Always create a fresh session even if one is already active. |
@@ -49,6 +49,12 @@ For automation flows that cannot attach to a TTY, pass both `--chat` and standar
 ```bash
 # Let the agent sign into Slack using GPT-5.5 with verbose tracing
 peekaboo agent "Check Slack mentions" --model gpt-5.5 --verbose
+
+# Use GPT-5.6 Sol (the gpt-5.6 shortcut selects Sol)
+peekaboo agent "Check the current window" --model gpt-5.6
+
+# Use Claude Sonnet 5
+peekaboo agent "Check the current window" --model claude-sonnet-5
 
 # Keep the agent loop local through Ollama
 peekaboo agent "Check the current window" --model ollama/llama3.3

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -18,8 +18,8 @@ pages instead of duplicating provider lists in multiple places.
 
 | Provider | Models we test | Credential |
 | --- | --- | --- |
-| **OpenAI** | gpt-5, gpt-5-mini, gpt-4.1 | `OPENAI_API_KEY` |
-| **Anthropic** | claude-fable-5, claude-opus-4-8, claude-sonnet-4-6, claude-haiku-4-5 | `ANTHROPIC_API_KEY` |
+| **OpenAI** | gpt-5.6-sol, gpt-5.6-terra, gpt-5.6-luna, gpt-5.5, gpt-5 | `OPENAI_API_KEY` |
+| **Anthropic** | claude-fable-5, claude-sonnet-5, claude-opus-4-8, claude-sonnet-4-6, claude-haiku-4-5 | `ANTHROPIC_API_KEY` |
 | **xAI** | grok-4 | `XAI_API_KEY` |
 | **Google** | gemini-3.1-pro-preview, gemini-3-flash | `GEMINI_API_KEY` |
 | **MiniMax** | MiniMax-M3, MiniMax-M2.7, MiniMax-M2.7-highspeed | `MINIMAX_API_KEY` |
@@ -56,7 +56,10 @@ See [configuration.md](configuration.md) for the full precedence table.
 ## Picking a model
 
 ```bash
+peekaboo agent --model gpt-5.6 "summarize this window"
+peekaboo agent --model gpt-5.6-terra "summarize this window"
 peekaboo agent --model claude-fable-5 "summarize this window"
+peekaboo agent --model claude-sonnet-5 "summarize this window"
 peekaboo agent --model claude-opus-4-8 "summarize this window"
 peekaboo agent --model gemini-3-flash "summarize this window"
 peekaboo agent --model minimax/MiniMax-M3 "summarize this window"
@@ -71,7 +74,7 @@ peekaboo agent --model lmstudio/openai/gpt-oss-120b "summarize this window"
 Defaults come from `agent.defaultModel` in `~/.peekaboo/config.json`. Anthropic defaults stay on Opus 4.8 for zero-retention compatibility; select Fable explicitly when your Anthropic organization allows it. Set a per-project default with `PEEKABOO_AGENT_MODEL`.
 
 The app and CLI share `agent.temperature` and `agent.maxTokens`. Peekaboo clamps those requests to provider
-capabilities; Fable supports a 1M context window and up to 128K output. See
+capabilities; Fable 5 and Sonnet 5 support 1M context windows and up to 128K output. See
 [configuration.md](configuration.md#agent-generation-settings).
 
 ## Tool calling

--- a/docs/providers/anthropic.md
+++ b/docs/providers/anthropic.md
@@ -15,14 +15,16 @@ tool calls, vision, thinking blocks, and provider-specific event handling.
 | Model | Context | Max output | Notes |
 | --- | ---: | ---: | --- |
 | `claude-fable-5` | 1M | 128K | Explicit opt-in for long-horizon agent work. |
+| `claude-sonnet-5` | 1M | 128K | Fast frontier model with adaptive thinking on by default. |
 | `claude-opus-4-8` | 1M | 128K | Default Anthropic choice; compatible with zero-retention organizations. |
 | `claude-sonnet-4-6` | 1M | 64K | Balanced speed and capability. |
 | `claude-haiku-4-5` | 200K | 64K | Fast, lower-cost tasks. |
 
-Fable is not the automatic Anthropic default. Select it explicitly when your Anthropic organization allows the model:
+Fable 5 and Sonnet 5 are not the automatic Anthropic default. Select either explicitly when your Anthropic organization allows the model:
 
 ```bash
 peekaboo agent --model claude-fable-5 "inspect this app and summarize its workflow"
+peekaboo agent --model claude-sonnet-5 "inspect this app and summarize its workflow"
 ```
 
 ## Credentials
@@ -46,11 +48,11 @@ The app and CLI read the same `agent.temperature` and `agent.maxTokens` values f
 `~/.peekaboo/config.json`. Peekaboo clamps the token request to the selected model's output capability and strips
 sampling parameters from current adaptive-thinking models when the Anthropic API does not accept them.
 
-Fable and Opus 4.8 currently use the non-streaming generation path so signed thinking history and rollback behavior
+Fable 5, Sonnet 5, and Opus 4.8 currently use the non-streaming generation path so signed thinking history and rollback behavior
 remain valid. Agent progress events still report start, assistant output, tool activity, completion, and errors.
 
-Anthropic-compatible custom providers inherit known Fable capability limits when their model ID is
-`claude-fable-5` (including provider-qualified forms). A custom model's explicit `maxTokens` value takes precedence
+Anthropic-compatible custom providers inherit known capability limits for `claude-fable-5` and `claude-sonnet-5`
+(including provider-qualified forms). A custom model's explicit `maxTokens` value takes precedence
 for other IDs.
 
 See [configuration.md](../configuration.md) for the shared settings schema and [providers.md](../providers.md) for


### PR DESCRIPTION
## Summary

- expose Claude Fable 5, Claude Sonnet 5, and GPT-5.6 Sol, Terra, and Luna across the CLI, macOS model catalogs, session labels, and agent execution
- add friendly aliases (`fable`, `sonnet`, and `gpt-5.6`) while rejecting unknown GPT-5.6 variants
- update the Tachikoma dependency to landed first-class provider support, compatible-endpoint limits, and dated Sonnet 5 pricing from openclaw/Tachikoma#30-#32

## Tests

- `pnpm run test:safe` (634 tests)
- focused PeekabooCore model, generation-settings, and streaming-filter tests (92 tests)
- focused macOS picker and session-label tests
- `./scripts/build-mac-debug.sh`
- live CLI dry-run validation for all canonical IDs and aliases; invalid `gpt-5.6-mars` rejected
- live debug-app session window validation with Agent mode enabled
- Tachikoma `swift test --no-parallel` (791 tests) plus full hosted platform matrix
- `pnpm run format`
- `pnpm run lint` (20 pre-existing warnings, 0 errors)
- autoreview: clean; provider-matrix claims cross-checked against current official/catalog contracts
