### PR TITLE
feat(agent): support GPT-5.6 and Claude Sonnet 5 models

### DIFF
--- a/Apps/CLI/Sources/PeekabooCLI/Commands/AI/AgentCommand+ModelParsing.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/AI/AgentCommand+ModelParsing.swift
@@ -23,6 +23,10 @@ extension AgentCommand {
             return .anthropic(.opus48)
         }
 
+        if trimmed.caseInsensitiveCompare("sonnet") == .orderedSame {
+            return .anthropic(.sonnet5)
+        }
+
         if let configuration {
             switch self.parseConfiguredCustomModel(
                 trimmed,
@@ -48,6 +52,11 @@ extension AgentCommand {
         switch parsed {
         case let .openai(model):
             if Self.supportedOpenAIInputs.contains(model) {
+                // GPT-5.6 models route as themselves; older supported aliases
+                // collapse to the flagship.
+                if Self.gpt56Models.contains(model) {
+                    return .openai(model)
+                }
                 return .openai(.gpt55)
             }
         case let .anthropic(model):
@@ -124,6 +133,9 @@ extension AgentCommand {
     }
 
     private static let supportedOpenAIInputs: Set<LanguageModel.OpenAI> = [
+        .gpt56Sol,
+        .gpt56Terra,
+        .gpt56Luna,
         .gpt55,
         .gpt54,
         .gpt54Mini,
@@ -134,8 +146,15 @@ extension AgentCommand {
         .gpt5Nano,
     ]
 
+    private static let gpt56Models: Set<LanguageModel.OpenAI> = [
+        .gpt56Sol,
+        .gpt56Terra,
+        .gpt56Luna,
+    ]
+
     private static let supportedAnthropicInputs: Set<LanguageModel.Anthropic> = [
         .fable5,
+        .sonnet5,
         .opus48,
         .opus47,
         .opus45,

--- a/Apps/CLI/Tests/CoreCLITests/AgentCommandModelParsingTests.swift
+++ b/Apps/CLI/Tests/CoreCLITests/AgentCommandModelParsingTests.swift
@@ -28,11 +28,24 @@ struct AgentCommandTests {
     }
 
     @Test
+    func `GPT-5_6 aliases preserve the selected tier`() throws {
+        let command = try AgentCommand.parse([])
+
+        #expect(command.parseModelString("gpt-5.6") == .openai(.gpt56Sol))
+        #expect(command.parseModelString("gpt-5.6-sol") == .openai(.gpt56Sol))
+        #expect(command.parseModelString("gpt-5.6-terra") == .openai(.gpt56Terra))
+        #expect(command.parseModelString("gpt-5.6-luna") == .openai(.gpt56Luna))
+        #expect(command.parseModelString("gpt-5.6-mars") == nil)
+    }
+
+    @Test
     func `Supported Anthropic aliases parse current models`() throws {
         let command = try AgentCommand.parse([])
 
         #expect(command.parseModelString("claude-fable-5") == .anthropic(.fable5))
         #expect(command.parseModelString("fable") == .anthropic(.fable5))
+        #expect(command.parseModelString("claude-sonnet-5") == .anthropic(.sonnet5))
+        #expect(command.parseModelString("sonnet") == .anthropic(.sonnet5))
         #expect(command.parseModelString("claude-opus-4.8") == .anthropic(.opus48))
         #expect(command.parseModelString("claude-opus-4.7") == .anthropic(.opus47))
         #expect(command.parseModelString("claude-sonnet-4.6") == .anthropic(.sonnet46))

--- a/Apps/Mac/Peekaboo/Features/Main/SessionHelpers.swift
+++ b/Apps/Mac/Peekaboo/Features/Main/SessionHelpers.swift
@@ -7,6 +7,9 @@ import SwiftUI
 func formatModelName(_ model: String) -> String {
     // Shorten common model names for display
     switch model {
+    case "gpt-5.6-sol": "GPT-5.6 Sol"
+    case "gpt-5.6-terra": "GPT-5.6 Terra"
+    case "gpt-5.6-luna": "GPT-5.6 Luna"
     case "gpt-5.5": "GPT-5.5"
     case "gpt-5.4": "GPT-5.4"
     case "gpt-5.4-mini": "GPT-5.4 mini"
@@ -14,6 +17,7 @@ func formatModelName(_ model: String) -> String {
     case "gpt-5": "GPT-5"
     case "gpt-5-mini": "GPT-5 mini"
     case "claude-fable-5": "Claude Fable 5"
+    case "claude-sonnet-5": "Claude Sonnet 5"
     case "claude-opus-4-8": "Claude Opus 4.8"
     case "claude-opus-4-7": "Claude Opus 4.7"
     case "claude-sonnet-4-6": "Claude Sonnet 4.6"

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/Agent/PeekabooAgentService+Execution.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/Agent/PeekabooAgentService+Execution.swift
@@ -121,6 +121,9 @@ extension PeekabooAgentService {
         case let .openai(openAIModel):
             switch openAIModel {
             case .chatLatest,
+                 .gpt56Sol,
+                 .gpt56Terra,
+                 .gpt56Luna,
                  .gpt55,
                  .gpt54,
                  .gpt54Mini,


### PR DESCRIPTION
## Summary

Restores GPT-5.6 (Sol/Terra/Luna) and Claude Sonnet 5 support that was stripped at the v3.8.0 release ("remove unpublished model identifiers") — both are published now. Bumps the Tachikoma submodule to current main (fe8f25e), which carries the GPT-5.6 catalog (openclaw/Tachikoma#30, #31), the Sonnet 5 pricing fix (#32), and the ollama prefix-stripping + auth-test isolation fixes (#33).

- `peekaboo agent --model gpt-5.6[-sol|-terra|-luna]` parses and routes to OpenAI as the selected tier (older supported aliases still collapse to the flagship GPT-5.5, unchanged).
- `claude-sonnet-5` / `sonnet` parse to Sonnet 5 next to the existing Fable 5 support.
- Mac app session view formats the new model ids ("GPT-5.6 Sol", "Claude Sonnet 5").
- Exhaustive-switch update in the agent runtime gives the 5.6 tiers the same 128k max-output bucket as 5.5.

## Verification

- Restored the exact pre-3.8.0 regression tests: `GPT-5_6 aliases preserve the selected tier` (incl. `gpt-5.6-mars` rejected) and the Sonnet 5 alias assertions. AgentCommandTests 15/15.
- `pnpm run test:safe` 696 green; CLI debug build and Mac app debug build both succeed.
- Live smoke with the placeholder key: `--model gpt-5.6` reaches OpenAI (clean 401, not "unsupported model"); `claude-fable-5` and `claude-sonnet-5` reach Anthropic. Routing verified end-to-end up to auth.
