### PR TITLE
fix(bridge): reject permission-less remote hosts during selection

### DIFF
--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Base/CommandRuntime.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Base/CommandRuntime.swift
@@ -35,6 +35,9 @@ struct CommandRuntimeOptions {
     var usesPerToolSnapshotInvalidation = false
     var requiresExactWindowTargetedClicks = false
     var requiresPostEventClickPermission = false
+    /// Set for interactive permission-request commands, which must be able to reach a host that
+    /// still lacks the permission being requested.
+    var requestsHostPermissionGrant = false
 
     func makeConfiguration() -> CommandRuntime.Configuration {
         CommandRuntime.Configuration(

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Base/CommandRuntime.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Base/CommandRuntime.swift
@@ -35,6 +35,10 @@ struct CommandRuntimeOptions {
     var usesPerToolSnapshotInvalidation = false
     var requiresExactWindowTargetedClicks = false
     var requiresPostEventClickPermission = false
+    /// Set for commands that acquire screen pixels (capture/detection/desktop observation) so a
+    /// remote host that explicitly lacks Screen Recording is rejected during selection. Not set for
+    /// interaction commands (click/scroll/type) that operate on cached snapshots.
+    var requiresScreenCapturePermission = false
     /// Set for interactive permission-request commands, which must be able to reach a host that
     /// still lacks the permission being requested.
     var requestsHostPermissionGrant = false

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Base/CommanderBinder.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Base/CommanderBinder.swift
@@ -65,6 +65,7 @@ enum CommanderCLIBinder {
             commandType,
             parsedValues: parsedValues
         )
+        options.requestsHostPermissionGrant = Self.isInteractivePermissionRequest(commandType)
         options.usesPerToolSnapshotInvalidation = commandType == AgentCommand.self ||
             commandType == MCPCommand.Serve.self ||
             commandType == InspectUICommand.self

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Base/CommanderBinder.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Base/CommanderBinder.swift
@@ -141,20 +141,20 @@ enum CommanderCLIBinder {
             commandType == AppCommand.ListSubcommand.self
     }
 
-    /// Commands that genuinely acquire screen pixels (capture, element detection, desktop
+    /// Commands that unconditionally acquire screen pixels (capture, element detection, desktop
     /// observation) and therefore need a remote host that holds the Screen Recording permission.
-    /// `run` is included because its script steps route `see`/`image` captures through the remote
-    /// screen-capture service. Interaction commands (`click`/`scroll`/`type`) are intentionally
-    /// excluded: they target cached snapshots and their optional observation barrier degrades
-    /// gracefully without Screen Recording.
+    /// Interaction commands (`click`/`scroll`/`type`) are excluded: they target cached snapshots and
+    /// their optional observation barrier degrades gracefully without Screen Recording. `run` is
+    /// also excluded: whether a script captures depends on its steps, which are not known at
+    /// host-resolution time, so gating every `run` would push non-capture scripts off otherwise
+    /// valid hosts. Any capture step inside a script still surfaces a permission error at execution.
     private static func requiresScreenCapturePermission(_ commandType: (any ParsableCommand.Type)?) -> Bool {
         commandType == ImageCommand.self ||
             commandType == SeeCommand.self ||
             commandType == CaptureLiveCommand.self ||
             commandType == CaptureWatchAlias.self ||
             commandType == CaptureVideoCommand.self ||
-            commandType == CaptureActionCommand.self ||
-            commandType == RunCommand.self
+            commandType == CaptureActionCommand.self
     }
 
     private static func requiresImplicitSnapshotInvalidation(

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Base/CommanderBinder.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Base/CommanderBinder.swift
@@ -65,6 +65,7 @@ enum CommanderCLIBinder {
             commandType,
             parsedValues: parsedValues
         )
+        options.requiresScreenCapturePermission = Self.requiresScreenCapturePermission(commandType)
         options.requestsHostPermissionGrant = Self.isInteractivePermissionRequest(commandType)
         options.usesPerToolSnapshotInvalidation = commandType == AgentCommand.self ||
             commandType == MCPCommand.Serve.self ||
@@ -138,6 +139,22 @@ enum CommanderCLIBinder {
     private static func requiresHostApplicationInventory(_ commandType: (any ParsableCommand.Type)?) -> Bool {
         commandType == ListCommand.AppsSubcommand.self ||
             commandType == AppCommand.ListSubcommand.self
+    }
+
+    /// Commands that genuinely acquire screen pixels (capture, element detection, desktop
+    /// observation) and therefore need a remote host that holds the Screen Recording permission.
+    /// `run` is included because its script steps route `see`/`image` captures through the remote
+    /// screen-capture service. Interaction commands (`click`/`scroll`/`type`) are intentionally
+    /// excluded: they target cached snapshots and their optional observation barrier degrades
+    /// gracefully without Screen Recording.
+    private static func requiresScreenCapturePermission(_ commandType: (any ParsableCommand.Type)?) -> Bool {
+        commandType == ImageCommand.self ||
+            commandType == SeeCommand.self ||
+            commandType == CaptureLiveCommand.self ||
+            commandType == CaptureWatchAlias.self ||
+            commandType == CaptureVideoCommand.self ||
+            commandType == CaptureActionCommand.self ||
+            commandType == RunCommand.self
     }
 
     private static func requiresImplicitSnapshotInvalidation(

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Base/Runtime/BridgeCapabilityPolicy.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Base/Runtime/BridgeCapabilityPolicy.swift
@@ -12,6 +12,14 @@ enum BridgeCapabilityPolicy {
             return false
         }
 
+        // Never select a host that explicitly reports it lacks a TCC permission this command
+        // needs (e.g. a stale GUI host with screenRecording=false serving bridge.sock); rejecting
+        // here lets the resolver fall through to a permissioned daemon. Hosts that omit the
+        // permission report entirely stay eligible for backward compatibility.
+        guard self.explicitlyMissingRemotePermissions(for: handshake, options: options).isEmpty else {
+            return false
+        }
+
         if options.requiresElementActions, !self.supportsElementActions(for: handshake) {
             return false
         }
@@ -56,6 +64,61 @@ enum BridgeCapabilityPolicy {
         }
 
         return true
+    }
+
+    /// TCC permissions the current command needs from a remote host, derived from the operations
+    /// it will use. The host's own `permissionTags` contract wins; operations without a tag fall
+    /// back to the client-side mapping so hosts that predate permission tags are still covered.
+    static func requiredRemotePermissions(
+        for handshake: PeekabooBridgeHandshakeResponse,
+        options: CommandRuntimeOptions
+    ) -> Set<PeekabooBridgePermissionKind> {
+        var required: Set<PeekabooBridgePermissionKind> = []
+        for operation in self.requiredRemoteOperations(options: options) {
+            required.formUnion(handshake.permissionTags[operation.rawValue] ?? Array(operation.requiredPermissions))
+        }
+        return required
+    }
+
+    /// Required permissions the host explicitly reports as not granted. A host that omits the
+    /// permission report (`permissions == nil`, older protocol builds) is trusted and never
+    /// rejected here; only an explicit `false` counts as missing.
+    static func explicitlyMissingRemotePermissions(
+        for handshake: PeekabooBridgeHandshakeResponse,
+        options: CommandRuntimeOptions
+    ) -> Set<PeekabooBridgePermissionKind> {
+        guard handshake.permissions != nil else { return [] }
+        return self.requiredRemotePermissions(for: handshake, options: options)
+            .subtracting(self.grantedPermissions(from: handshake.permissions))
+    }
+
+    /// Operations the current command is known to route through a remote host, based on the
+    /// declared runtime options. `captureScreen` is the baseline every remote-routed command
+    /// relies on (shared snapshots and detection state); the rest mirror the option flags.
+    private static func requiredRemoteOperations(options: CommandRuntimeOptions) -> [PeekabooBridgeOperation] {
+        // Permission-request commands intentionally target hosts that still lack grants.
+        guard !options.requestsHostPermissionGrant else { return [] }
+
+        var operations: [PeekabooBridgeOperation] = [.captureScreen]
+        if options.requiresElementActions {
+            operations.append(contentsOf: [.setValue, .performAction])
+        }
+        if options.requiresInspectAccessibilityTree {
+            operations.append(.inspectAccessibilityTree)
+        }
+        if options.requiresApplicationLaunchOptions {
+            operations.append(.launchApplicationWithOptions)
+        }
+        if options.requiresApplicationRelaunch {
+            operations.append(.relaunchApplicationWithOptions)
+        }
+        if options.requiresHostApplicationInventory {
+            operations.append(.listApplications)
+        }
+        if options.requiresExactWindowTargetedClicks {
+            operations.append(.exactWindowTargetedClick)
+        }
+        return operations
     }
 
     static func supportsTargetedHotkeys(for handshake: PeekabooBridgeHandshakeResponse) -> Bool {
@@ -267,7 +330,7 @@ enum BridgeCapabilityPolicy {
         return requiredPermissions.subtracting(grantedPermissions)
     }
 
-    private static func missingPermissionNames(_ permissions: Set<PeekabooBridgePermissionKind>) -> [String] {
+    static func missingPermissionNames(_ permissions: Set<PeekabooBridgePermissionKind>) -> [String] {
         permissions.map(\.displayName).sorted()
     }
 

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Base/Runtime/BridgeCapabilityPolicy.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Base/Runtime/BridgeCapabilityPolicy.swift
@@ -13,9 +13,11 @@ enum BridgeCapabilityPolicy {
         }
 
         // Never select a host that explicitly reports it lacks a TCC permission this command
-        // needs (e.g. a stale GUI host with screenRecording=false serving bridge.sock); rejecting
-        // here lets the resolver fall through to a permissioned daemon. Hosts that omit the
-        // permission report entirely stay eligible for backward compatibility.
+        // actually needs (e.g. a stale GUI host with screenRecording=false serving bridge.sock for
+        // a capture command); rejecting here lets the resolver fall through to a permissioned
+        // daemon. Only the permissions the command uses are required, so a non-capture command is
+        // not blocked by a missing Screen Recording grant. Hosts that omit the permission report
+        // entirely stay eligible for backward compatibility.
         guard self.explicitlyMissingRemotePermissions(for: handshake, options: options).isEmpty else {
             return false
         }
@@ -92,31 +94,26 @@ enum BridgeCapabilityPolicy {
             .subtracting(self.grantedPermissions(from: handshake.permissions))
     }
 
-    /// Operations the current command is known to route through a remote host, based on the
-    /// declared runtime options. `captureScreen` is the baseline every remote-routed command
-    /// relies on (shared snapshots and detection state); the rest mirror the option flags.
+    /// Operations whose required TCC permissions the current command must find granted on a remote
+    /// host, based on declared runtime options. This is a permission gate only: capability (does the
+    /// host support the operation) is enforced separately by `supportsRemoteRequirements`. Screen
+    /// Recording is demanded ONLY for commands that actually acquire screen pixels
+    /// (`requiresScreenCapturePermission`); non-capture commands are never rejected for lacking it.
+    /// Operations that require no permission (app launch/relaunch, inventory, exact-window clicks)
+    /// are intentionally absent — they are already capability-gated and add nothing here.
     private static func requiredRemoteOperations(options: CommandRuntimeOptions) -> [PeekabooBridgeOperation] {
         // Permission-request commands intentionally target hosts that still lack grants.
         guard !options.requestsHostPermissionGrant else { return [] }
 
-        var operations: [PeekabooBridgeOperation] = [.captureScreen]
+        var operations: [PeekabooBridgeOperation] = []
+        if options.requiresScreenCapturePermission {
+            operations.append(.captureScreen)
+        }
         if options.requiresElementActions {
             operations.append(contentsOf: [.setValue, .performAction])
         }
         if options.requiresInspectAccessibilityTree {
             operations.append(.inspectAccessibilityTree)
-        }
-        if options.requiresApplicationLaunchOptions {
-            operations.append(.launchApplicationWithOptions)
-        }
-        if options.requiresApplicationRelaunch {
-            operations.append(.relaunchApplicationWithOptions)
-        }
-        if options.requiresHostApplicationInventory {
-            operations.append(.listApplications)
-        }
-        if options.requiresExactWindowTargetedClicks {
-            operations.append(.exactWindowTargetedClick)
         }
         return operations
     }

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Base/Runtime/RuntimeHostResolver.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Base/Runtime/RuntimeHostResolver.swift
@@ -94,11 +94,13 @@ enum RuntimeHostResolver {
             hostname: Host.current().name
         )
 
+        var permissionRejections: [String] = []
         if let resolved = await resolveRemoteServices(
             candidates: candidatePlan.candidates,
             identity: identity,
             options: options,
-            snapshotInvalidationRemoteSocketPaths: snapshotInvalidationRemoteSocketPaths
+            snapshotInvalidationRemoteSocketPaths: snapshotInvalidationRemoteSocketPaths,
+            permissionRejections: &permissionRejections
         ) {
             return resolved
         }
@@ -124,15 +126,21 @@ enum RuntimeHostResolver {
                     )],
                     identity: identity,
                     options: options,
-                    snapshotInvalidationRemoteSocketPaths: snapshotInvalidationRemoteSocketPaths
+                    snapshotInvalidationRemoteSocketPaths: snapshotInvalidationRemoteSocketPaths,
+                    permissionRejections: &permissionRejections
                 ) {
                 return resolved
             }
         }
 
+        // Name the hosts skipped for missing TCC permissions so a fallback is explainable
+        // instead of the previous silent selection of a permission-less bridge host.
+        let rejectionSummary = permissionRejections.isEmpty
+            ? ""
+            : "; rejected " + permissionRejections.joined(separator: "; ")
         return Resolution(
             services: RuntimeServiceFactory.makeLocalServices(options: options),
-            hostDescription: "local (in-process fallback)",
+            hostDescription: "local (in-process fallback\(rejectionSummary))",
             selectedRemoteSocketPath: nil,
             selectedRemoteHostProcessIdentifier: nil,
             snapshotInvalidationRemoteSocketPaths: snapshotInvalidationRemoteSocketPaths,
@@ -356,7 +364,8 @@ enum RuntimeHostResolver {
         candidates: [ImplicitRemoteCandidate],
         identity: PeekabooBridgeClientIdentity,
         options: CommandRuntimeOptions,
-        snapshotInvalidationRemoteSocketPaths: [String]
+        snapshotInvalidationRemoteSocketPaths: [String],
+        permissionRejections: inout [String]
     )
     async -> Resolution? {
         for candidate in candidates {
@@ -368,7 +377,21 @@ enum RuntimeHostResolver {
                     candidate,
                     handshake: handshake,
                     options: options
-                ) else { continue }
+                ) else {
+                    let missingPermissions = BridgeCapabilityPolicy.explicitlyMissingRemotePermissions(
+                        for: handshake,
+                        options: options
+                    )
+                    if !missingPermissions.isEmpty {
+                        let permissionNames = BridgeCapabilityPolicy
+                            .missingPermissionNames(missingPermissions)
+                            .joined(separator: ", ")
+                        permissionRejections.append(
+                            "\(handshake.hostKind.rawValue) host via \(socketPath) missing \(permissionNames)"
+                        )
+                    }
+                    continue
+                }
                 let reusableDaemonStatus = validation.reusableDaemonStatus
 
                 let targetedHotkeyAvailability = BridgeCapabilityPolicy.targetedHotkeyAvailability(for: handshake)

--- a/Apps/CLI/Tests/CoreCLITests/CommanderBinderTests.swift
+++ b/Apps/CLI/Tests/CoreCLITests/CommanderBinderTests.swift
@@ -1372,4 +1372,34 @@ extension CommanderBinderTests {
         #expect(requestOptions.requestsHostPermissionGrant)
         #expect(!captureOptions.requestsHostPermissionGrant)
     }
+
+    @Test
+    func `Screen capture permission is required only by capture commands`() throws {
+        let parsed = ParsedValues(positional: [], options: [:], flags: [])
+        let captureCommands: [any ParsableCommand.Type] = [
+            ImageCommand.self,
+            SeeCommand.self,
+            CaptureLiveCommand.self,
+            CaptureWatchAlias.self,
+            CaptureVideoCommand.self,
+            CaptureActionCommand.self,
+            RunCommand.self,
+        ]
+        for commandType in captureCommands {
+            let options = try CommanderCLIBinder.makeRuntimeOptions(from: parsed, commandType: commandType)
+            #expect(options.requiresScreenCapturePermission, "Expected capture gating for \(commandType)")
+        }
+
+        let nonCaptureCommands: [any ParsableCommand.Type] = [
+            ClickCommand.self,
+            ScrollCommand.self,
+            TypeCommand.self,
+            AppCommand.LaunchSubcommand.self,
+            ListCommand.AppsSubcommand.self,
+        ]
+        for commandType in nonCaptureCommands {
+            let options = try CommanderCLIBinder.makeRuntimeOptions(from: parsed, commandType: commandType)
+            #expect(!options.requiresScreenCapturePermission, "Unexpected capture gating for \(commandType)")
+        }
+    }
 }

--- a/Apps/CLI/Tests/CoreCLITests/CommanderBinderTests.swift
+++ b/Apps/CLI/Tests/CoreCLITests/CommanderBinderTests.swift
@@ -1383,19 +1383,21 @@ extension CommanderBinderTests {
             CaptureWatchAlias.self,
             CaptureVideoCommand.self,
             CaptureActionCommand.self,
-            RunCommand.self,
         ]
         for commandType in captureCommands {
             let options = try CommanderCLIBinder.makeRuntimeOptions(from: parsed, commandType: commandType)
             #expect(options.requiresScreenCapturePermission, "Expected capture gating for \(commandType)")
         }
 
+        // `run` is intentionally NOT gated: its script may contain only non-capture steps, and the
+        // steps are unknown at host-resolution time, so gating would push valid hosts away.
         let nonCaptureCommands: [any ParsableCommand.Type] = [
             ClickCommand.self,
             ScrollCommand.self,
             TypeCommand.self,
             AppCommand.LaunchSubcommand.self,
             ListCommand.AppsSubcommand.self,
+            RunCommand.self,
         ]
         for commandType in nonCaptureCommands {
             let options = try CommanderCLIBinder.makeRuntimeOptions(from: parsed, commandType: commandType)

--- a/Apps/CLI/Tests/CoreCLITests/CommanderBinderTests.swift
+++ b/Apps/CLI/Tests/CoreCLITests/CommanderBinderTests.swift
@@ -1357,4 +1357,19 @@ extension CommanderBinderTests {
         #expect(options.preferRemote == true)
         #expect(options.bridgeSocketPath == "/tmp/peekaboo.sock")
     }
+
+    @Test
+    func `Permission request commands opt out of host permission gating`() throws {
+        let parsed = ParsedValues(positional: [], options: [:], flags: [])
+        let requestOptions = try CommanderCLIBinder.makeRuntimeOptions(
+            from: parsed,
+            commandType: PermissionsCommand.RequestEventSynthesizingSubcommand.self
+        )
+        let captureOptions = try CommanderCLIBinder.makeRuntimeOptions(
+            from: parsed,
+            commandType: ImageCommand.self
+        )
+        #expect(requestOptions.requestsHostPermissionGrant)
+        #expect(!captureOptions.requestsHostPermissionGrant)
+    }
 }

--- a/Apps/CLI/Tests/CoreCLITests/RuntimeHostResolverTests.swift
+++ b/Apps/CLI/Tests/CoreCLITests/RuntimeHostResolverTests.swift
@@ -263,4 +263,201 @@ struct RuntimeHostResolverTests {
             options: options
         ) != nil)
     }
+
+    @Test
+    func `Candidate validation rejects hosts that explicitly lack required capture permission`() async {
+        // Mirrors the reproduced bug: a stale GUI build serving bridge.sock while holding zero
+        // TCC permissions must not win selection for a capture-dependent command.
+        let candidate = RuntimeHostResolver.ImplicitRemoteCandidate(
+            socketPath: "/tmp/bridge.sock",
+            requireReusableDaemon: false,
+            requiredHostKind: .gui,
+            requiresValidatedHistoricalDaemon: false
+        )
+        let unpermissioned = PeekabooBridgeHandshakeResponse(
+            negotiatedVersion: PeekabooBridgeConstants.protocolVersion,
+            hostKind: .gui,
+            build: "stale-debug",
+            supportedOperations: [.captureScreen, .listApplications],
+            permissions: PermissionsStatus(
+                screenRecording: false,
+                accessibility: false,
+                appleScript: false,
+                postEvent: false
+            ),
+            enabledOperations: [.captureScreen, .listApplications],
+            permissionTags: [PeekabooBridgeOperation.captureScreen.rawValue: [.screenRecording]]
+        )
+
+        #expect(await RuntimeHostResolver.validateRemoteCandidate(
+            candidate,
+            handshake: unpermissioned,
+            options: CommandRuntimeOptions()
+        ) == nil)
+        #expect(BridgeCapabilityPolicy.explicitlyMissingRemotePermissions(
+            for: unpermissioned,
+            options: CommandRuntimeOptions()
+        ) == [.screenRecording])
+    }
+
+    @Test
+    func `Candidate validation rejects permission-less hosts even without permission tags`() async {
+        // Hosts that report permissions but predate permissionTags fall back to the client-side
+        // operation-to-permission mapping.
+        let candidate = RuntimeHostResolver.ImplicitRemoteCandidate(
+            socketPath: "/tmp/bridge.sock",
+            requireReusableDaemon: false,
+            requiredHostKind: nil,
+            requiresValidatedHistoricalDaemon: false
+        )
+        let untagged = PeekabooBridgeHandshakeResponse(
+            negotiatedVersion: PeekabooBridgeConstants.protocolVersion,
+            hostKind: .gui,
+            build: nil,
+            supportedOperations: [.captureScreen],
+            permissions: PermissionsStatus(
+                screenRecording: false,
+                accessibility: false,
+                appleScript: false,
+                postEvent: false
+            )
+        )
+
+        #expect(await RuntimeHostResolver.validateRemoteCandidate(
+            candidate,
+            handshake: untagged,
+            options: CommandRuntimeOptions()
+        ) == nil)
+    }
+
+    @Test
+    func `Candidate validation accepts hosts that omit the permission report`() async {
+        // Back-compat: older hosts do not include permissions in the handshake. Unknown is
+        // acceptable; only an explicit false rejects.
+        let candidate = RuntimeHostResolver.ImplicitRemoteCandidate(
+            socketPath: "/tmp/bridge.sock",
+            requireReusableDaemon: false,
+            requiredHostKind: .gui,
+            requiresValidatedHistoricalDaemon: false
+        )
+        let unknownPermissions = PeekabooBridgeHandshakeResponse(
+            negotiatedVersion: PeekabooBridgeConstants.protocolVersion,
+            hostKind: .gui,
+            build: nil,
+            supportedOperations: [.captureScreen]
+        )
+
+        #expect(await RuntimeHostResolver.validateRemoteCandidate(
+            candidate,
+            handshake: unknownPermissions,
+            options: CommandRuntimeOptions()
+        ) != nil)
+    }
+
+    @Test
+    func `Candidate validation selects hosts that hold the required permissions`() async {
+        let candidate = RuntimeHostResolver.ImplicitRemoteCandidate(
+            socketPath: "/tmp/bridge.sock",
+            requireReusableDaemon: false,
+            requiredHostKind: .gui,
+            requiresValidatedHistoricalDaemon: false
+        )
+        let permissioned = PeekabooBridgeHandshakeResponse(
+            negotiatedVersion: PeekabooBridgeConstants.protocolVersion,
+            hostKind: .gui,
+            build: nil,
+            supportedOperations: [.captureScreen],
+            permissions: PermissionsStatus(
+                screenRecording: true,
+                accessibility: true,
+                appleScript: true,
+                postEvent: true
+            ),
+            enabledOperations: [.captureScreen],
+            permissionTags: [PeekabooBridgeOperation.captureScreen.rawValue: [.screenRecording]]
+        )
+
+        #expect(await RuntimeHostResolver.validateRemoteCandidate(
+            candidate,
+            handshake: permissioned,
+            options: CommandRuntimeOptions()
+        ) != nil)
+    }
+
+    @Test
+    func `Required permissions follow the operations the command uses`() async {
+        let candidate = RuntimeHostResolver.ImplicitRemoteCandidate(
+            socketPath: "/tmp/bridge.sock",
+            requireReusableDaemon: false,
+            requiredHostKind: nil,
+            requiresValidatedHistoricalDaemon: false
+        )
+        let captureOnlyPermissions = PeekabooBridgeHandshakeResponse(
+            negotiatedVersion: PeekabooBridgeConstants.protocolVersion,
+            hostKind: .onDemand,
+            build: nil,
+            supportedOperations: [.captureScreen, .inspectAccessibilityTree],
+            permissions: PermissionsStatus(
+                screenRecording: true,
+                accessibility: false,
+                appleScript: false,
+                postEvent: false
+            ),
+            enabledOperations: [.captureScreen],
+            permissionTags: [
+                PeekabooBridgeOperation.captureScreen.rawValue: [.screenRecording],
+                PeekabooBridgeOperation.inspectAccessibilityTree.rawValue: [.accessibility],
+            ]
+        )
+
+        var inspectOptions = CommandRuntimeOptions()
+        inspectOptions.requiresInspectAccessibilityTree = true
+
+        #expect(await RuntimeHostResolver.validateRemoteCandidate(
+            candidate,
+            handshake: captureOnlyPermissions,
+            options: CommandRuntimeOptions()
+        ) != nil)
+        #expect(await RuntimeHostResolver.validateRemoteCandidate(
+            candidate,
+            handshake: captureOnlyPermissions,
+            options: inspectOptions
+        ) == nil)
+        #expect(BridgeCapabilityPolicy.explicitlyMissingRemotePermissions(
+            for: captureOnlyPermissions,
+            options: inspectOptions
+        ) == [.accessibility])
+    }
+
+    @Test
+    func `Permission request commands may target hosts that lack the permission`() async {
+        let candidate = RuntimeHostResolver.ImplicitRemoteCandidate(
+            socketPath: "/tmp/bridge.sock",
+            requireReusableDaemon: false,
+            requiredHostKind: .gui,
+            requiresValidatedHistoricalDaemon: false
+        )
+        let unpermissioned = PeekabooBridgeHandshakeResponse(
+            negotiatedVersion: PeekabooBridgeConstants.protocolVersion,
+            hostKind: .gui,
+            build: nil,
+            supportedOperations: [.captureScreen, .requestPostEventPermission],
+            permissions: PermissionsStatus(
+                screenRecording: false,
+                accessibility: false,
+                appleScript: false,
+                postEvent: false
+            ),
+            permissionTags: [PeekabooBridgeOperation.captureScreen.rawValue: [.screenRecording]]
+        )
+
+        var requestOptions = CommandRuntimeOptions()
+        requestOptions.requestsHostPermissionGrant = true
+
+        #expect(await RuntimeHostResolver.validateRemoteCandidate(
+            candidate,
+            handshake: unpermissioned,
+            options: requestOptions
+        ) != nil)
+    }
 }

--- a/Apps/CLI/Tests/CoreCLITests/RuntimeHostResolverTests.swift
+++ b/Apps/CLI/Tests/CoreCLITests/RuntimeHostResolverTests.swift
@@ -264,6 +264,12 @@ struct RuntimeHostResolverTests {
         ) != nil)
     }
 
+    private static func captureOptions() -> CommandRuntimeOptions {
+        var options = CommandRuntimeOptions()
+        options.requiresScreenCapturePermission = true
+        return options
+    }
+
     @Test
     func `Candidate validation rejects hosts that explicitly lack required capture permission`() async {
         // Mirrors the reproduced bug: a stale GUI build serving bridge.sock while holding zero
@@ -292,12 +298,61 @@ struct RuntimeHostResolverTests {
         #expect(await RuntimeHostResolver.validateRemoteCandidate(
             candidate,
             handshake: unpermissioned,
-            options: CommandRuntimeOptions()
+            options: Self.captureOptions()
         ) == nil)
         #expect(BridgeCapabilityPolicy.explicitlyMissingRemotePermissions(
             for: unpermissioned,
-            options: CommandRuntimeOptions()
+            options: Self.captureOptions()
         ) == [.screenRecording])
+    }
+
+    @Test
+    func `Non-capture commands tolerate hosts that lack screen recording`() async {
+        // Regression: a host that supports the capture operation but reports screenRecording=false,
+        // while holding the permissions its own commands need, must NOT be rejected for non-capture
+        // commands such as `app launch` (no permission) or `app list` (no permission).
+        let candidate = RuntimeHostResolver.ImplicitRemoteCandidate(
+            socketPath: "/tmp/bridge.sock",
+            requireReusableDaemon: false,
+            requiredHostKind: nil,
+            requiresValidatedHistoricalDaemon: false
+        )
+        let noScreenRecording = PeekabooBridgeHandshakeResponse(
+            negotiatedVersion: PeekabooBridgeConstants.protocolVersion,
+            hostKind: .onDemand,
+            build: nil,
+            supportedOperations: [.captureScreen, .launchApplicationWithOptions, .listApplications],
+            permissions: PermissionsStatus(
+                screenRecording: false,
+                accessibility: true,
+                appleScript: true,
+                postEvent: true
+            ),
+            enabledOperations: [.captureScreen, .launchApplicationWithOptions, .listApplications],
+            permissionTags: [PeekabooBridgeOperation.captureScreen.rawValue: [.screenRecording]]
+        )
+
+        var launchOptions = CommandRuntimeOptions()
+        launchOptions.requiresApplicationLaunchOptions = true
+        var inventoryOptions = CommandRuntimeOptions()
+        inventoryOptions.requiresHostApplicationInventory = true
+
+        #expect(await RuntimeHostResolver.validateRemoteCandidate(
+            candidate,
+            handshake: noScreenRecording,
+            options: launchOptions
+        ) != nil)
+        #expect(await RuntimeHostResolver.validateRemoteCandidate(
+            candidate,
+            handshake: noScreenRecording,
+            options: inventoryOptions
+        ) != nil)
+        // ... yet the same host is still rejected for a command that actually captures pixels.
+        #expect(await RuntimeHostResolver.validateRemoteCandidate(
+            candidate,
+            handshake: noScreenRecording,
+            options: Self.captureOptions()
+        ) == nil)
     }
 
     @Test
@@ -326,7 +381,7 @@ struct RuntimeHostResolverTests {
         #expect(await RuntimeHostResolver.validateRemoteCandidate(
             candidate,
             handshake: untagged,
-            options: CommandRuntimeOptions()
+            options: Self.captureOptions()
         ) == nil)
     }
 
@@ -350,7 +405,7 @@ struct RuntimeHostResolverTests {
         #expect(await RuntimeHostResolver.validateRemoteCandidate(
             candidate,
             handshake: unknownPermissions,
-            options: CommandRuntimeOptions()
+            options: Self.captureOptions()
         ) != nil)
     }
 
@@ -380,7 +435,7 @@ struct RuntimeHostResolverTests {
         #expect(await RuntimeHostResolver.validateRemoteCandidate(
             candidate,
             handshake: permissioned,
-            options: CommandRuntimeOptions()
+            options: Self.captureOptions()
         ) != nil)
     }
 
@@ -392,6 +447,7 @@ struct RuntimeHostResolverTests {
             requiredHostKind: nil,
             requiresValidatedHistoricalDaemon: false
         )
+        // Holds Screen Recording but not Accessibility.
         let captureOnlyPermissions = PeekabooBridgeHandshakeResponse(
             negotiatedVersion: PeekabooBridgeConstants.protocolVersion,
             hostKind: .onDemand,
@@ -413,11 +469,13 @@ struct RuntimeHostResolverTests {
         var inspectOptions = CommandRuntimeOptions()
         inspectOptions.requiresInspectAccessibilityTree = true
 
+        // A capture command is satisfied (Screen Recording present)...
         #expect(await RuntimeHostResolver.validateRemoteCandidate(
             candidate,
             handshake: captureOnlyPermissions,
-            options: CommandRuntimeOptions()
+            options: Self.captureOptions()
         ) != nil)
+        // ...but an AX-tree inspection command is rejected (Accessibility missing).
         #expect(await RuntimeHostResolver.validateRemoteCandidate(
             candidate,
             handshake: captureOnlyPermissions,


### PR DESCRIPTION
## Problem

Reproduced live: a stale, long-running `Peekaboo.app` (old 3.5.4 debug build from DerivedData) was serving the GUI bridge socket at `~/Library/Application Support/Peekaboo/bridge.sock` while holding **zero TCC permissions**. Its handshake advertised:

```json
"permissions": { "accessibility": false, "screenRecording": false, "appleScript": false, "postEvent": false }
```

The CLI selected that host anyway — over an on-demand daemon path that had all permissions — because `RuntimeHostResolver.validateRemoteCandidate` / `BridgeCapabilityPolicy.supportsRemoteRequirements` never inspected the handshake's advertised TCC permissions (only operation/version capability, plus two narrow opt-in flags for synthetic clicks). Every capture and automation command then failed with confusing downstream errors.

Proof of the repro: `peekaboo permissions status --json` reported Screen Recording and Accessibility as NOT granted while routing through the GUI host; the same command with `--no-remote` (caller-local TCC) reported both GRANTED. Killing the stale app made the CLI fall back to the daemon and everything worked.

## Fix: permission-aware candidate validation, scoped to the permissions a command actually uses

`BridgeCapabilityPolicy.supportsRemoteRequirements` now rejects a candidate whose handshake **explicitly** reports a required permission as not granted. Crucially, "required" is derived from what the specific command does, NOT applied blanket:

- **Capability vs permission are kept separate.** The pre-existing hard guard `handshake.supportedOperations.contains(.captureScreen)` (does the host *support* the operation) is unchanged. The new logic adds a *permission* dimension on top.
- **Screen Recording is demanded only by commands that genuinely acquire screen pixels** — gated behind a new `CommandRuntimeOptions.requiresScreenCapturePermission` flag set in `CommanderBinder`. Non-capture commands (`app launch`, `app list`, window/menu/dock/dialog ops, etc.) are never rejected for a missing Screen Recording grant.
- **Accessibility** is required for `requiresElementActions` (`set-value`/`perform-action`) and `requiresInspectAccessibilityTree` (`inspect-ui`), via those operations' `requiredPermissions`.
- Per operation, the required permissions come from the host's own `permissionTags` contract when present, falling back to the client-side `PeekabooBridgeOperation.requiredPermissions` mapping for hosts that predate permission tags (the stale-host case).
- A candidate is rejected only when a required permission is **explicitly `false`** in `handshake.permissions`. Rejection makes `resolveRemoteServices` continue down the candidate list and ultimately auto-start a permissioned on-demand daemon — exactly the path that worked once the stale app was killed.

### Which commands are marked capture-requiring (audited, not guessed)

`image`, `see`, `capture live`, `capture watch` (alias), `capture video`, `capture action`. These are the only commands that route through the remote screen-capture service (`screenCaptureService.capture*`) / element detection / desktop observation. Verified by grepping every command's capture-API usage and cross-checking `PeekabooBridgeOperation.requiredPermissions`.

- **Interaction commands (`click`/`scroll`/`type`) are intentionally NOT gated** — they operate on cached snapshots; their optional desktop-observation barrier degrades gracefully without Screen Recording.
- **`run` is intentionally NOT gated.** Whether a script captures depends on its steps, which are not known at host-resolution time (the host is resolved before the script loads), so gating every `run` would push non-capture scripts (window/app/clipboard/type only) off otherwise-valid hosts. A capture step inside a script still surfaces a permission error at execution — the pre-existing behavior for `run`, unchanged by this PR.

### Backward compatibility

- Hosts that omit the permission report entirely (`permissions == nil`, older protocol builds) are treated as *unknown* and stay eligible — only an explicit `false` rejects.
- Hosts reporting permissions but no `permissionTags` are checked against the client-side operation->permission mapping.
- Validation-based rejection was chosen over re-ranking candidates: lower-risk, preserves existing candidate ordering (GUI-first for inventory/launch commands), and the daemon fallback already supplies the better host once a broken one is vetoed.

### Carve-out for permission-request commands

Interactive permission-request commands (`permissions request-*`) intentionally target hosts that still *lack* the grant being requested. They set `requestsHostPermissionGrant`, exempting them from the veto so `permissions request-event-synthesizing` can still reach an unpermissioned GUI host.

### Observability

When candidates are skipped for missing permissions and the resolver ends in the local in-process fallback, the runtime host description names the rejected host and the missing permission(s), e.g. `local (in-process fallback; rejected gui host via .../bridge.sock missing Screen Recording)` — instead of the previous silent selection of a permission-less host. `peekaboo bridge status` selection mirrors runtime automatically since diagnostics reuse `validateRemoteCandidate`.

## Before / after selection behavior

| Scenario | Before | After |
| --- | --- | --- |
| GUI host advertises `screenRecording: false`, capture command, daemon available/startable | GUI host selected; captures fail confusingly | GUI host rejected; daemon (or auto-started daemon) selected |
| GUI host `screenRecording: false` but holds AppleScript/Accessibility, **non-capture** command (`app launch`/`app list`) | Selected | Still selected (not gated on Screen Recording) |
| Host omits `permissions` in handshake (older host) | Selected | Still selected (unknown is acceptable) |
| Host holds required permissions | Selected | Selected |
| `inspect-ui` / element-action command vs host with Accessibility `false` | Selected | Rejected (missing Accessibility) |
| `permissions request-event-synthesizing` against unpermissioned host | Reaches host | Still reaches host (`requestsHostPermissionGrant` carve-out) |

## Tests

`Apps/CLI/Tests/CoreCLITests/RuntimeHostResolverTests.swift`:

- a fake GUI handshake advertising `screenRecording: false` (capture still listed as enabled — mirrors the stale host) is **not** selected for a capture command, and the missing permission is identified as `screenRecording`;
- **regression the corrected design guards:** the same `screenRecording: false` host (holding the grants its own commands need) **is** accepted for non-capture commands (`requiresApplicationLaunchOptions`, `requiresHostApplicationInventory`), yet still rejected for a capture command;
- rejection also works for hosts that report permissions but predate `permissionTags` (client-side mapping fallback);
- a handshake with `permissions == nil` **is** accepted (back-compat);
- a fully permissioned host **is** selected;
- required permissions follow the command's operations: a Screen-Recording-only host is accepted for a capture command but rejected for `requiresInspectAccessibilityTree` (missing Accessibility);
- `requestsHostPermissionGrant` options may target hosts that lack permissions.

`CommanderBinderTests.swift`:

- `PermissionsCommand.RequestEventSynthesizingSubcommand` opts out of gating while `ImageCommand` does not;
- `requiresScreenCapturePermission` is set for the six capture commands and NOT for `click`/`scroll`/`type`/`app launch`/`app list`/`run`.

Commands run: `pnpm run build:cli`, `pnpm run format`, `pnpm run lint`, `swift test --filter RuntimeHostResolverTests --filter CommanderBinderTests` (70 tests, all passing), `swift test --filter CommandRuntimeInjectionTests` (36 passing). Autoreview (Codex gpt-5.5, thinking high) run to clean. No automation/UI suites were run.

**Note:** live end-to-end verification against a real stale host is pending and will be done by the coordinator.
