### PR TITLE
feat(visualizer): replace click reticle and mouse comet with an animated macOS-style cursor

### DIFF
--- a/Apps/CLI/Sources/PeekabooCLI/Commands/System/VisualizerCommand.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/System/VisualizerCommand.swift
@@ -99,7 +99,7 @@ private struct VisualizerSmokeSequence {
     private static let stepNames = [
         "Screenshot flash",
         "Watch capture HUD",
-        "Click ripple",
+        "Cursor click",
         "Typing indicator",
         "Scroll indicator",
         "Mouse movement trail",
@@ -154,7 +154,7 @@ private struct VisualizerSmokeSequence {
             await client.showWatchCapture(in: primaryRect)
         })
 
-        try await steps.append(self.step("Click ripple") {
+        try await steps.append(self.step("Cursor click") {
             await client.showClickFeedback(at: point, type: .single)
         })
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+### Changed
+- Clicks and mouse moves are now visualized by a small animated macOS-style cursor that glides to the target and presses (double-press for double-click, blue-tinted for right-click), replacing the targeting reticle and comet.
+
 ## [3.7.1] - 2026-07-05
 
 ### Changed

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/UIAutomationService+Operations.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/UIAutomationService+Operations.swift
@@ -115,9 +115,9 @@ extension UIAutomationService {
      *
      * ## Visual Feedback
      * When visualizer is connected, shows:
-     * - Ripple animation at click location
-     * - Click type indicator (single, double, right)
-     * - Targeting crosshairs for precision feedback
+     * - Animated cursor gliding to the click location
+     * - Visible single, double, or right-button press
+     * - Subtle click ring centered on the cursor hotspot
      *
      * ## Performance
      * - **Element Resolution**: 10-50ms for cached elements

--- a/Core/PeekabooVisualizer/Sources/PeekabooVisualizer/Renderer/VisualizerCoordinator+AnimationAPI.swift
+++ b/Core/PeekabooVisualizer/Sources/PeekabooVisualizer/Renderer/VisualizerCoordinator+AnimationAPI.swift
@@ -103,7 +103,7 @@ extension VisualizerCoordinator {
         ].joined(separator: " ")
         self.logger.info("\(message, privacy: .public)")
 
-        // Short hops don't need a comet, and rapid successive moves would
+        // Short hops don't need a cursor trail, and rapid successive moves would
         // paint overlapping trails.
         let distance = hypot(to.x - from.x, to.y - from.y)
         guard distance >= FeedbackThrottle.minimumTrailDistance else { return true }

--- a/Core/PeekabooVisualizer/Sources/PeekabooVisualizer/Renderer/VisualizerCoordinator+InputDisplays.swift
+++ b/Core/PeekabooVisualizer/Sources/PeekabooVisualizer/Renderer/VisualizerCoordinator+InputDisplays.swift
@@ -78,7 +78,7 @@ extension VisualizerCoordinator {
         _ = self.overlayManager.showAnimation(
             at: Self.paddedRect(rect, padding: Self.OverlayPadding.click),
             content: clickView,
-            duration: self.scaledDuration(AnimationBaseline.clickRipple),
+            duration: self.scaledDuration(AnimationBaseline.clickCursor),
             fadeOut: true)
 
         return true
@@ -179,7 +179,7 @@ extension VisualizerCoordinator {
             to: Self.windowLocalPoint(to, in: windowRect),
             duration: mouseDuration)
 
-        // Comet coordinates are window-local; the travel padding is the margin.
+        // Cursor-trail coordinates are window-local; the travel padding is the margin.
         _ = self.overlayManager.showAnimation(
             at: windowRect,
             content: mouseView,

--- a/Core/PeekabooVisualizer/Sources/PeekabooVisualizer/Renderer/VisualizerCoordinator.swift
+++ b/Core/PeekabooVisualizer/Sources/PeekabooVisualizer/Renderer/VisualizerCoordinator.swift
@@ -38,7 +38,7 @@ public final class VisualizerCoordinator {
 
     enum AnimationBaseline {
         static let screenshotFlash: TimeInterval = 0.35
-        static let clickRipple: TimeInterval = 0.45
+        static let clickCursor: TimeInterval = 1.15
         static let typingOverlay: TimeInterval = 1.2
         static let scrollIndicator: TimeInterval = 0.6
         static let mouseTrail: TimeInterval = 0.75
@@ -62,7 +62,7 @@ public final class VisualizerCoordinator {
         static let scroll: TimeInterval = 0.3
         static let mouseTrail: TimeInterval = 0.4
         static let elementDetection: TimeInterval = 1.0
-        /// Mouse moves shorter than this aren't worth a comet.
+        /// Mouse moves shorter than this aren't worth a cursor trail.
         static let minimumTrailDistance: CGFloat = 80
     }
 

--- a/Core/PeekabooVisualizer/Sources/PeekabooVisualizer/Views/ClickAnimationView.swift
+++ b/Core/PeekabooVisualizer/Sources/PeekabooVisualizer/Views/ClickAnimationView.swift
@@ -2,15 +2,14 @@
 //  ClickAnimationView.swift
 //  Peekaboo
 //
-//  A targeting reticle that locks onto the click point and pulses on impact.
+//  A macOS-style cursor that glides to the click point and visibly presses.
 //
 
 import PeekabooFoundation
 import SwiftUI
 
-/// Click feedback: an outer ring contracts onto the point, a center dot pops,
-/// and an impact pulse expands outward. Double-click pulses twice; right-click
-/// uses a dashed ring to hint at a context menu.
+/// Click feedback: a cursor glides onto the point, presses, and emits a subtle ripple.
+/// Double-click presses twice; right-click uses the secondary accent.
 struct ClickAnimationView: View {
     // MARK: - Properties
 
@@ -21,130 +20,134 @@ struct ClickAnimationView: View {
     let durationScale: Double
 
     /// Animation state
-    @State private var ringDiameter: CGFloat = 130
-    @State private var ringOpacity: Double = 0
-    @State private var dotScale: CGFloat = 0.2
-    @State private var dotOpacity: Double = 0
-    @State private var glowOpacity: Double = 0
-    @State private var reticleOpacity: Double = 1
+    @State private var cursorOffset = CGSize(width: 60, height: 50)
+    @State private var cursorOpacity: Double = 0
+    @State private var cursorScale: CGFloat = 1.12
+
+    private let clickPoint = CGPoint(x: 160, y: 160)
 
     private var tint: Color {
         self.clickType == .right ? VisualizerTheme.accentSecondary : VisualizerTheme.accent
     }
 
-    private var ringStyle: StrokeStyle {
-        switch self.clickType {
-        case .right:
-            StrokeStyle(lineWidth: 2.5, lineCap: .round, dash: [7, 6])
-        case .single, .double:
-            StrokeStyle(lineWidth: 2.5, lineCap: .round)
-        }
-    }
-
-    private var pulseDelays: [Double] {
-        self.clickType == .double ? [0.22, 0.36] : [0.22]
+    private var pressDelays: [Double] {
+        self.clickType == .double ? [0.36, 0.62] : [0.36]
     }
 
     // MARK: - Body
 
     var body: some View {
-        ZStack {
-            // Soft bloom behind the impact point
-            Circle()
-                .fill(
-                    RadialGradient(
-                        colors: [self.tint.opacity(0.45), self.tint.opacity(0)],
-                        center: .center,
-                        startRadius: 0,
-                        endRadius: 44))
-                .frame(width: 88, height: 88)
-                .opacity(self.glowOpacity)
-
-            // Targeting ring that contracts onto the point
-            Circle()
-                .stroke(self.tint, style: self.ringStyle)
-                .frame(width: self.ringDiameter, height: self.ringDiameter)
-                .opacity(self.ringOpacity)
-
-            // Impact pulses expanding outward
-            ForEach(Array(self.pulseDelays.enumerated()), id: \.offset) { _, delay in
-                ImpactPulseView(tint: self.tint, delay: delay * self.durationScale, duration: 0.3 * self.durationScale)
+        ZStack(alignment: .topLeading) {
+            ForEach(Array(self.pressDelays.enumerated()), id: \.offset) { _, delay in
+                ClickRippleView(
+                    tint: self.tint,
+                    delay: delay * self.durationScale,
+                    duration: 0.3 * self.durationScale)
+                    .position(self.clickPoint)
             }
 
-            // Center dot
-            Circle()
-                .fill(self.tint)
-                .frame(width: 9, height: 9)
-                .scaleEffect(self.dotScale)
-                .opacity(self.dotOpacity)
-                .shadow(color: self.tint.opacity(0.8), radius: 6)
+            CursorGlyphView()
+                .scaleEffect(self.cursorScale, anchor: .topLeading)
+                .opacity(self.cursorOpacity)
+                .offset(
+                    x: self.clickPoint.x + self.cursorOffset.width,
+                    y: self.clickPoint.y + self.cursorOffset.height)
         }
-        .opacity(self.reticleOpacity)
         .frame(width: 320, height: 320)
-        .onAppear {
-            self.startAnimation()
+        .task {
+            await self.startAnimation()
         }
     }
 
     // MARK: - Methods
 
-    private func startAnimation() {
+    private func startAnimation() async {
         let scale = self.durationScale
 
-        // Ring locks onto the target
-        withAnimation(VisualizerMotion.enter(0.1 * scale)) {
-            self.ringOpacity = 1
+        withAnimation(VisualizerMotion.enter(0.12 * scale)) {
+            self.cursorOpacity = 1
         }
-        withAnimation(VisualizerMotion.enter(0.26 * scale)) {
-            self.ringDiameter = 46
-        }
-
-        // Center dot pops with a glow bloom
-        withAnimation(VisualizerMotion.pop(0.3 * scale).delay(0.06 * scale)) {
-            self.dotScale = 1.0
-            self.dotOpacity = 1
-        }
-        withAnimation(VisualizerMotion.enter(0.2 * scale).delay(0.16 * scale)) {
-            self.glowOpacity = 1
-        }
-        withAnimation(VisualizerMotion.exit(0.18 * scale).delay(0.34 * scale)) {
-            self.glowOpacity = 0
+        withAnimation(VisualizerMotion.glide(0.32 * scale)) {
+            self.cursorOffset = .zero
+            self.cursorScale = 1
         }
 
-        // Everything dissolves at the end
-        withAnimation(VisualizerMotion.exit(0.14 * scale).delay(0.31 * scale)) {
-            self.reticleOpacity = 0
-            self.dotScale = 0.6
+        await self.sleep(0.36 * scale)
+        guard !Task.isCancelled else { return }
+        withAnimation(VisualizerMotion.pop(0.1 * scale)) {
+            self.cursorScale = 0.82
         }
+
+        await self.sleep(0.14 * scale)
+        guard !Task.isCancelled else { return }
+        withAnimation(VisualizerMotion.settle(0.16 * scale)) {
+            self.cursorScale = 1
+        }
+
+        if self.clickType == .double {
+            await self.sleep(0.12 * scale)
+            guard !Task.isCancelled else { return }
+            withAnimation(VisualizerMotion.pop(0.1 * scale)) {
+                self.cursorScale = 0.82
+            }
+
+            await self.sleep(0.14 * scale)
+            guard !Task.isCancelled else { return }
+            withAnimation(VisualizerMotion.settle(0.16 * scale)) {
+                self.cursorScale = 1
+            }
+        }
+
+        await self.sleep(0.2 * scale)
+        guard !Task.isCancelled else { return }
+        withAnimation(VisualizerMotion.exit(0.15 * scale)) {
+            self.cursorOpacity = 0
+        }
+    }
+
+    private func sleep(_ seconds: Double) async {
+        try? await Task.sleep(nanoseconds: UInt64(seconds * 1_000_000_000))
     }
 }
 
-/// A single expanding impact ring.
-private struct ImpactPulseView: View {
+/// A small expanding click ring centered on the cursor hotspot.
+private struct ClickRippleView: View {
     let tint: Color
     let delay: Double
     let duration: Double
 
-    @State private var pulseScale: CGFloat = 0.3
-    @State private var pulseOpacity: Double = 0
+    @State private var diameter: CGFloat = 10
+    @State private var rippleOpacity: Double = 0
 
     var body: some View {
         Circle()
-            .stroke(self.tint, lineWidth: 2)
-            .frame(width: 150, height: 150)
-            .scaleEffect(self.pulseScale)
-            .opacity(self.pulseOpacity)
-            .onAppear {
-                withAnimation(VisualizerMotion.enter(0.05).delay(self.delay)) {
-                    self.pulseOpacity = 0.9
-                }
-                withAnimation(VisualizerMotion.enter(self.duration).delay(self.delay)) {
-                    self.pulseScale = 1.0
-                }
-                withAnimation(VisualizerMotion.exit(self.duration * 0.7).delay(self.delay + self.duration * 0.3)) {
-                    self.pulseOpacity = 0
-                }
+            .stroke(self.tint, lineWidth: 1.5)
+            .frame(width: self.diameter, height: self.diameter)
+            .opacity(self.rippleOpacity)
+            .task {
+                await self.animateRipple()
             }
+    }
+
+    private func animateRipple() async {
+        await self.sleep(self.delay)
+        guard !Task.isCancelled else { return }
+        withAnimation(VisualizerMotion.enter(0.02 * self.duration / 0.3)) {
+            self.rippleOpacity = 0.85
+        }
+        withAnimation(VisualizerMotion.glide(self.duration)) {
+            self.diameter = 34
+        }
+
+        await self.sleep(self.duration * 0.1)
+        guard !Task.isCancelled else { return }
+        withAnimation(VisualizerMotion.exit(self.duration * 0.9)) {
+            self.rippleOpacity = 0
+        }
+    }
+
+    private func sleep(_ seconds: Double) async {
+        try? await Task.sleep(nanoseconds: UInt64(seconds * 1_000_000_000))
     }
 }
 

--- a/Core/PeekabooVisualizer/Sources/PeekabooVisualizer/Views/CursorGlyphView.swift
+++ b/Core/PeekabooVisualizer/Sources/PeekabooVisualizer/Views/CursorGlyphView.swift
@@ -1,0 +1,46 @@
+//
+//  CursorGlyphView.swift
+//  Peekaboo
+//
+//  A crisp macOS-style arrow cursor whose tip is its top-leading hotspot.
+//
+
+import SwiftUI
+
+/// Classic arrow-pointer polygon with its hotspot at the path's top-leading origin.
+struct CursorShape: Shape {
+    func path(in rect: CGRect) -> Path {
+        let scale = min(rect.width / 13, rect.height / 20)
+
+        return Path { path in
+            path.move(to: CGPoint(x: rect.minX, y: rect.minY))
+            path.addLine(to: CGPoint(x: rect.minX, y: rect.minY + 17.5 * scale))
+            path.addLine(to: CGPoint(x: rect.minX + 4.2 * scale, y: rect.minY + 13.6 * scale))
+            path.addLine(to: CGPoint(x: rect.minX + 7 * scale, y: rect.minY + 19.8 * scale))
+            path.addLine(to: CGPoint(x: rect.minX + 9.8 * scale, y: rect.minY + 18.6 * scale))
+            path.addLine(to: CGPoint(x: rect.minX + 7 * scale, y: rect.minY + 12.5 * scale))
+            path.addLine(to: CGPoint(x: rect.minX + 12.6 * scale, y: rect.minY + 12.5 * scale))
+            path.closeSubpath()
+        }
+    }
+}
+
+/// macOS-style cursor glyph. Position and scale from `.topLeading` to keep the tip on the hotspot.
+struct CursorGlyphView: View {
+    let height: CGFloat
+
+    init(height: CGFloat = 22) {
+        self.height = height
+    }
+
+    var body: some View {
+        CursorShape()
+            .fill(.black)
+            .overlay {
+                CursorShape()
+                    .stroke(.white, lineWidth: 1.5)
+            }
+            .frame(width: self.height * 13 / 20, height: self.height)
+            .shadow(color: .black.opacity(0.35), radius: 3, y: 1.5)
+    }
+}

--- a/Core/PeekabooVisualizer/Sources/PeekabooVisualizer/Views/MouseTrailView.swift
+++ b/Core/PeekabooVisualizer/Sources/PeekabooVisualizer/Views/MouseTrailView.swift
@@ -2,14 +2,14 @@
 //  MouseTrailView.swift
 //  Peekaboo
 //
-//  A comet with a tapered glowing trail tracing the cursor's travel.
+//  A macOS-style cursor tracing its travel with a subtle tapered trail.
 //
 
 import SwiftUI
 
-/// Mouse-movement feedback: a glowing head glides from start to destination,
-/// stretching a soft gradient tail behind it, and lands with a small ring.
-/// Points are window-local SwiftUI coordinates (top-left origin).
+/// Mouse-movement feedback: a cursor glides from start to destination,
+/// stretching a soft gradient tail behind it. Points are window-local
+/// SwiftUI coordinates (top-left origin).
 struct MouseTrailView: View {
     let fromPoint: CGPoint
     let toPoint: CGPoint
@@ -17,9 +17,7 @@ struct MouseTrailView: View {
 
     @State private var progress: CGFloat = 0
     @State private var trailOpacity: Double = 1
-    @State private var headOpacity: Double = 0
-    @State private var landingScale: CGFloat = 0.3
-    @State private var landingOpacity: Double = 0
+    @State private var cursorOpacity: Double = 0
 
     init(from: CGPoint, to: CGPoint, duration: TimeInterval = 1.0) {
         self.fromPoint = from
@@ -28,47 +26,30 @@ struct MouseTrailView: View {
     }
 
     var body: some View {
-        ZStack {
+        ZStack(alignment: .topLeading) {
             // Soft afterglow beneath the trail
             self.trailPath
                 .trim(from: max(0, self.progress - 0.35), to: self.progress)
                 .stroke(
-                    VisualizerTheme.accent.opacity(0.35),
+                    VisualizerTheme.accent.opacity(0.22),
                     style: StrokeStyle(lineWidth: 8, lineCap: .round))
                 .blur(radius: 5)
                 .opacity(self.trailOpacity)
 
-            // Tapered comet tail
+            // Tapered cursor trail
             self.trailPath
                 .trim(from: max(0, self.progress - 0.35), to: self.progress)
                 .stroke(
                     self.travelGradient,
-                    style: StrokeStyle(lineWidth: 3.5, lineCap: .round))
+                    style: StrokeStyle(lineWidth: 2.5, lineCap: .round))
                 .opacity(self.trailOpacity)
 
-            // Comet head
-            Circle()
-                .fill(.white)
-                .frame(width: 7, height: 7)
-                .background(
-                    Circle()
-                        .fill(VisualizerTheme.accent)
-                        .frame(width: 15, height: 15)
-                        .blur(radius: 3))
-                .position(self.headPosition)
-                .opacity(self.headOpacity)
-                .shadow(color: VisualizerTheme.accent.opacity(0.9), radius: 7)
-
-            // Landing ring at the destination
-            Circle()
-                .stroke(VisualizerTheme.accent, lineWidth: 2)
-                .frame(width: 34, height: 34)
-                .scaleEffect(self.landingScale)
-                .opacity(self.landingOpacity)
-                .position(self.toPoint)
+            CursorGlyphView()
+                .opacity(self.cursorOpacity)
+                .offset(x: self.cursorPosition.x, y: self.cursorPosition.y)
         }
-        .onAppear {
-            self.animateTrail()
+        .task {
+            await self.animateTrail()
         }
     }
 
@@ -79,13 +60,13 @@ struct MouseTrailView: View {
         }
     }
 
-    private var headPosition: CGPoint {
+    private var cursorPosition: CGPoint {
         CGPoint(
             x: self.fromPoint.x + (self.toPoint.x - self.fromPoint.x) * self.progress,
             y: self.fromPoint.y + (self.toPoint.y - self.fromPoint.y) * self.progress)
     }
 
-    /// Gradient oriented along the travel direction so the tail fades out behind the head.
+    /// Gradient oriented along the travel direction so the tail fades out behind the cursor.
     private var travelGradient: LinearGradient {
         LinearGradient(
             colors: [VisualizerTheme.accent.opacity(0.05), VisualizerTheme.accentSecondary, .white],
@@ -100,30 +81,26 @@ struct MouseTrailView: View {
             y: (point.y - bounds.minY) / max(bounds.height, 1))
     }
 
-    private func animateTrail() {
+    private func animateTrail() async {
         let travel = max(self.duration * 0.75, 0.15)
 
         withAnimation(VisualizerMotion.enter(0.1)) {
-            self.headOpacity = 1
+            self.cursorOpacity = 1
         }
         withAnimation(VisualizerMotion.glide(travel)) {
-            self.progress = 1.0
+            self.progress = 1
         }
 
-        // Landing ring blooms as the head arrives
-        withAnimation(VisualizerMotion.enter(0.25).delay(travel * 0.9)) {
-            self.landingScale = 1.0
-            self.landingOpacity = 0.9
-        }
-        withAnimation(VisualizerMotion.exit(0.2).delay(travel + 0.15)) {
-            self.landingOpacity = 0
-        }
-
-        // Trail and head dissolve after arrival
-        withAnimation(VisualizerMotion.exit(0.25).delay(travel)) {
+        await self.sleep(travel)
+        guard !Task.isCancelled else { return }
+        withAnimation(VisualizerMotion.exit(0.25)) {
             self.trailOpacity = 0
-            self.headOpacity = 0
+            self.cursorOpacity = 0
         }
+    }
+
+    private func sleep(_ seconds: Double) async {
+        try? await Task.sleep(nanoseconds: UInt64(seconds * 1_000_000_000))
     }
 }
 

--- a/docs/cli-command-reference.md
+++ b/docs/cli-command-reference.md
@@ -49,7 +49,7 @@ Use `peekaboo <command> --help` for inline flag descriptions; this page links to
 - [`open`](commands/open.md) – Enhanced macOS `open` that respects `--app/--bundle-id`, `--wait-until-ready`, `--no-focus`, and emits JSON payloads for scripting.
 - [`dock`](commands/dock.md) – `launch`, `right-click`, `hide`, `show`, `list` Dock items.
 - [`dialog`](commands/dialog.md) – `click`, `input`, `file`, `dismiss`, `list` system dialogs.
-- [`visualizer`](commands/visualizer.md) – Run the built-in visual feedback smoke suite (fires screenshot flash, capture HUD, click ripple, menu highlights, etc.) to verify Peekaboo.app overlays.
+- [`visualizer`](commands/visualizer.md) – Run the built-in visual feedback smoke suite (fires screenshot flash, capture HUD, cursor click, menu highlights, etc.) to verify Peekaboo.app overlays.
 
 ## Automation & Integrations
 

--- a/docs/commands/visualizer.md
+++ b/docs/commands/visualizer.md
@@ -11,7 +11,7 @@ Runs a lightweight smoke sequence that fires a representative set of visualizer 
 
 ## What it does
 - Connects to the visualizer host (typically `Peekaboo.app`)
-- Emits events such as screenshot flash, capture HUD, click ripple, typing overlay, scroll indicator, swipe path, hotkey HUD, window/app/menu/dialog overlays, and a sample element-detection overlay
+- Emits events such as screenshot flash, capture HUD, cursor click, typing overlay, scroll indicator, cursor movement, swipe path, hotkey HUD, window/app/menu/dialog overlays, and a sample element-detection overlay
 
 ## Usage
 ```bash

--- a/docs/testing/tools.md
+++ b/docs/testing/tools.md
@@ -472,7 +472,7 @@ The following subsections spell out the concrete steps, required Playground surf
 - **Setup**: Ensure `Peekaboo.app` is running (visual feedback host) and keep Playground visible so you can quickly spot overlays.
 - **Steps**:
   1. `peekaboo visualizer --json-output > .artifacts/playground-tools/<timestamp>-visualizer.json`
-  2. Visually confirm you see (in order): screenshot flash, capture HUD, click ripple, typing overlay, scroll indicator, mouse trail, swipe path, hotkey HUD, window move overlay, app launch/quit animation, menu breadcrumb, dialog highlight, space switch indicator, and element detection overlay.
+  2. Visually confirm you see (in order): screenshot flash, capture HUD, cursor click, typing overlay, scroll indicator, cursor movement trail, swipe path, hotkey HUD, window move overlay, app launch/quit animation, menu breadcrumb, dialog highlight, space switch indicator, and element detection overlay.
 - **Pass criteria**: No CLI errors, the JSON report shows every step `dispatched=true`, and the full overlay sequence renders end-to-end.
 - **2025-12-18 run**:
   - JSON reports all 15 steps `dispatched=true` (manual “eyes on overlay” still required for full pass criteria).

--- a/docs/visualizer.md
+++ b/docs/visualizer.md
@@ -23,7 +23,7 @@ The Peekaboo Visual Feedback System provides delightful, informative visual indi
 
 ### Communication Internals
 1. **Event creation (CLI/MCP side)**  
-   - `VisualizationClient` builds a strongly typed `VisualizerEvent.Payload` (e.g., screenshot flash, click ripple).  
+   - `VisualizationClient` builds a strongly typed `VisualizerEvent.Payload` (e.g., screenshot flash, click feedback).
    - The payload is persisted via `VisualizerEventStore.persist(_:)`, which writes `<uuid>.json` to the shared VisualizerEvents directory and logs the exact path (look for `[VisualizerEventStore][VisualizerSmoke] persisted event …` in CLI output when debugging).  
    - Immediately afterwards the client posts `DistributedNotificationCenter.default().post(name: .visualizerEventDispatched, object: "<uuid>|<kind>")`. No `userInfo` data is used so the bridge remains sandbox friendly.
 2. **Notification delivery**  
@@ -50,7 +50,7 @@ MCP Server → peekaboo CLI → VisualizerEventStore → Distributed Notificatio
 | `VisualizationClient` | `Core/PeekabooVisualizer/Sources/PeekabooVisualizer/Visualizer/VisualizationClient.swift` | Runs inside CLI/MCP processes, serializes payloads, persists them, and posts distributed notifications containing the event descriptor. |
 | `VisualizerEventStore` | `Core/PeekabooVisualizer/Sources/PeekabooVisualizer/Visualizer/VisualizerEventStore.swift` | Owns the shared storage directory, defines the `VisualizerEvent` schema, and exposes helpers to persist, load, and clean up JSON envelopes. |
 | `VisualizerEventReceiver` | `Core/PeekabooVisualizer/Sources/PeekabooVisualizer/Renderer/VisualizerEventReceiver.swift` | Hosted by Peekaboo.app, listens for `boo.peekaboo.visualizer.event`, loads the referenced JSON, and forwards it to `VisualizerCoordinator`. |
-| `VisualizerCoordinator` | `Core/PeekabooVisualizer/Sources/PeekabooVisualizer/Renderer/VisualizerCoordinator.swift` | Renders SwiftUI overlays (reticles, HUD chips, comets, annotations) and honors user settings such as animation speed and per-action toggles. |
+| `VisualizerCoordinator` | `Core/PeekabooVisualizer/Sources/PeekabooVisualizer/Renderer/VisualizerCoordinator.swift` | Renders SwiftUI overlays (cursor feedback, HUD chips, swipe paths, annotations) and honors user settings such as animation speed and per-action toggles. |
 | `VisualizerDesign` | `Core/PeekabooVisualizer/Sources/PeekabooVisualizer/Views/VisualizerDesign.swift` | The shared "Ghost HUD" design language: theme tokens, motion curves, HUD chip container, keycaps, and glyph badges every animation composes from. |
 
 ## Smoke Testing
@@ -107,7 +107,7 @@ Peekaboo.app still respects user-facing toggles via `PeekabooSettings`; the coor
 
 ## Visual Feedback Designs — the "Ghost HUD" language
 
-All animations share one design system (`VisualizerDesign.swift`): a single violet accent (`VisualizerTheme.accent`, cyan secondary for gradients, red strictly for destructive operations), dark translucent HUD chips with hairline strokes, and a common motion vocabulary (`VisualizerMotion.pop/settle/enter/exit/glide`). Geometry over cartoons: reticles, comets, chevrons, and keycaps — no particle bursts, no clip-art cursors, no rainbow per-action colors.
+All animations share one design system (`VisualizerDesign.swift`): a single violet accent (`VisualizerTheme.accent`, cyan secondary for gradients, red strictly for destructive operations), dark translucent HUD chips with hairline strokes, and a common motion vocabulary (`VisualizerMotion.pop/settle/enter/exit/glide`). Crisp cursor glyphs, restrained trails, chevrons, and keycaps keep the feedback readable without particle bursts or rainbow per-action colors.
 
 ### Screenshot Capture 📸
 - **Effect**: Viewfinder corner brackets snap onto the captured region while a white veil flashes once
@@ -115,11 +115,11 @@ All animations share one design system (`VisualizerDesign.swift`): a single viol
 - **Coverage**: Only the captured area, not the full screen
 - **Easter egg**: Every 100th screenshot floats a 👻 up through the frame
 
-### Click Actions 🎯
-- **Single Click**: A targeting ring contracts onto the point, the center dot pops with a glow bloom, and one impact pulse expands
-- **Double Click**: Two staggered impact pulses
-- **Right Click**: Dashed contracting ring in the secondary accent, hinting at a context menu
-- **No labels**: The geometry communicates the action; there is no "Click" text
+### Click Actions 🖱️
+- **Single Click**: A small macOS-style cursor glides to the point, presses once, and emits a subtle ring at its hotspot
+- **Double Click**: The cursor presses twice with a ring for each press
+- **Right Click**: The same cursor press uses the blue secondary accent
+- **No labels**: The cursor motion communicates the action; there is no "Click" text
 
 ### Typing Feedback ⌨️
 - **Style**: A caption pill at bottom center streams the typed text verbatim with a blinking caret
@@ -133,8 +133,8 @@ All animations share one design system (`VisualizerDesign.swift`): a single viol
 - **Extra**: A small "×N" tag beneath the chip when scrolling more than one unit
 
 ### Mouse Movement 🖱️
-- **Effect**: A glowing comet head glides from start to destination, stretching a tapered gradient tail
-- **Landing**: A small ring blooms at the destination as the head arrives
+- **Effect**: A small macOS-style cursor glides from start to destination with a restrained tapered gradient trail
+- **Landing**: The cursor tip arriving at the destination is the signal; no separate landing ring is drawn
 
 ### Swipe/Drag Gestures 👆
 - **Effect**: The same comet vocabulary with a thicker stroke (button held)
@@ -175,7 +175,7 @@ All animations share one design system (`VisualizerDesign.swift`): a single viol
 
 Agents fire actions in bursts, so the coordinator coalesces:
 
-- **Throttles** (`VisualizerCoordinator.FeedbackThrottle`): screenshot flash ≥ 1.2s apart, scroll chips ≥ 0.3s, mouse comets ≥ 0.4s and only for moves ≥ 80pt, element sheets ≥ 1.0s, watch HUD ≥ 1.0s. Throttled events report success without drawing.
+- **Throttles** (`VisualizerCoordinator.FeedbackThrottle`): screenshot flash ≥ 1.2s apart, scroll chips ≥ 0.3s, mouse cursor trails ≥ 0.4s and only for moves ≥ 80pt, element sheets ≥ 1.0s, watch HUD ≥ 1.0s. Throttled events report success without drawing.
 - **Replace slots** (`VisualizerCoordinator.OverlaySlot`): typing caption, hotkey chip, menu breadcrumb, Space indicator, app toast, watch HUD, annotated screenshot, and per-screen element sheets each keep at most one live overlay — a new event fades the previous one out in 0.12s and takes its place.
 
 ## Implementation Details
@@ -200,10 +200,12 @@ Agents fire actions in bursts, so the coordinator coalesces:
 Located in `Core/PeekabooVisualizer/Sources/PeekabooVisualizer/Views/`:
 - `VisualizerDesign.swift` - Shared theme, motion curves, HUD chip, keycap, corner brackets, glyph badge
 - `ScreenshotFlashView.swift` - Viewfinder brackets + shutter veil
-- `ClickAnimationView.swift` - Targeting reticle with impact pulses
+- `CursorGlyphView.swift` - Shared macOS-style cursor shape and rendering
+- `ClickAnimationView.swift` - Cursor glide, press, and hotspot ring
 - `TypeAnimationView.swift` - Streaming caption pill
 - `ScrollAnimationView.swift` - Flowing chevron chip
-- `MouseTrailView.swift` / `SwipePathView.swift` - Comet trails (window-local coordinates)
+- `MouseTrailView.swift` - Cursor travel with a subtle trail (window-local coordinates)
+- `SwipePathView.swift` - Drag comet with press/release rings (window-local coordinates)
 - `HotkeyOverlayView.swift` - Keycap chord display
 - ... (one file per animation type)
 
@@ -211,7 +213,7 @@ Overlay invariants worth knowing when adding animations:
 - Automation, Accessibility, Core Graphics, and capture geometry enters the visualizer in global display coordinates with an upper-left primary-display origin. `VisualizerAutomationFeedbackClient` and `SeeTool` convert it exactly once through `VisualizerScreenGeometry`; everything downstream uses global AppKit coordinates with a lower-left origin. Both spaces use logical points.
 - The flip axis is the primary/menu-bar display (`NSScreen.screens[0]`), not `NSScreen.main`, which follows keyboard focus and can change during automation.
 - `AnimationOverlayManager` wraps every animation in a flexible container so fixed-size views center on the overlay window; without it they pin to the top-leading corner and misalign by the window padding.
-- Every overlay window is inflated by a 40pt chrome margin so chip shadows and glows fade out instead of clipping at the window edge. Views that fill the window and use window-local coordinates (comets, capture flash, element sheets) pass `chromeMargin: 0` and provide their own breathing room.
+- Every overlay window is inflated by a 40pt chrome margin so chip shadows and glows fade out instead of clipping at the window edge. Views that fill the window and use window-local coordinates (cursor trails, swipe paths, capture flash, element sheets) pass `chromeMargin: 0` and provide their own breathing room.
 - Point-based views (mouse trail, swipe) receive window-local SwiftUI coordinates. `VisualizerCoordinator.windowLocalPoint(_:in:)` / `windowLocalRect(_:in:)` convert AppKit screen geometry (bottom-left origin) into flipped view coordinates.
 - Overlays that should never stack pass a `replaceKey`; the manager crossfades the previous window of the same key.
 
@@ -260,8 +262,8 @@ PEEKABOO_VISUALIZER_FORCE_APP=true        # Pretend the CLI is running inside th
 - **Customization**: Users can adjust flash intensity
 
 ### Click Animations
-- **Variety**: Ring shape distinguishes the click type — solid for left, dashed for right, double pulse for double-click
-- **Precision**: The reticle contracts onto the exact click point, so recordings read like a targeting lock
+- **Variety**: The cursor presses once for a single click, twice for a double-click, and uses blue hotspot rings for a right-click
+- **Precision**: The cursor tip is the hotspot and lands exactly on the click point
 
 ### Typing Caption
 - **Content over chrome**: Shows the actual text being typed rather than a fake keyboard
@@ -339,10 +341,11 @@ Most importantly, it's completely optional - the CLI and MCP continue to work pe
 All per-action views exist in `Core/PeekabooVisualizer/Sources/PeekabooVisualizer/Views/` and compose the shared design system in `VisualizerDesign.swift`:
 
 - [x] `ScreenshotFlashView` — viewfinder brackets, shutter veil, 👻 easter egg (every 100th)
-- [x] `ClickAnimationView` — targeting reticle; solid/dashed/double-pulse per click type
+- [x] `CursorGlyphView` — crisp macOS-style arrow with a top-leading hotspot
+- [x] `ClickAnimationView` — cursor glide with single/double/right-button press feedback
 - [x] `TypeAnimationView` — streaming caption pill with cadence-derived pacing
 - [x] `ScrollAnimationView` — flowing chevron chip with amount tag
-- [x] `MouseTrailView` — comet trail with landing ring (window-local coordinates)
+- [x] `MouseTrailView` — cursor travel with a subtle tapered trail (window-local coordinates)
 - [x] `SwipePathView` — drag comet with press/release rings
 - [x] `HotkeyOverlayView` — keycap chord with sequenced presses
 - [x] `AppLifecycleView` — launch/quit toast with status dot


### PR DESCRIPTION
## Summary

Replaces the click "targeting reticle" and the mouse-move "comet" with a small animated macOS-style arrow cursor, so automation feedback reads as a pointer that moves around and clicks:

- New shared `CursorGlyphView`/`CursorShape` (classic arrow polygon, black fill + white outline, tip = hotspot).
- `ClickAnimationView`: the cursor glides in from lower-right, lands its tip exactly on the click point, visibly presses (scale anchored at the tip) with a small tinted ring at the hotspot, then fades. Double-click presses twice; right-click uses the secondary (blue) accent.
- `MouseTrailView`: the comet head and landing ring are gone; the same cursor glyph now traces the travel path with a toned-down tapered trail.
- `AnimationBaseline.clickRipple` → `clickCursor` (0.45s → 1.15s) so the overlay window outlives the glide + press + fade timeline.
- Docs, CLI smoke-step naming, and changelog updated to match; `SwipePathView` intentionally keeps its comet.

## Testing

- `swift build --package-path Core/PeekabooVisualizer` ✅
- `pnpm run build:cli` ✅ (151s, full debug build)
- `pnpm run lint` ✅ (19 pre-existing warnings, 0 serious, none in touched files) / `pnpm run format` ✅
- Live end-to-end: built the debug Mac app, ran `peekaboo visualizer` (15/15 events dispatched), and captured the overlay windows mid-animation — verified the cursor glides in, presses at the exact click point with the subtle ring, and the mouse trail shows the cursor riding a tapered trail.
- Codex autoreview (gpt-5.5, high): clean, no actionable findings.
