### PR TITLE
test(daemon): gate daemon runtime tests behind automation env

### DIFF
--- a/Apps/CLI/Tests/CLIRuntimeTests/DaemonLaunchRuntimeTests.swift
+++ b/Apps/CLI/Tests/CLIRuntimeTests/DaemonLaunchRuntimeTests.swift
@@ -3,7 +3,16 @@ import Foundation
 import Subprocess
 import Testing
 
-@Suite(.serialized)
+/// These tests spawn the real peekaboo binary and its daemon. CI runners
+/// cannot host the daemon (the child times out and is SIGKILLed after
+/// minutes), so they run only alongside the automation suites.
+private enum DaemonRuntimeTestEnvironment {
+    nonisolated static var isEnabled: Bool {
+        ProcessInfo.processInfo.environment["PEEKABOO_INCLUDE_AUTOMATION_TESTS"]?.lowercased() == "true"
+    }
+}
+
+@Suite(.serialized, .enabled(if: DaemonRuntimeTestEnvironment.isEnabled))
 struct DaemonLaunchRuntimeTests {
     @Test
     func `bare argv zero starts and stops the production daemon from an empty directory`() async throws {


### PR DESCRIPTION
## Summary

`DaemonLaunchRuntimeTests` spawns the real peekaboo binary and its daemon. GitHub CI runners cannot host the daemon: the child process hangs until SIGKILL, which burned ~20 minutes per run and then failed the job. It is currently failing every PR's "Peekaboo CLI build & tests" job deterministically (#246, #247, and #244's own runs).

This gates the suite behind `PEEKABOO_INCLUDE_AUTOMATION_TESTS=true` — the same environment the other process-spawning suites use (`pnpm run test:automation` lanes) — so the skip-automation CI lane skips it.

Verified both lanes locally: without the env the suite skips in 0.001s; with `PEEKABOO_INCLUDE_AUTOMATION_TESTS=true` it runs and passes (2.4s). `pnpm run test:safe` green.

This intentionally does NOT compete with #244, which is making the runtime test itself bounded and CI-safe — when that lands it can relax or remove this gate. This just stops every other PR from paying 20 minutes to fail.
