### PR TITLE
fix(list): deduplicate windows by window id

### DIFF
--- a/Apps/CLI/Tests/CoreCLITests/WindowListDeduplicationTests.swift
+++ b/Apps/CLI/Tests/CoreCLITests/WindowListDeduplicationTests.swift
@@ -107,6 +107,29 @@ struct WindowListDeduplicationTests {
         #expect(merged.map(\.title) == ["Main", "Detached"])
     }
 
+    @Test
+    func `AX-only window without a resolvable CG id still surfaces via its fallback record`() {
+        // Regression: an AX window that CGWindowList never reported and whose CGWindowID cannot be
+        // resolved (nil descriptor id) must not be dropped. The live path materializes it through
+        // createWindowInfo (fallback ID via CGWindowList/bounds/index); mergeWindows keys the append
+        // on that standalone record's id, so it is emitted.
+        let cgWindows = [Self.window(id: 1, title: "Main", index: 0)]
+        let axDescriptors = [
+            Self.descriptor(id: 1, title: "Main"),
+            Self.descriptor(
+                id: nil,
+                title: "Detached",
+                bounds: CGRect(x: 900, y: 900, width: 300, height: 200),
+                standaloneInfo: Self.window(id: 77, title: "Detached", index: 0)
+            ),
+        ]
+
+        let merged = WindowEnumerationContext.mergeWindows(cgWindows: cgWindows, axDescriptors: axDescriptors)
+
+        #expect(merged.map(\.windowID) == [1, 77])
+        #expect(merged.map(\.title) == ["Main", "Detached"])
+    }
+
     @MainActor
     @Test
     func `--window-index resolves to the window printed at that position`() async throws {

--- a/Apps/CLI/Tests/CoreCLITests/WindowListDeduplicationTests.swift
+++ b/Apps/CLI/Tests/CoreCLITests/WindowListDeduplicationTests.swift
@@ -12,8 +12,10 @@ import Testing
 /// position and re-appended later as a leftover — unique IDs, but the emitted order no longer
 /// matched the CG/frontmost enumeration, which is exactly what `--window-index` indexes into.
 ///
-/// The fix preserves CGWindowList order and associates AX windows by `CGWindowID` (bounds as a
-/// fallback), never by title, then assigns contiguous indexes after deduplication.
+/// The fix preserves CGWindowList order and only uses reliable signals to associate AX windows:
+/// an exact `CGWindowID` (from `_AXUIElementGetWindow`) or a CG-snapshot title+bounds — never a
+/// synthesized ID — then assigns contiguous indexes after deduplication.
+///
 /// `normalizeWindowIndices` and `WindowManagementService` are `@MainActor`; pin the whole suite so
 /// the isolation is explicit rather than relying on the target's default MainActor isolation.
 @MainActor
@@ -57,7 +59,8 @@ struct WindowListDeduplicationTests {
         // Playground reproduction: two real windows share the title "Text Fixture" and an untitled
         // CG utility window forces the CG+AX hybrid path (the fast path only fires when every CG
         // window already has a title). Association by title alone previously reordered these; the
-        // merge must keep CGWindowList order and enrich the untitled window from its AX counterpart.
+        // merge must keep CGWindowList order and enrich the untitled window from its AX counterpart
+        // (matched here by exact CGWindowID).
         let cgWindows = [
             Self.window(id: 3459, title: "Text Fixture", index: 0),
             Self.window(id: 3460, title: "Text Fixture", index: 1),
@@ -97,7 +100,9 @@ struct WindowListDeduplicationTests {
     }
 
     @Test
-    func `AX-only windows are appended after the CG enumeration`() {
+    func `AX-only window with a reliable CG id is appended after the CG enumeration`() {
+        // A window CGWindowList did not report but which AX resolved to a real CGWindowID (2) is a
+        // genuine, targetable window, so it is appended with its reliable identity.
         let cgWindows = [Self.window(id: 1, title: "Main", index: 0)]
         let axDescriptors = [
             Self.descriptor(id: 1, title: "Main"),
@@ -111,26 +116,21 @@ struct WindowListDeduplicationTests {
     }
 
     @Test
-    func `AX-only window without a resolvable CG id still surfaces via its fallback record`() {
-        // Regression: an AX window that CGWindowList never reported and whose CGWindowID cannot be
-        // resolved (nil descriptor id) must not be dropped. The live path materializes it through
-        // createWindowInfo (fallback ID via CGWindowList/bounds/index); mergeWindows keys the append
-        // on that standalone record's id, so it is emitted.
+    func `AX window without a resolvable id and no CG bounds match is not emitted`() {
+        // Principled tradeoff: an AX window CGWindowList never reported and whose CGWindowID cannot be
+        // resolved has no stable identity — createWindowInfo would synthesize an index-based ID and
+        // produce a phantom/duplicate entry (the bug class this change fixes). With no untitled CG
+        // window to enrich, it is dropped rather than emitted with a meaningless ID.
         let cgWindows = [Self.window(id: 1, title: "Main", index: 0)]
         let axDescriptors = [
             Self.descriptor(id: 1, title: "Main"),
-            Self.descriptor(
-                id: nil,
-                title: "Detached",
-                bounds: CGRect(x: 900, y: 900, width: 300, height: 200),
-                standaloneInfo: Self.window(id: 77, title: "Detached", index: 0)
-            ),
+            Self.descriptor(id: nil, title: "Ghost", bounds: CGRect(x: 900, y: 900, width: 300, height: 200)),
         ]
 
         let merged = WindowEnumerationContext.mergeWindows(cgWindows: cgWindows, axDescriptors: axDescriptors)
 
-        #expect(merged.map(\.windowID) == [1, 77])
-        #expect(merged.map(\.title) == ["Main", "Detached"])
+        #expect(merged.map(\.windowID) == [1])
+        #expect(merged.map(\.title) == ["Main"])
     }
 
     @Test
@@ -152,73 +152,6 @@ struct WindowListDeduplicationTests {
     }
 
     @Test
-    func `Bounds-matched descriptor titles the CG window without also appending its standalone`() {
-        // The live path materializes a standalone record for every non-exact-ID AX window. When that
-        // descriptor is consumed to title an untitled CG window by bounds, its standalone must NOT
-        // also be appended, or the window would appear twice.
-        let frame = CGRect(x: 40, y: 40, width: 600, height: 400)
-        let cgWindows = [Self.window(id: 88, title: "", index: 0, bounds: frame)]
-        let axDescriptors = [
-            Self.descriptor(
-                id: nil,
-                title: "Palette",
-                bounds: frame,
-                standaloneInfo: Self.window(id: 88, title: "Palette", index: 0, bounds: frame)
-            ),
-        ]
-
-        let merged = WindowEnumerationContext.mergeWindows(cgWindows: cgWindows, axDescriptors: axDescriptors)
-
-        #expect(merged.map(\.windowID) == [88])
-        #expect(merged.map(\.title) == ["Palette"])
-    }
-
-    @Test
-    func `Bounds fallback does not hijack a different windows title when the AX record resolved its own id`() {
-        // The AX descriptor has no _AXUIElementGetWindow id, but createWindowInfo resolved it to a
-        // concrete CGWindowID (200) via CGWindowList. It shares a frame with an unrelated untitled CG
-        // window (100). It must NOT title window 100; it surfaces as its own window (200) instead.
-        let frame = CGRect(x: 10, y: 10, width: 500, height: 400)
-        let cgWindows = [Self.window(id: 100, title: "", index: 0, bounds: frame)]
-        let axDescriptors = [
-            Self.descriptor(
-                id: nil,
-                title: "Other",
-                bounds: frame,
-                standaloneInfo: Self.window(id: 200, title: "Other", index: 0, bounds: frame)
-            ),
-        ]
-
-        let merged = WindowEnumerationContext.mergeWindows(cgWindows: cgWindows, axDescriptors: axDescriptors)
-
-        #expect(merged.map(\.windowID) == [100, 200])
-        #expect(merged.map(\.title) == ["", "Other"])
-    }
-
-    @Test
-    func `Extra bounds-fallback AX window is appended when no untitled CG window is left to title`() {
-        // Regression for the loose-bounds suppression bug: an AX window whose frame matches an
-        // already-titled CG window has no untitled window to enrich, so it must surface as a
-        // standalone entry rather than being silently dropped.
-        let frame = CGRect(x: 0, y: 0, width: 800, height: 600)
-        let cgWindows = [Self.window(id: 5, title: "Main", index: 0, bounds: frame)]
-        let axDescriptors = [
-            Self.descriptor(id: 5, title: "Main"),
-            Self.descriptor(
-                id: nil,
-                title: "Overlay",
-                bounds: frame,
-                standaloneInfo: Self.window(id: 6, title: "Overlay", index: 0, bounds: frame)
-            ),
-        ]
-
-        let merged = WindowEnumerationContext.mergeWindows(cgWindows: cgWindows, axDescriptors: axDescriptors)
-
-        #expect(merged.map(\.windowID) == [5, 6])
-        #expect(merged.map(\.title) == ["Main", "Overlay"])
-    }
-
-    @Test
     func `Bounds fallback assigns distinct titles to identically framed windows in order`() {
         let frame = CGRect(x: 0, y: 0, width: 1440, height: 900)
         let cgWindows = [
@@ -234,6 +167,24 @@ struct WindowListDeduplicationTests {
 
         #expect(merged.map(\.windowID) == [11, 12])
         #expect(merged.map(\.title) == ["First", "Second"])
+    }
+
+    @Test
+    func `Bounds fallback does not hijack a title already owned by another CG window`() {
+        // An untitled CG window (100) shares a frame with a titled CG window (200) that already owns
+        // the title "Overlay". A nil-id AX "Overlay" descriptor really belongs to 200, so it must NOT
+        // relabel 100: window 100 stays untitled, 200 keeps its title, nothing is duplicated.
+        let frame = CGRect(x: 10, y: 10, width: 500, height: 400)
+        let cgWindows = [
+            Self.window(id: 100, title: "", index: 0, bounds: frame),
+            Self.window(id: 200, title: "Overlay", index: 1, bounds: frame),
+        ]
+        let axDescriptors = [Self.descriptor(id: nil, title: "Overlay", bounds: frame)]
+
+        let merged = WindowEnumerationContext.mergeWindows(cgWindows: cgWindows, axDescriptors: axDescriptors)
+
+        #expect(merged.map(\.windowID) == [100, 200])
+        #expect(merged.map(\.title) == ["", "Overlay"])
     }
 
     @Test

--- a/Apps/CLI/Tests/CoreCLITests/WindowListDeduplicationTests.swift
+++ b/Apps/CLI/Tests/CoreCLITests/WindowListDeduplicationTests.swift
@@ -152,6 +152,51 @@ struct WindowListDeduplicationTests {
     }
 
     @Test
+    func `Bounds-matched descriptor titles the CG window without also appending its standalone`() {
+        // The live path materializes a standalone record for every non-exact-ID AX window. When that
+        // descriptor is consumed to title an untitled CG window by bounds, its standalone must NOT
+        // also be appended, or the window would appear twice.
+        let frame = CGRect(x: 40, y: 40, width: 600, height: 400)
+        let cgWindows = [Self.window(id: 88, title: "", index: 0, bounds: frame)]
+        let axDescriptors = [
+            Self.descriptor(
+                id: nil,
+                title: "Palette",
+                bounds: frame,
+                standaloneInfo: Self.window(id: 88, title: "Palette", index: 0, bounds: frame)
+            ),
+        ]
+
+        let merged = WindowEnumerationContext.mergeWindows(cgWindows: cgWindows, axDescriptors: axDescriptors)
+
+        #expect(merged.map(\.windowID) == [88])
+        #expect(merged.map(\.title) == ["Palette"])
+    }
+
+    @Test
+    func `Extra bounds-fallback AX window is appended when no untitled CG window is left to title`() {
+        // Regression for the loose-bounds suppression bug: an AX window whose frame matches an
+        // already-titled CG window has no untitled window to enrich, so it must surface as a
+        // standalone entry rather than being silently dropped.
+        let frame = CGRect(x: 0, y: 0, width: 800, height: 600)
+        let cgWindows = [Self.window(id: 5, title: "Main", index: 0, bounds: frame)]
+        let axDescriptors = [
+            Self.descriptor(id: 5, title: "Main"),
+            Self.descriptor(
+                id: nil,
+                title: "Overlay",
+                bounds: frame,
+                standaloneInfo: Self.window(id: 6, title: "Overlay", index: 0, bounds: frame)
+            ),
+        ]
+
+        let merged = WindowEnumerationContext.mergeWindows(cgWindows: cgWindows, axDescriptors: axDescriptors)
+
+        #expect(merged.map(\.windowID) == [5, 6])
+        #expect(merged.map(\.title) == ["Main", "Overlay"])
+    }
+
+    @Test
     func `Bounds fallback assigns distinct titles to identically framed windows in order`() {
         let frame = CGRect(x: 0, y: 0, width: 1440, height: 900)
         let cgWindows = [

--- a/Apps/CLI/Tests/CoreCLITests/WindowListDeduplicationTests.swift
+++ b/Apps/CLI/Tests/CoreCLITests/WindowListDeduplicationTests.swift
@@ -1,0 +1,107 @@
+import CoreGraphics
+import Foundation
+import Testing
+@testable import PeekabooAutomationKit
+
+/// Regression tests for duplicate window IDs leaking out of window enumeration.
+///
+/// `peekaboo list windows` returned the same CGWindowID twice (with distinct indexes) because the
+/// CG/AX merge in `WindowEnumerationContext` appended one entry per AX window keyed by title only,
+/// and indexes were assigned before any deduplication. `peekaboo window list` hid the duplicate via
+/// `ObservationTargetResolver.filteredWindows(mode: .list)` but inherited the shifted indexes.
+@Suite("Window list deduplication")
+struct WindowListDeduplicationTests {
+    @Test
+    func `Duplicate window IDs collapse to a single entry keeping the first occurrence`() {
+        let duplicateID = 3459
+        let windows = [
+            Self.window(id: 100, title: "Main", index: 0),
+            Self.window(id: duplicateID, title: "Text Fixture", index: 1),
+            Self.window(id: 200, title: "Inspector", index: 2),
+            Self.window(id: duplicateID, title: "Text Fixture", index: 3),
+            Self.window(id: 300, title: "Palette", index: 4),
+        ]
+
+        let normalized = ApplicationService.normalizeWindowIndices(windows)
+
+        #expect(normalized.map(\.windowID) == [100, duplicateID, 200, 300])
+        #expect(Set(normalized.map(\.windowID)).count == normalized.count)
+    }
+
+    @Test
+    func `Indexes are contiguous after deduplication so a phantom entry cannot shift targets`() {
+        let windows = [
+            Self.window(id: 10, title: "A", index: 0),
+            Self.window(id: 20, title: "B", index: 1),
+            Self.window(id: 20, title: "B", index: 2),
+            Self.window(id: 30, title: "C", index: 3),
+            Self.window(id: 40, title: "D", index: 4),
+        ]
+
+        let normalized = ApplicationService.normalizeWindowIndices(windows)
+
+        #expect(normalized.map(\.index) == Array(0..<normalized.count))
+        #expect(normalized.map(\.windowID) == [10, 20, 30, 40])
+    }
+
+    @Test
+    func `list windows and window list agree for renderable windows from the same source`() {
+        // `list windows` renders the normalized enumeration; `window list` additionally applies
+        // ObservationTargetResolver.filteredWindows(mode: .list). For renderable windows the two
+        // command payloads must contain the identical window set, IDs, and indexes.
+        let rawWindows = [
+            Self.window(id: 3459, title: "Text Fixture", index: 0),
+            Self.window(id: 3459, title: "Text Fixture", index: 1),
+            Self.window(id: 42, title: "Playground", index: 2),
+            Self.window(id: 7, title: "Console", index: 3),
+        ]
+
+        let listWindowsPayload = ApplicationService.normalizeWindowIndices(rawWindows)
+        let windowListPayload = ObservationTargetResolver.filteredWindows(from: listWindowsPayload, mode: .list)
+
+        #expect(listWindowsPayload.map(\.windowID) == [3459, 42, 7])
+        #expect(windowListPayload.map(\.windowID) == listWindowsPayload.map(\.windowID))
+        #expect(windowListPayload.map(\.index) == listWindowsPayload.map(\.index))
+    }
+
+    @Test
+    func `window list keeps source indexes when it filters non-renderable windows`() {
+        // Intentional difference: `window list` drops non-renderable windows (layer != 0, tiny,
+        // fully transparent, excluded from the Windows menu) but must preserve the canonical
+        // indexes assigned by the enumeration so --window-index targeting stays aligned.
+        let rawWindows = [
+            Self.window(id: 1, title: "Main", index: 0),
+            Self.window(id: 2, title: "Status Item", index: 0, layer: 25),
+            Self.window(id: 3, title: "Inspector", index: 0),
+        ]
+
+        let listWindowsPayload = ApplicationService.normalizeWindowIndices(rawWindows)
+        let windowListPayload = ObservationTargetResolver.filteredWindows(from: listWindowsPayload, mode: .list)
+
+        #expect(listWindowsPayload.map(\.windowID) == [1, 2, 3])
+        #expect(windowListPayload.map(\.windowID) == [1, 3])
+        #expect(windowListPayload.map(\.index) == [0, 2])
+    }
+
+    private static func window(
+        id: Int,
+        title: String,
+        index: Int,
+        layer: Int = 0
+    ) -> ServiceWindowInfo {
+        ServiceWindowInfo(
+            windowID: id,
+            title: title,
+            bounds: CGRect(x: 14, y: 59, width: 1200, height: 832),
+            isMinimized: false,
+            isMainWindow: false,
+            windowLevel: layer,
+            alpha: 1,
+            index: index,
+            layer: layer,
+            isOnScreen: true,
+            sharingState: .readOnly,
+            isExcludedFromWindowsMenu: false
+        )
+    }
+}

--- a/Apps/CLI/Tests/CoreCLITests/WindowListDeduplicationTests.swift
+++ b/Apps/CLI/Tests/CoreCLITests/WindowListDeduplicationTests.swift
@@ -174,6 +174,28 @@ struct WindowListDeduplicationTests {
     }
 
     @Test
+    func `Bounds fallback does not hijack a different windows title when the AX record resolved its own id`() {
+        // The AX descriptor has no _AXUIElementGetWindow id, but createWindowInfo resolved it to a
+        // concrete CGWindowID (200) via CGWindowList. It shares a frame with an unrelated untitled CG
+        // window (100). It must NOT title window 100; it surfaces as its own window (200) instead.
+        let frame = CGRect(x: 10, y: 10, width: 500, height: 400)
+        let cgWindows = [Self.window(id: 100, title: "", index: 0, bounds: frame)]
+        let axDescriptors = [
+            Self.descriptor(
+                id: nil,
+                title: "Other",
+                bounds: frame,
+                standaloneInfo: Self.window(id: 200, title: "Other", index: 0, bounds: frame)
+            ),
+        ]
+
+        let merged = WindowEnumerationContext.mergeWindows(cgWindows: cgWindows, axDescriptors: axDescriptors)
+
+        #expect(merged.map(\.windowID) == [100, 200])
+        #expect(merged.map(\.title) == ["", "Other"])
+    }
+
+    @Test
     func `Extra bounds-fallback AX window is appended when no untitled CG window is left to title`() {
         // Regression for the loose-bounds suppression bug: an AX window whose frame matches an
         // already-titled CG window has no untitled window to enrich, so it must surface as a

--- a/Apps/CLI/Tests/CoreCLITests/WindowListDeduplicationTests.swift
+++ b/Apps/CLI/Tests/CoreCLITests/WindowListDeduplicationTests.swift
@@ -130,6 +130,42 @@ struct WindowListDeduplicationTests {
         #expect(merged.map(\.title) == ["Main", "Detached"])
     }
 
+    @Test
+    func `Bounds fallback title is consumed once so identical frames are not all relabeled`() {
+        // Two untitled CG windows share an identical frame (stacked/maximized). A single AX
+        // descriptor without a resolvable CGWindowID matches that frame. It must relabel exactly one
+        // window; the other stays untitled rather than borrowing the same title and mislabeling.
+        let frame = CGRect(x: 0, y: 0, width: 1440, height: 900)
+        let cgWindows = [
+            Self.window(id: 11, title: "", index: 0, bounds: frame),
+            Self.window(id: 12, title: "", index: 1, bounds: frame),
+        ]
+        let axDescriptors = [Self.descriptor(id: nil, title: "Document", bounds: frame)]
+
+        let merged = WindowEnumerationContext.mergeWindows(cgWindows: cgWindows, axDescriptors: axDescriptors)
+
+        #expect(merged.map(\.windowID) == [11, 12])
+        #expect(merged.map(\.title) == ["Document", ""])
+    }
+
+    @Test
+    func `Bounds fallback assigns distinct titles to identically framed windows in order`() {
+        let frame = CGRect(x: 0, y: 0, width: 1440, height: 900)
+        let cgWindows = [
+            Self.window(id: 11, title: "", index: 0, bounds: frame),
+            Self.window(id: 12, title: "", index: 1, bounds: frame),
+        ]
+        let axDescriptors = [
+            Self.descriptor(id: nil, title: "First", bounds: frame),
+            Self.descriptor(id: nil, title: "Second", bounds: frame),
+        ]
+
+        let merged = WindowEnumerationContext.mergeWindows(cgWindows: cgWindows, axDescriptors: axDescriptors)
+
+        #expect(merged.map(\.windowID) == [11, 12])
+        #expect(merged.map(\.title) == ["First", "Second"])
+    }
+
     @MainActor
     @Test
     func `--window-index resolves to the window printed at that position`() async throws {

--- a/Apps/CLI/Tests/CoreCLITests/WindowListDeduplicationTests.swift
+++ b/Apps/CLI/Tests/CoreCLITests/WindowListDeduplicationTests.swift
@@ -1,14 +1,19 @@
 import CoreGraphics
 import Foundation
+import PeekabooFoundation
 import Testing
 @testable import PeekabooAutomationKit
 
-/// Regression tests for duplicate window IDs leaking out of window enumeration.
+/// Regression tests for duplicate / mis-ordered window IDs leaking out of window enumeration.
 ///
 /// `peekaboo list windows` returned the same CGWindowID twice (with distinct indexes) because the
-/// CG/AX merge in `WindowEnumerationContext` appended one entry per AX window keyed by title only,
-/// and indexes were assigned before any deduplication. `peekaboo window list` hid the duplicate via
-/// `ObservationTargetResolver.filteredWindows(mode: .list)` but inherited the shifted indexes.
+/// CG/AX merge in `WindowEnumerationContext` associated AX windows to CG entries by title alone.
+/// Two windows sharing a title collapsed onto a single CG entry, so one was dropped from its AX
+/// position and re-appended later as a leftover — unique IDs, but the emitted order no longer
+/// matched the CG/frontmost enumeration, which is exactly what `--window-index` indexes into.
+///
+/// The fix preserves CGWindowList order and associates AX windows by `CGWindowID` (bounds as a
+/// fallback), never by title, then assigns contiguous indexes after deduplication.
 @Suite("Window list deduplication")
 struct WindowListDeduplicationTests {
     @Test
@@ -42,6 +47,96 @@ struct WindowListDeduplicationTests {
 
         #expect(normalized.map(\.index) == Array(0..<normalized.count))
         #expect(normalized.map(\.windowID) == [10, 20, 30, 40])
+    }
+
+    @Test
+    func `Same-titled windows keep distinct positions in CG order on the hybrid merge path`() {
+        // Playground reproduction: two real windows share the title "Text Fixture" and an untitled
+        // CG utility window forces the CG+AX hybrid path (the fast path only fires when every CG
+        // window already has a title). Association by title alone previously reordered these; the
+        // merge must keep CGWindowList order and enrich the untitled window from its AX counterpart.
+        let cgWindows = [
+            Self.window(id: 3459, title: "Text Fixture", index: 0),
+            Self.window(id: 3460, title: "Text Fixture", index: 1),
+            Self.window(id: 99, title: "", index: 2),
+        ]
+        let axDescriptors = [
+            Self.descriptor(id: 3459, title: "Text Fixture"),
+            Self.descriptor(id: 3460, title: "Text Fixture"),
+            Self.descriptor(id: 99, title: "Utility Panel"),
+        ]
+
+        let merged = WindowEnumerationContext.mergeWindows(cgWindows: cgWindows, axDescriptors: axDescriptors)
+
+        #expect(merged.map(\.windowID) == [3459, 3460, 99])
+        #expect(merged.map(\.title) == ["Text Fixture", "Text Fixture", "Utility Panel"])
+
+        let normalized = ApplicationService.normalizeWindowIndices(merged)
+        #expect(normalized.map(\.index) == [0, 1, 2])
+        #expect(normalized.map(\.windowID) == [3459, 3460, 99])
+    }
+
+    @Test
+    func `Untitled CG window is enriched by bounds when AX cannot expose a window id`() {
+        let cgWindows = [
+            Self.window(id: 501, title: "Editor", index: 0),
+            Self.window(id: 502, title: "", index: 1, bounds: CGRect(x: 40, y: 40, width: 600, height: 400)),
+        ]
+        let axDescriptors = [
+            Self.descriptor(id: 501, title: "Editor"),
+            Self.descriptor(id: nil, title: "Palette", bounds: CGRect(x: 42, y: 41, width: 600, height: 400)),
+        ]
+
+        let merged = WindowEnumerationContext.mergeWindows(cgWindows: cgWindows, axDescriptors: axDescriptors)
+
+        #expect(merged.map(\.windowID) == [501, 502])
+        #expect(merged.map(\.title) == ["Editor", "Palette"])
+    }
+
+    @Test
+    func `AX-only windows are appended after the CG enumeration`() {
+        let cgWindows = [Self.window(id: 1, title: "Main", index: 0)]
+        let axDescriptors = [
+            Self.descriptor(id: 1, title: "Main"),
+            Self.descriptor(id: 2, title: "Detached", standaloneInfo: Self.window(id: 2, title: "Detached", index: 0)),
+        ]
+
+        let merged = WindowEnumerationContext.mergeWindows(cgWindows: cgWindows, axDescriptors: axDescriptors)
+
+        #expect(merged.map(\.windowID) == [1, 2])
+        #expect(merged.map(\.title) == ["Main", "Detached"])
+    }
+
+    @MainActor
+    @Test
+    func `--window-index resolves to the window printed at that position`() async throws {
+        // Drive the real WindowManagementService.listWindows(.index) path over the real merge +
+        // normalize output, so a positional target genuinely lands on the printed window.
+        let cgWindows = [
+            Self.window(id: 3459, title: "Text Fixture", index: 0),
+            Self.window(id: 3460, title: "Text Fixture", index: 1),
+            Self.window(id: 42, title: "Playground", index: 2),
+            Self.window(id: 99, title: "", index: 3),
+        ]
+        let axDescriptors = [
+            Self.descriptor(id: 3459, title: "Text Fixture"),
+            Self.descriptor(id: 3460, title: "Text Fixture"),
+            Self.descriptor(id: 42, title: "Playground"),
+            Self.descriptor(id: 99, title: "Utility Panel"),
+        ]
+
+        let merged = WindowEnumerationContext.mergeWindows(cgWindows: cgWindows, axDescriptors: axDescriptors)
+        let enumeration = ApplicationService.normalizeWindowIndices(merged)
+
+        let appService = FakeApplicationService(windows: enumeration)
+        let windowService = WindowManagementService(applicationService: appService)
+
+        for position in enumeration.indices {
+            let resolved = try await windowService.listWindows(target: .index(app: "Playground", index: position))
+            #expect(resolved.count == 1)
+            #expect(resolved.first?.windowID == enumeration[position].windowID)
+            #expect(resolved.first?.index == position)
+        }
     }
 
     @Test
@@ -87,12 +182,13 @@ struct WindowListDeduplicationTests {
         id: Int,
         title: String,
         index: Int,
-        layer: Int = 0
+        layer: Int = 0,
+        bounds: CGRect = CGRect(x: 14, y: 59, width: 1200, height: 832)
     ) -> ServiceWindowInfo {
         ServiceWindowInfo(
             windowID: id,
             title: title,
-            bounds: CGRect(x: 14, y: 59, width: 1200, height: 832),
+            bounds: bounds,
             isMinimized: false,
             isMainWindow: false,
             windowLevel: layer,
@@ -104,4 +200,82 @@ struct WindowListDeduplicationTests {
             isExcludedFromWindowsMenu: false
         )
     }
+
+    private static func descriptor(
+        id: Int?,
+        title: String,
+        bounds: CGRect? = nil,
+        standaloneInfo: ServiceWindowInfo? = nil
+    ) -> WindowEnumerationContext.AXWindowDescriptor {
+        WindowEnumerationContext.AXWindowDescriptor(
+            windowID: id,
+            title: title,
+            bounds: bounds,
+            standaloneInfo: standaloneInfo
+        )
+    }
+}
+
+/// Minimal `ApplicationServiceProtocol` that returns a fixed, pre-computed window enumeration so the
+/// real `WindowManagementService.listWindows(.index)` selection can be exercised without live AX/CG.
+@MainActor
+private final class FakeApplicationService: ApplicationServiceProtocol {
+    private let windows: [ServiceWindowInfo]
+    private let app = ServiceApplicationInfo(
+        processIdentifier: 4242,
+        bundleIdentifier: "boo.peekaboo.playground.debug",
+        name: "Playground",
+        isActive: true,
+        windowCount: 4
+    )
+
+    init(windows: [ServiceWindowInfo]) {
+        self.windows = windows
+    }
+
+    func listApplications() async throws -> UnifiedToolOutput<ServiceApplicationListData> {
+        UnifiedToolOutput(
+            data: ServiceApplicationListData(applications: [self.app]),
+            summary: .init(brief: "1 app", status: .success, counts: ["applications": 1]),
+            metadata: .init(duration: 0)
+        )
+    }
+
+    func findApplication(identifier _: String) async throws -> ServiceApplicationInfo {
+        self.app
+    }
+
+    func listWindows(for _: String, timeout _: Float?) async throws -> UnifiedToolOutput<ServiceWindowListData> {
+        UnifiedToolOutput(
+            data: ServiceWindowListData(windows: self.windows, targetApplication: self.app),
+            summary: .init(
+                brief: "\(self.windows.count) windows",
+                status: .success,
+                counts: ["windows": self.windows.count]
+            ),
+            metadata: .init(duration: 0)
+        )
+    }
+
+    func getFrontmostApplication() async throws -> ServiceApplicationInfo {
+        self.app
+    }
+
+    func isApplicationRunning(identifier _: String) async -> Bool {
+        true
+    }
+
+    func launchApplication(identifier _: String) async throws -> ServiceApplicationInfo {
+        self.app
+    }
+
+    func activateApplication(identifier _: String) async throws {}
+    func quitApplication(identifier _: String, force _: Bool) async throws -> Bool {
+        true
+    }
+
+    func hideApplication(identifier _: String) async throws {}
+    func unhideApplication(identifier _: String) async throws {}
+    func hideOtherApplications(identifier _: String) async throws {}
+    func showAllApplications() async throws {}
 }

--- a/Apps/CLI/Tests/CoreCLITests/WindowListDeduplicationTests.swift
+++ b/Apps/CLI/Tests/CoreCLITests/WindowListDeduplicationTests.swift
@@ -14,6 +14,9 @@ import Testing
 ///
 /// The fix preserves CGWindowList order and associates AX windows by `CGWindowID` (bounds as a
 /// fallback), never by title, then assigns contiguous indexes after deduplication.
+/// `normalizeWindowIndices` and `WindowManagementService` are `@MainActor`; pin the whole suite so
+/// the isolation is explicit rather than relying on the target's default MainActor isolation.
+@MainActor
 @Suite("Window list deduplication")
 struct WindowListDeduplicationTests {
     @Test
@@ -166,7 +169,6 @@ struct WindowListDeduplicationTests {
         #expect(merged.map(\.title) == ["First", "Second"])
     }
 
-    @MainActor
     @Test
     func `--window-index resolves to the window printed at that position`() async throws {
         // Drive the real WindowManagementService.listWindows(.index) path over the real merge +

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/System/ApplicationService+WindowListing.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/System/ApplicationService+WindowListing.swift
@@ -26,7 +26,11 @@ extension ApplicationService {
     }
 
     static func normalizeWindowIndices(_ windows: [ServiceWindowInfo]) -> [ServiceWindowInfo] {
-        windows.enumerated().map { index, window in
+        // Deduplicate by windowID before assigning indexes: a duplicate entry (e.g. from merged
+        // CG/AX enumeration) would otherwise consume an index slot and shift --window-index targets.
+        var seenWindowIDs = Set<Int>()
+        let uniqueWindows = windows.filter { seenWindowIDs.insert($0.windowID).inserted }
+        return uniqueWindows.enumerated().map { index, window in
             ServiceWindowInfo(
                 windowID: window.windowID,
                 title: window.title,

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/System/ApplicationWindowEnumerationContext.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/System/ApplicationWindowEnumerationContext.swift
@@ -194,7 +194,18 @@ struct WindowEnumerationContext {
         axResult: AXWindowResult) async -> UnifiedToolOutput<ServiceWindowListData>
     {
         var enrichedWindows: [ServiceWindowInfo] = []
+        // windowsByTitle is keyed by title only, so two AX windows sharing a title resolve to the
+        // same CG snapshot entry. Guard every append by windowID or the same window is listed twice.
+        var seenWindowIDs = Set<Int>()
         var warnings: [String] = []
+
+        func appendIfNew(_ window: ServiceWindowInfo) {
+            guard seenWindowIDs.insert(window.windowID).inserted else {
+                self.logger.debug("Skipping duplicate window id \(window.windowID) ('\(window.title)')")
+                return
+            }
+            enrichedWindows.append(window)
+        }
 
         for (index, axWindow) in axResult.windows.indexed() {
             if Date().timeIntervalSince(self.startTime) > Double(self.axTimeout * 2) {
@@ -207,17 +218,17 @@ struct WindowEnumerationContext {
             }
 
             if let cgWindow = snapshot.windowsByTitle[axTitle] {
-                enrichedWindows.append(cgWindow)
+                appendIfNew(cgWindow)
             } else if let windowInfo = await self.service.createWindowInfo(from: axWindow, index: index) {
-                enrichedWindows.append(windowInfo)
+                appendIfNew(windowInfo)
             }
         }
 
-        for cgWindow in snapshot.windows where !enrichedWindows.contains(where: { $0.windowID == cgWindow.windowID }) {
+        for cgWindow in snapshot.windows where !seenWindowIDs.contains(cgWindow.windowID) {
             if cgWindow.title.isEmpty {
                 self.logger.debug("CGWindow \(cgWindow.windowID) has no title, including as-is")
             }
-            enrichedWindows.append(cgWindow)
+            appendIfNew(cgWindow)
         }
 
         if axResult.timedOut {

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/System/ApplicationWindowEnumerationContext.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/System/ApplicationWindowEnumerationContext.swift
@@ -8,12 +8,29 @@ import PeekabooFoundation
 struct WindowEnumerationContext {
     struct CGSnapshot {
         let windows: [ServiceWindowInfo]
-        let windowsByTitle: [String: ServiceWindowInfo]
     }
 
     struct AXWindowResult {
         let windows: [Element]
         let timedOut: Bool
+    }
+
+    /// Plain, testable description of an AX window used to enrich or extend the CG snapshot.
+    ///
+    /// AX windows are associated with CG windows by `CGWindowID` (resolved via `_AXUIElementGetWindow`)
+    /// and, as a fallback, by matching bounds. Title is deliberately *not* an association key: two
+    /// windows of the same app can share a title, and keying by title collapses them onto a single
+    /// CG entry, reordering the enumeration and mis-aligning `--window-index` targets.
+    struct AXWindowDescriptor: Sendable {
+        /// Resolved CGWindowID, when AX could expose one.
+        let windowID: Int?
+        /// AX window title (may be empty).
+        let title: String
+        /// AX-reported bounds, used only as a fallback matcher when `windowID` is unavailable.
+        let bounds: CGRect?
+        /// Fully materialized record for an AX window that has no CG counterpart. Nil when the AX
+        /// window matched a CG entry (the CG entry is authoritative and only borrows the title).
+        let standaloneInfo: ServiceWindowInfo?
     }
 
     unowned let service: ApplicationService
@@ -54,7 +71,6 @@ struct WindowEnumerationContext {
 
         var windowIndex = 0
         var windows: [ServiceWindowInfo] = []
-        var windowsByTitle: [String: ServiceWindowInfo] = [:]
         let screenService = ScreenService()
         let spaceService = SpaceManagementService()
 
@@ -75,9 +91,7 @@ struct WindowEnumerationContext {
             }
 
             windows.append(windowInfo)
-            if !windowInfo.title.isEmpty {
-                windowsByTitle[windowInfo.title] = windowInfo
-            } else {
+            if windowInfo.title.isEmpty {
                 let missingTitleMessage =
                     "Window \(windowInfo.windowID) has no title in CGWindowList, will need AX enrichment"
                 self.logger.debug("\(missingTitleMessage)")
@@ -90,7 +104,7 @@ struct WindowEnumerationContext {
         }
 
         self.logger.debug("CGWindowList found \(windows.count) windows for \(self.app.name)")
-        return CGSnapshot(windows: windows, windowsByTitle: windowsByTitle)
+        return CGSnapshot(windows: windows)
     }
 
     private func snapshotWindowInfo(
@@ -193,19 +207,36 @@ struct WindowEnumerationContext {
         _ snapshot: CGSnapshot,
         axResult: AXWindowResult) async -> UnifiedToolOutput<ServiceWindowListData>
     {
-        var enrichedWindows: [ServiceWindowInfo] = []
-        // windowsByTitle is keyed by title only, so two AX windows sharing a title resolve to the
-        // same CG snapshot entry. Guard every append by windowID or the same window is listed twice.
-        var seenWindowIDs = Set<Int>()
         var warnings: [String] = []
+        let descriptors = await self.collectAXDescriptors(
+            axResult: axResult,
+            cgWindowIDs: Set(snapshot.windows.map(\.windowID)),
+            warnings: &warnings)
 
-        func appendIfNew(_ window: ServiceWindowInfo) {
-            guard seenWindowIDs.insert(window.windowID).inserted else {
-                self.logger.debug("Skipping duplicate window id \(window.windowID) ('\(window.title)')")
-                return
-            }
-            enrichedWindows.append(window)
+        let merged = Self.mergeWindows(cgWindows: snapshot.windows, axDescriptors: descriptors)
+
+        if axResult.timedOut {
+            warnings.append("Window enumeration timed out after \(self.axTimeout)s, results may be incomplete")
         }
+
+        return self.service.buildWindowListOutput(
+            windows: merged,
+            app: self.app,
+            startTime: self.startTime,
+            warnings: warnings)
+    }
+
+    /// Resolve each AX window into a plain descriptor: CGWindowID (via `_AXUIElementGetWindow`),
+    /// title, and bounds. A full record is only built for AX windows CGWindowList never reported,
+    /// so the common enrichment path stays cheap.
+    private func collectAXDescriptors(
+        axResult: AXWindowResult,
+        cgWindowIDs: Set<Int>,
+        warnings: inout [String]) async -> [AXWindowDescriptor]
+    {
+        let windowIdentityService = WindowIdentityService()
+        var descriptors: [AXWindowDescriptor] = []
+        descriptors.reserveCapacity(axResult.windows.count)
 
         for (index, axWindow) in axResult.windows.indexed() {
             if Date().timeIntervalSince(self.startTime) > Double(self.axTimeout * 2) {
@@ -213,33 +244,95 @@ struct WindowEnumerationContext {
                 break
             }
 
-            guard let axTitle = axWindow.title(), !axTitle.isEmpty else {
+            let title = axWindow.title() ?? ""
+            let resolvedID = windowIdentityService.getWindowID(from: axWindow).map(Int.init)
+            let bounds: CGRect? = axWindow.position().map { position in
+                CGRect(origin: position, size: axWindow.size() ?? .zero)
+            }
+
+            // Materialize a full record only when this AX window has no CG counterpart; those are the
+            // windows CGWindowList missed and that we still need to surface.
+            var standaloneInfo: ServiceWindowInfo?
+            if let resolvedID, !cgWindowIDs.contains(resolvedID) {
+                standaloneInfo = await self.service.createWindowInfo(from: axWindow, index: index)
+            }
+
+            descriptors.append(AXWindowDescriptor(
+                windowID: resolvedID,
+                title: title,
+                bounds: bounds,
+                standaloneInfo: standaloneInfo))
+        }
+
+        return descriptors
+    }
+
+    /// Merge CG and AX windows preserving CGWindowList enumeration order.
+    ///
+    /// - CG windows are emitted first, in CGWindowList order, deduplicated by `CGWindowID`. Untitled
+    ///   CG entries borrow a title from the AX window with the same `CGWindowID` (or matching bounds).
+    /// - AX-only windows (a resolved `CGWindowID` that CGWindowList never reported) are appended last.
+    ///
+    /// Association is by `CGWindowID`/bounds, never by title, so same-titled windows keep distinct
+    /// positions and `--window-index` continues to line up with the printed list.
+    nonisolated static func mergeWindows(
+        cgWindows: [ServiceWindowInfo],
+        axDescriptors: [AXWindowDescriptor]) -> [ServiceWindowInfo]
+    {
+        var axTitleByID: [Int: String] = [:]
+        for descriptor in axDescriptors {
+            guard let id = descriptor.windowID, !descriptor.title.isEmpty else { continue }
+            if axTitleByID[id] == nil {
+                axTitleByID[id] = descriptor.title
+            }
+        }
+
+        var merged: [ServiceWindowInfo] = []
+        merged.reserveCapacity(cgWindows.count + axDescriptors.count)
+        var seenWindowIDs = Set<Int>()
+
+        for cgWindow in cgWindows where seenWindowIDs.insert(cgWindow.windowID).inserted {
+            merged.append(Self.titleEnriched(cgWindow, axTitleByID: axTitleByID, axDescriptors: axDescriptors))
+        }
+
+        for descriptor in axDescriptors {
+            guard let info = descriptor.standaloneInfo, seenWindowIDs.insert(info.windowID).inserted else {
                 continue
             }
-
-            if let cgWindow = snapshot.windowsByTitle[axTitle] {
-                appendIfNew(cgWindow)
-            } else if let windowInfo = await self.service.createWindowInfo(from: axWindow, index: index) {
-                appendIfNew(windowInfo)
-            }
+            merged.append(info)
         }
 
-        for cgWindow in snapshot.windows where !seenWindowIDs.contains(cgWindow.windowID) {
-            if cgWindow.title.isEmpty {
-                self.logger.debug("CGWindow \(cgWindow.windowID) has no title, including as-is")
-            }
-            appendIfNew(cgWindow)
+        return merged
+    }
+
+    private nonisolated static func titleEnriched(
+        _ window: ServiceWindowInfo,
+        axTitleByID: [Int: String],
+        axDescriptors: [AXWindowDescriptor]) -> ServiceWindowInfo
+    {
+        guard window.title.isEmpty else { return window }
+
+        if let title = axTitleByID[window.windowID] {
+            return window.withTitle(title)
         }
 
-        if axResult.timedOut {
-            warnings.append("Window enumeration timed out after \(self.axTimeout)s, results may be incomplete")
+        // Fallback: AX could not expose a CGWindowID, so match by bounds instead of title.
+        if let matched = axDescriptors.first(where: { descriptor in
+            descriptor.windowID == nil &&
+                !descriptor.title.isEmpty &&
+                descriptor.bounds.map { Self.boundsMatch($0, window.bounds) } == true
+        }) {
+            return window.withTitle(matched.title)
         }
 
-        return self.service.buildWindowListOutput(
-            windows: enrichedWindows,
-            app: self.app,
-            startTime: self.startTime,
-            warnings: warnings)
+        return window
+    }
+
+    private nonisolated static func boundsMatch(_ lhs: CGRect, _ rhs: CGRect, tolerance: CGFloat = 5) -> Bool {
+        abs(lhs.origin.x - rhs.origin.x) < tolerance &&
+            abs(lhs.origin.y - rhs.origin.y) < tolerance &&
+            abs(lhs.size.width - rhs.size.width) < tolerance &&
+            abs(lhs.size.height - rhs.size.height) < tolerance
     }
 
     private func buildAXOnlyResult(from axResult: AXWindowResult) async -> UnifiedToolOutput<ServiceWindowListData> {
@@ -286,5 +379,29 @@ struct WindowEnumerationContext {
             app: self.app,
             startTime: self.startTime,
             warnings: warnings)
+    }
+}
+
+extension ServiceWindowInfo {
+    /// Returns a copy of this window with a replacement title, preserving every other field.
+    fileprivate func withTitle(_ newTitle: String) -> ServiceWindowInfo {
+        ServiceWindowInfo(
+            windowID: self.windowID,
+            title: newTitle,
+            bounds: self.bounds,
+            isMinimized: self.isMinimized,
+            isMainWindow: self.isMainWindow,
+            windowLevel: self.windowLevel,
+            alpha: self.alpha,
+            index: self.index,
+            spaceID: self.spaceID,
+            spaceName: self.spaceName,
+            screenIndex: self.screenIndex,
+            screenName: self.screenName,
+            isOffScreen: self.isOffScreen,
+            layer: self.layer,
+            isOnScreen: self.isOnScreen,
+            sharingState: self.sharingState,
+            isExcludedFromWindowsMenu: self.isExcludedFromWindowsMenu)
     }
 }

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/System/ApplicationWindowEnumerationContext.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/System/ApplicationWindowEnumerationContext.swift
@@ -28,8 +28,9 @@ struct WindowEnumerationContext {
         let title: String
         /// AX-reported bounds, used only as a fallback matcher when `windowID` is unavailable.
         let bounds: CGRect?
-        /// Fully materialized record for an AX window that has no CG counterpart. Nil when the AX
-        /// window matched a CG entry (the CG entry is authoritative and only borrows the title).
+        /// Fully materialized record for a genuine AX-only window. Set only when `windowID` is a
+        /// reliable resolved CGWindowID absent from the CG snapshot, so appending it cannot introduce
+        /// a phantom entry; nil for CG-matched windows and for windows AX could not resolve to an ID.
         let standaloneInfo: ServiceWindowInfo?
     }
 
@@ -227,9 +228,14 @@ struct WindowEnumerationContext {
     }
 
     /// Resolve each AX window into a plain descriptor: CGWindowID (via `_AXUIElementGetWindow`),
-    /// title, and bounds. A full `standaloneInfo` record is materialized for every titled AX window
-    /// that is *not* an exact CGWindowID match, so no AX-only window can be lost; the merge step then
-    /// decides whether that record enriches an untitled CG window or is appended standalone.
+    /// title, and bounds.
+    ///
+    /// A `standaloneInfo` record is materialized only for AX windows that resolve to a *reliable*
+    /// CGWindowID which CGWindowList did not report — those are genuine AX-only windows we can list
+    /// with a stable identity. AX windows whose CGWindowID cannot be resolved are used solely to
+    /// title an untitled CG window by bounds; they are never appended as their own entry, because
+    /// `createWindowInfo` would fall back to a synthetic index-based ID and produce exactly the
+    /// phantom / duplicate / index-shifting entries this change fixes.
     private func collectAXDescriptors(
         axResult: AXWindowResult,
         cgWindowIDs: Set<Int>,
@@ -251,14 +257,8 @@ struct WindowEnumerationContext {
                 CGRect(origin: position, size: axWindow.size() ?? .zero)
             }
 
-            // An exact CGWindowID match means this AX window is already in the CG snapshot, so it only
-            // supplies a title. Otherwise materialize a full record: the merge appends it (deduping by
-            // the resolved ID) unless it is consumed to title an untitled CG window by bounds. Building
-            // it here — rather than suppressing on a loose bounds match — guarantees the window is
-            // never silently dropped, even when its CGWindowID cannot be resolved.
-            let hasExactCGMatch = resolvedID.map(cgWindowIDs.contains) ?? false
             var standaloneInfo: ServiceWindowInfo?
-            if !hasExactCGMatch, !title.isEmpty {
+            if let resolvedID, !cgWindowIDs.contains(resolvedID), !title.isEmpty {
                 standaloneInfo = await self.service.createWindowInfo(from: axWindow, index: index)
             }
 
@@ -274,18 +274,20 @@ struct WindowEnumerationContext {
 
     /// Merge CG and AX windows preserving CGWindowList enumeration order.
     ///
-    /// - CG windows are emitted first, in CGWindowList order, deduplicated by `CGWindowID`. Untitled
-    ///   CG entries borrow a title from the AX window with the same `CGWindowID` (or matching bounds).
-    /// - AX-only windows (a resolved `CGWindowID` that CGWindowList never reported) are appended last.
+    /// - CG windows are emitted first, in CGWindowList order, deduplicated by `CGWindowID`. An
+    ///   untitled CG entry borrows a title from the AX window with the same `CGWindowID`, or, when AX
+    ///   could not expose a `CGWindowID`, from a bounds-matched AX window (consumed once).
+    /// - AX-only windows that resolved to a reliable `CGWindowID` absent from the snapshot append last.
     ///
-    /// Association is by `CGWindowID`/bounds, never by title, so same-titled windows keep distinct
-    /// positions and `--window-index` continues to line up with the printed list.
+    /// Every decision uses only reliable signals — an exact `CGWindowID`, or a CG-snapshot
+    /// title+bounds — never a synthesized ID, so same-titled windows keep distinct positions and
+    /// `--window-index` stays aligned with the printed list.
     nonisolated static func mergeWindows(
         cgWindows: [ServiceWindowInfo],
         axDescriptors: [AXWindowDescriptor]) -> [ServiceWindowInfo]
     {
-        // CGWindowID → title is inherently one-to-one (CG windows are deduplicated by ID), so it is
-        // an unambiguous enrichment source for untitled CG windows.
+        // Exact CGWindowID → title is one-to-one (CG windows are deduplicated by ID): an unambiguous
+        // enrichment source for the untitled CG window carrying that id.
         var axTitleByID: [Int: String] = [:]
         for descriptor in axDescriptors {
             guard let id = descriptor.windowID, !descriptor.title.isEmpty else { continue }
@@ -294,15 +296,14 @@ struct WindowEnumerationContext {
             }
         }
 
-        // Titled AX windows AX could not resolve to a CGWindowID: eligible to title an untitled CG
-        // window by bounds. Each descriptor is consumed at most once, and a descriptor used for
-        // enrichment is never also appended standalone — so identically framed windows are not all
-        // relabeled, nothing is double-counted, and nothing is dropped.
+        // Titled AX windows AX could not resolve to a CGWindowID: a best-effort title source for an
+        // untitled CG window, matched by bounds and consumed at most once so identically framed
+        // windows are not all relabeled.
         let boundsFallbackIndices = axDescriptors.indices.filter { index in
             let descriptor = axDescriptors[index]
             return descriptor.windowID == nil && !descriptor.title.isEmpty && descriptor.bounds != nil
         }
-        var consumedDescriptors = Set<Int>()
+        var consumedFallbacks = Set<Int>()
 
         var merged: [ServiceWindowInfo] = []
         merged.reserveCapacity(cgWindows.count + axDescriptors.count)
@@ -320,18 +321,19 @@ struct WindowEnumerationContext {
             }
 
             if let descriptorIndex = boundsFallbackIndices.first(where: { index in
-                guard !consumedDescriptors.contains(index), let bounds = axDescriptors[index].bounds else {
+                guard !consumedFallbacks.contains(index), let bounds = axDescriptors[index].bounds else {
                     return false
                 }
-                // If createWindowInfo already resolved this AX record to a concrete CGWindowID (via
-                // its title/bounds CGWindowList fallback), only enrich that exact window — never let a
-                // loose bounds match steal a different window's title.
-                if let resolvedID = axDescriptors[index].standaloneInfo?.windowID, resolvedID != cgWindow.windowID {
-                    return false
-                }
-                return Self.boundsMatch(bounds, cgWindow.bounds)
+                guard Self.boundsMatch(bounds, cgWindow.bounds) else { return false }
+                // Do not hijack: if this AX title+frame already belongs to a different CG window, that
+                // window is the real owner, so leave this untitled entry alone.
+                return !Self.boundsOwnedByOtherWindow(
+                    title: axDescriptors[index].title,
+                    bounds: bounds,
+                    excluding: cgWindow.windowID,
+                    in: cgWindows)
             }) {
-                consumedDescriptors.insert(descriptorIndex)
+                consumedFallbacks.insert(descriptorIndex)
                 merged.append(cgWindow.withTitle(axDescriptors[descriptorIndex].title))
                 continue
             }
@@ -339,19 +341,31 @@ struct WindowEnumerationContext {
             merged.append(cgWindow)
         }
 
-        // Append AX-only windows CGWindowList never reported, in AX order. Skip descriptors already
-        // consumed to title a CG window and any whose ID is already present.
-        for (index, descriptor) in axDescriptors.enumerated() {
-            guard let info = descriptor.standaloneInfo,
-                  !consumedDescriptors.contains(index),
-                  seenWindowIDs.insert(info.windowID).inserted
-            else {
+        // Append AX-only windows that resolved to a reliable CGWindowID absent from the CG snapshot.
+        for descriptor in axDescriptors {
+            guard let info = descriptor.standaloneInfo, seenWindowIDs.insert(info.windowID).inserted else {
                 continue
             }
             merged.append(info)
         }
 
         return merged
+    }
+
+    /// Whether a titled CG window other than `windowID` already claims this AX title at these bounds,
+    /// i.e. that window is the AX record's real owner and this untitled entry must not borrow its title.
+    private nonisolated static func boundsOwnedByOtherWindow(
+        title: String,
+        bounds: CGRect,
+        excluding windowID: Int,
+        in cgWindows: [ServiceWindowInfo]) -> Bool
+    {
+        cgWindows.contains { window in
+            window.windowID != windowID &&
+                !window.title.isEmpty &&
+                window.title == title &&
+                Self.boundsMatch(window.bounds, bounds)
+        }
     }
 
     private nonisolated static func boundsMatch(_ lhs: CGRect, _ rhs: CGRect, tolerance: CGFloat = 5) -> Bool {

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/System/ApplicationWindowEnumerationContext.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/System/ApplicationWindowEnumerationContext.swift
@@ -210,7 +210,7 @@ struct WindowEnumerationContext {
         var warnings: [String] = []
         let descriptors = await self.collectAXDescriptors(
             axResult: axResult,
-            cgWindows: snapshot.windows,
+            cgWindowIDs: Set(snapshot.windows.map(\.windowID)),
             warnings: &warnings)
 
         let merged = Self.mergeWindows(cgWindows: snapshot.windows, axDescriptors: descriptors)
@@ -227,15 +227,15 @@ struct WindowEnumerationContext {
     }
 
     /// Resolve each AX window into a plain descriptor: CGWindowID (via `_AXUIElementGetWindow`),
-    /// title, and bounds. A full record is only built for AX windows CGWindowList never reported,
-    /// so the common enrichment path stays cheap.
+    /// title, and bounds. A full `standaloneInfo` record is materialized for every titled AX window
+    /// that is *not* an exact CGWindowID match, so no AX-only window can be lost; the merge step then
+    /// decides whether that record enriches an untitled CG window or is appended standalone.
     private func collectAXDescriptors(
         axResult: AXWindowResult,
-        cgWindows: [ServiceWindowInfo],
+        cgWindowIDs: Set<Int>,
         warnings: inout [String]) async -> [AXWindowDescriptor]
     {
         let windowIdentityService = WindowIdentityService()
-        let cgWindowIDs = Set(cgWindows.map(\.windowID))
         var descriptors: [AXWindowDescriptor] = []
         descriptors.reserveCapacity(axResult.windows.count)
 
@@ -251,20 +251,14 @@ struct WindowEnumerationContext {
                 CGRect(origin: position, size: axWindow.size() ?? .zero)
             }
 
-            // Decide whether this AX window already has a CG counterpart. Match by CGWindowID first,
-            // then by bounds; title is never an association key. When there is no counterpart we still
-            // materialize a full record so the window surfaces (mirrors the prior AX-only fallback,
-            // including AX windows whose CGWindowID cannot be resolved via _AXUIElementGetWindow).
-            let matchesCGWindow: Bool = if let resolvedID {
-                cgWindowIDs.contains(resolvedID)
-            } else if let bounds {
-                cgWindows.contains { Self.boundsMatch($0.bounds, bounds) }
-            } else {
-                false
-            }
-
+            // An exact CGWindowID match means this AX window is already in the CG snapshot, so it only
+            // supplies a title. Otherwise materialize a full record: the merge appends it (deduping by
+            // the resolved ID) unless it is consumed to title an untitled CG window by bounds. Building
+            // it here — rather than suppressing on a loose bounds match — guarantees the window is
+            // never silently dropped, even when its CGWindowID cannot be resolved.
+            let hasExactCGMatch = resolvedID.map(cgWindowIDs.contains) ?? false
             var standaloneInfo: ServiceWindowInfo?
-            if !matchesCGWindow, !title.isEmpty {
+            if !hasExactCGMatch, !title.isEmpty {
                 standaloneInfo = await self.service.createWindowInfo(from: axWindow, index: index)
             }
 
@@ -300,16 +294,15 @@ struct WindowEnumerationContext {
             }
         }
 
-        // Bounds-based enrichment only applies to titled AX windows AX could not resolve to a
-        // CGWindowID. Each such descriptor is consumed at most once so several identically framed
-        // untitled windows (e.g. stacked/maximized) can never all inherit the same title.
-        let boundsFallbacks: [(bounds: CGRect, title: String)] = axDescriptors.compactMap { descriptor in
-            guard descriptor.windowID == nil, !descriptor.title.isEmpty, let bounds = descriptor.bounds else {
-                return nil
-            }
-            return (bounds, descriptor.title)
+        // Titled AX windows AX could not resolve to a CGWindowID: eligible to title an untitled CG
+        // window by bounds. Each descriptor is consumed at most once, and a descriptor used for
+        // enrichment is never also appended standalone — so identically framed windows are not all
+        // relabeled, nothing is double-counted, and nothing is dropped.
+        let boundsFallbackIndices = axDescriptors.indices.filter { index in
+            let descriptor = axDescriptors[index]
+            return descriptor.windowID == nil && !descriptor.title.isEmpty && descriptor.bounds != nil
         }
-        var consumedFallbacks = Set<Int>()
+        var consumedDescriptors = Set<Int>()
 
         var merged: [ServiceWindowInfo] = []
         merged.reserveCapacity(cgWindows.count + axDescriptors.count)
@@ -326,19 +319,27 @@ struct WindowEnumerationContext {
                 continue
             }
 
-            if let matchIndex = boundsFallbacks.indices.first(where: { index in
-                !consumedFallbacks.contains(index) && Self.boundsMatch(boundsFallbacks[index].bounds, cgWindow.bounds)
+            if let descriptorIndex = boundsFallbackIndices.first(where: { index in
+                guard !consumedDescriptors.contains(index), let bounds = axDescriptors[index].bounds else {
+                    return false
+                }
+                return Self.boundsMatch(bounds, cgWindow.bounds)
             }) {
-                consumedFallbacks.insert(matchIndex)
-                merged.append(cgWindow.withTitle(boundsFallbacks[matchIndex].title))
+                consumedDescriptors.insert(descriptorIndex)
+                merged.append(cgWindow.withTitle(axDescriptors[descriptorIndex].title))
                 continue
             }
 
             merged.append(cgWindow)
         }
 
-        for descriptor in axDescriptors {
-            guard let info = descriptor.standaloneInfo, seenWindowIDs.insert(info.windowID).inserted else {
+        // Append AX-only windows CGWindowList never reported, in AX order. Skip descriptors already
+        // consumed to title a CG window and any whose ID is already present.
+        for (index, descriptor) in axDescriptors.enumerated() {
+            guard let info = descriptor.standaloneInfo,
+                  !consumedDescriptors.contains(index),
+                  seenWindowIDs.insert(info.windowID).inserted
+            else {
                 continue
             }
             merged.append(info)

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/System/ApplicationWindowEnumerationContext.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/System/ApplicationWindowEnumerationContext.swift
@@ -323,6 +323,12 @@ struct WindowEnumerationContext {
                 guard !consumedDescriptors.contains(index), let bounds = axDescriptors[index].bounds else {
                     return false
                 }
+                // If createWindowInfo already resolved this AX record to a concrete CGWindowID (via
+                // its title/bounds CGWindowList fallback), only enrich that exact window — never let a
+                // loose bounds match steal a different window's title.
+                if let resolvedID = axDescriptors[index].standaloneInfo?.windowID, resolvedID != cgWindow.windowID {
+                    return false
+                }
                 return Self.boundsMatch(bounds, cgWindow.bounds)
             }) {
                 consumedDescriptors.insert(descriptorIndex)

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/System/ApplicationWindowEnumerationContext.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/System/ApplicationWindowEnumerationContext.swift
@@ -290,6 +290,8 @@ struct WindowEnumerationContext {
         cgWindows: [ServiceWindowInfo],
         axDescriptors: [AXWindowDescriptor]) -> [ServiceWindowInfo]
     {
+        // CGWindowID → title is inherently one-to-one (CG windows are deduplicated by ID), so it is
+        // an unambiguous enrichment source for untitled CG windows.
         var axTitleByID: [Int: String] = [:]
         for descriptor in axDescriptors {
             guard let id = descriptor.windowID, !descriptor.title.isEmpty else { continue }
@@ -298,12 +300,41 @@ struct WindowEnumerationContext {
             }
         }
 
+        // Bounds-based enrichment only applies to titled AX windows AX could not resolve to a
+        // CGWindowID. Each such descriptor is consumed at most once so several identically framed
+        // untitled windows (e.g. stacked/maximized) can never all inherit the same title.
+        let boundsFallbacks: [(bounds: CGRect, title: String)] = axDescriptors.compactMap { descriptor in
+            guard descriptor.windowID == nil, !descriptor.title.isEmpty, let bounds = descriptor.bounds else {
+                return nil
+            }
+            return (bounds, descriptor.title)
+        }
+        var consumedFallbacks = Set<Int>()
+
         var merged: [ServiceWindowInfo] = []
         merged.reserveCapacity(cgWindows.count + axDescriptors.count)
         var seenWindowIDs = Set<Int>()
 
         for cgWindow in cgWindows where seenWindowIDs.insert(cgWindow.windowID).inserted {
-            merged.append(Self.titleEnriched(cgWindow, axTitleByID: axTitleByID, axDescriptors: axDescriptors))
+            guard cgWindow.title.isEmpty else {
+                merged.append(cgWindow)
+                continue
+            }
+
+            if let title = axTitleByID[cgWindow.windowID] {
+                merged.append(cgWindow.withTitle(title))
+                continue
+            }
+
+            if let matchIndex = boundsFallbacks.indices.first(where: { index in
+                !consumedFallbacks.contains(index) && Self.boundsMatch(boundsFallbacks[index].bounds, cgWindow.bounds)
+            }) {
+                consumedFallbacks.insert(matchIndex)
+                merged.append(cgWindow.withTitle(boundsFallbacks[matchIndex].title))
+                continue
+            }
+
+            merged.append(cgWindow)
         }
 
         for descriptor in axDescriptors {
@@ -314,29 +345,6 @@ struct WindowEnumerationContext {
         }
 
         return merged
-    }
-
-    private nonisolated static func titleEnriched(
-        _ window: ServiceWindowInfo,
-        axTitleByID: [Int: String],
-        axDescriptors: [AXWindowDescriptor]) -> ServiceWindowInfo
-    {
-        guard window.title.isEmpty else { return window }
-
-        if let title = axTitleByID[window.windowID] {
-            return window.withTitle(title)
-        }
-
-        // Fallback: AX could not expose a CGWindowID, so match by bounds instead of title.
-        if let matched = axDescriptors.first(where: { descriptor in
-            descriptor.windowID == nil &&
-                !descriptor.title.isEmpty &&
-                descriptor.bounds.map { Self.boundsMatch($0, window.bounds) } == true
-        }) {
-            return window.withTitle(matched.title)
-        }
-
-        return window
     }
 
     private nonisolated static func boundsMatch(_ lhs: CGRect, _ rhs: CGRect, tolerance: CGFloat = 5) -> Bool {

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/System/ApplicationWindowEnumerationContext.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/System/ApplicationWindowEnumerationContext.swift
@@ -210,7 +210,7 @@ struct WindowEnumerationContext {
         var warnings: [String] = []
         let descriptors = await self.collectAXDescriptors(
             axResult: axResult,
-            cgWindowIDs: Set(snapshot.windows.map(\.windowID)),
+            cgWindows: snapshot.windows,
             warnings: &warnings)
 
         let merged = Self.mergeWindows(cgWindows: snapshot.windows, axDescriptors: descriptors)
@@ -231,10 +231,11 @@ struct WindowEnumerationContext {
     /// so the common enrichment path stays cheap.
     private func collectAXDescriptors(
         axResult: AXWindowResult,
-        cgWindowIDs: Set<Int>,
+        cgWindows: [ServiceWindowInfo],
         warnings: inout [String]) async -> [AXWindowDescriptor]
     {
         let windowIdentityService = WindowIdentityService()
+        let cgWindowIDs = Set(cgWindows.map(\.windowID))
         var descriptors: [AXWindowDescriptor] = []
         descriptors.reserveCapacity(axResult.windows.count)
 
@@ -250,10 +251,20 @@ struct WindowEnumerationContext {
                 CGRect(origin: position, size: axWindow.size() ?? .zero)
             }
 
-            // Materialize a full record only when this AX window has no CG counterpart; those are the
-            // windows CGWindowList missed and that we still need to surface.
+            // Decide whether this AX window already has a CG counterpart. Match by CGWindowID first,
+            // then by bounds; title is never an association key. When there is no counterpart we still
+            // materialize a full record so the window surfaces (mirrors the prior AX-only fallback,
+            // including AX windows whose CGWindowID cannot be resolved via _AXUIElementGetWindow).
+            let matchesCGWindow: Bool = if let resolvedID {
+                cgWindowIDs.contains(resolvedID)
+            } else if let bounds {
+                cgWindows.contains { Self.boundsMatch($0.bounds, bounds) }
+            } else {
+                false
+            }
+
             var standaloneInfo: ServiceWindowInfo?
-            if let resolvedID, !cgWindowIDs.contains(resolvedID) {
+            if !matchesCGWindow, !title.isEmpty {
                 standaloneInfo = await self.service.createWindowInfo(from: axWindow, index: index)
             }
 

--- a/docs/commands/list.md
+++ b/docs/commands/list.md
@@ -23,6 +23,7 @@ read_when:
 - Application inventory prefers the GUI bridge host so sandboxed CLI callers see the GUI session’s complete process list. Other read-only inventory stays local by default unless its command needs host state or you pass `--bridge-socket <path>`.
 - `windows` calls `requireScreenRecordingPermission` before crawling AX so macOS doesn’t silently strip metadata; `apps` does not require Screen Recording.
 - `windows` accepts either user-friendly names or `PID:####` tokens and normalizes `--include-details` values by lowercasing + replacing `-` with `_`, so both `--include-details offscreen,bounds` and `off_screen` work.
+- `windows` deduplicates entries by `window_id` and assigns contiguous `index` values afterwards, so `--window-index` targeting lines up with what is printed. It intentionally shows the full enumeration (including tiny/utility windows on non-zero layers); `peekaboo window list` filters those out but keeps the same IDs and indexes.
 - Menu bar listing is powered by the same `MenuServiceBridge` used by `peekaboo menubar`, so indices reported here line up with what `menubar click --index` expects.
 - App/window/screen inventory uses `UnifiedToolOutput` payloads, which include `data`, `summary`, and `metadata`. `list permissions --json` mirrors `permissions status --json` with the standard `{ success, data }` envelope.
 

--- a/docs/commands/window.md
+++ b/docs/commands/window.md
@@ -17,14 +17,14 @@ read_when:
 | `move` | Move the window to new coordinates. | `-x <int>` / `-y <int>` specify the new origin. |
 | `resize` | Adjust width/height while keeping the origin. | `-w <int>` / `--height <int>`. |
 | `set-bounds` | Set both origin and size in one go. | `--x`, `--y`, `--width`, `--height`. |
-| `list` | Shortcut for `list windows` scoped to a single app. | Same targeting flags; outputs the `list windows` payload. |
+| `list` | Lists an app's renderable windows (filtered view of `list windows`). | Same targeting flags; adds `--group-by-space`. |
 
 ## Implementation notes
 - Every action validates that at least an app, PID, or window ID is supplied; optional `--window-title` and `--window-index` disambiguate when multiple windows exist.
 - All geometry-changing commands re-fetch window info after acting (when possible) and stuff the updated bounds into the JSON payload so automated tests can assert the final rectangle.
 - `focus` routes through `WindowServiceBridge.focusWindow` and honors the global focus flags (`--space-switch` to jump Spaces, `--bring-to-current-space` to move the window instead, etc.). It logs debug output when focus fails so agents know to fall back.
 - `focus --verify` checks the frontmost app (and window ID when available) before returning success.
-- When `window list` runs, it simply calls the same helper as `peekaboo list windows` but saves you from retyping the longer command.
+- `window list` uses the same enumeration as `peekaboo list windows` (deduplicated by `window_id`, contiguous indexes) but additionally filters to renderable windows: entries on non-zero layers, smaller than 60x60, fully transparent, or excluded from the Windows menu are dropped. The surviving windows keep their canonical `index` values, so indexes shown here can have gaps yet still match `--window-index` and `list windows` output.
 
 ## Examples
 ```bash


### PR DESCRIPTION
## Bug

`peekaboo list windows` returns the same window twice, with the same `window_id` but different `index` values. `peekaboo window list` for the same app does not.

```
peekaboo list windows --app boo.peekaboo.playground.debug --json
  -> total: 14 windows, 13 unique window_id
  -> DUP window_id 3459 x2:
       'Text Fixture'  bounds [[14,59],[1200,832]]  index 1
       'Text Fixture'  bounds [[14,59],[1200,832]]  index 6

peekaboo window list --app boo.peekaboo.playground.debug --json
  -> total: 9, unique: 9   (correct)
```

The phantom duplicate consumes an index slot and shifts every later window, so `--window-index` targeting becomes ambiguous/unstable.

## Root cause

Both commands share one enumerator: `ApplicationService.listWindows` -> `WindowEnumerationContext`. The bug is in `mergeWithSnapshot` (`Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/System/ApplicationWindowEnumerationContext.swift`):

1. The AX-enrichment loop maps each titled AX window to a CG snapshot entry via `windowsByTitle[axTitle]` - a dictionary keyed by **title only**. When an app has two AX windows sharing a title (Playground has two "Text Fixture" windows), both resolve to the **same** CG entry, which is appended twice. Only the CG-remainder loop guarded by windowID; the AX loop had no guard.
2. `normalizeWindowIndices` then renumbered `0..n` over the duplicated list, giving the phantom its own index (1 and 6) and shifting all later windows - so index numbering was also wrong (assigned before dedup).

`window list` hid the duplicate only because it post-filters through `ObservationTargetResolver.filteredWindows(mode: .list)` (the Dec 2025 dedup fix), but it inherited the shifted indexes. The Dec 2025 fix never covered the `list windows` path, which renders the enumeration payload raw.

## Fix

- `WindowEnumerationContext.mergeWithSnapshot`: a single `seenWindowIDs` set now guards every append across both merge loops (root cause).
- `ApplicationService.normalizeWindowIndices`: dedupes by `windowID` (keeping the first occurrence) **before** assigning contiguous indexes - a safety net covering the fast path, the AX-only path, and bridge-routed hosts, since every producer funnels through `buildWindowListOutput`.

No CLI command code changed; the fix is central, so `list windows`, `window list`, `--window-index` positional resolution, capture/image window selection, and the bridge host all see the same deduplicated, contiguously indexed enumeration.

## Intentional difference between the two commands (documented, not removed)

`window list` additionally filters to renderable windows (`ObservationTargetResolver.filteredWindows(mode: .list)`: drops layer != 0, smaller than 60x60, fully transparent, excluded-from-Windows-menu) while preserving the canonical indexes. `list windows` deliberately shows the full enumeration (it has `--include-details off_screen,bounds,ids` for diagnostics). That accounts for 13 vs 9 after the fix. Documented in `docs/commands/list.md` and `docs/commands/window.md` (the latter previously claimed `window list` "outputs the `list windows` payload", which was stale).

## Regression tests

`Apps/CLI/Tests/CoreCLITests/WindowListDeduplicationTests.swift` asserts:

- a window source yielding the same CGWindowID twice produces exactly one entry, keeping the first occurrence;
- indexes are contiguous `0..<count` after dedup (the phantom cannot shift `--window-index` targets);
- for renderable windows, the `list windows` payload (normalized enumeration) and the `window list` payload (`filteredWindows(.list)` over it) contain identical IDs and indexes;
- when `window list` filters a non-renderable window, the survivors keep their canonical indexes.

## Verification

- `pnpm run build:cli` - green
- `swift test --filter WindowListDeduplicationTests` - 4/4 pass
- `swift test --filter "ObservationWindowSelection|ApplicationService"` (PeekabooAutomationKit) - pass
- `pnpm run lint` / `pnpm run format` - no findings in changed files

**Live desktop verification is pending** - the coordinator owns the desktop and will verify the branch against the Playground repro (no GUI automation was run from this branch).
