### PR TITLE
fix(agent): execute Ollama tool calls and explain tool-incapable models

### DIFF
--- a/Apps/CLI/Sources/PeekabooCLI/Commands/AI/AgentCommand+ModelParsing.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/AI/AgentCommand+ModelParsing.swift
@@ -125,6 +125,15 @@ extension AgentCommand {
     func validatedModelSelection(configuration: PeekabooCore.ConfigurationManager? = nil) throws -> LanguageModel? {
         guard let modelString = self.model else { return nil }
         guard let parsed = self.parseModelString(modelString, configuration: configuration) else {
+            // A model that parses but lacks tool support is a real, installed model —
+            // saying "unsupported" and listing an allowlist implies the name is wrong.
+            if let known = LanguageModel.parse(from: modelString), !known.supportsTools {
+                throw PeekabooError.invalidInput(
+                    "Model '\(modelString)' does not support tool calling, which `peekaboo agent` requires. " +
+                        "Use it for vision instead (`peekaboo image --analyze` / `see --analyze`), " +
+                        "or pick a tool-capable model."
+                )
+            }
             throw PeekabooError.invalidInput(
                 "Unsupported model '\(modelString)'. Allowed values: \(Self.allowedModelList)"
             )

--- a/Apps/CLI/Tests/CoreCLITests/AgentCommandModelParsingTests.swift
+++ b/Apps/CLI/Tests/CoreCLITests/AgentCommandModelParsingTests.swift
@@ -82,6 +82,35 @@ struct AgentCommandTests {
     }
 
     @Test
+    @MainActor
+    func `Tool-incapable models explain the tool requirement instead of claiming unsupported`() throws {
+        // A real, installed vision model. The agent rejects it for lacking tool
+        // support, so the message must say that rather than list an allowlist and
+        // imply the name is wrong.
+        var command = try AgentCommand.parse([])
+        command.model = "ollama/qwen2.5vl:3b"
+        do {
+            _ = try command.validatedModelSelection()
+            Issue.record("expected a validation error for a tool-incapable model")
+        } catch let error as PeekabooError {
+            let message = error.localizedDescription
+            #expect(message.contains("does not support tool calling"))
+            #expect(message.contains("--analyze"))
+            #expect(!message.contains("Allowed values"))
+        }
+
+        // An unknown name keeps the allowlist hint.
+        var unknown = try AgentCommand.parse([])
+        unknown.model = "definitely-not-a-model-xyz"
+        do {
+            _ = try unknown.validatedModelSelection()
+            Issue.record("expected a validation error for an unknown model")
+        } catch let error as PeekabooError {
+            #expect(error.localizedDescription.contains("Allowed values"))
+        }
+    }
+
+    @Test
     func `Current Gemini models are accepted`() throws {
         let command = try AgentCommand.parse([])
 


### PR DESCRIPTION
Fixes #245 (items 1–3).

## The bug

`peekaboo agent --model ollama/<model>` executed **nothing** and reported success. The model emitted tool calls as raw JSON text:

    Starting: What is 2+2? Reply with just the number.
    {"name": "launch", "parameters": {"name": "Calculator"}}Please wait for Calculator to open.
    {"name": "inspect_ui", "parameters": {}}Calculator window now open...
    Task completed in 4.3s with 0 tools

Root cause was upstream: Tachikoma's streaming `/api/chat` parser read only `message.content` and `done`, silently dropping the `tool_calls` Ollama returns alongside empty content (openclaw/Tachikoma#34, verified against a live ollama server). With no tools reaching the model's transcript, models fell back to printing tool-call JSON, `--json` reported `toolCallCount: 0` with `content: ""`, and the agent still claimed success.

## Changes

- Bump Tachikoma to `8e230bc` (streaming tool calls surfaced; shared with the non-streaming conversion).
- `agent --model <tool-incapable model>` no longer claims the model is "Unsupported" and prints an allowlist. `ollama/qwen2.5vl:latest` is a real, installed vision model rejected only because the agent gates on tool support. It now says so and points at `image --analyze` / `see --analyze`. Unknown names keep the allowlist hint.

## Verification (live, against the Playground app)

Before: `toolCallCount: 0`, `content: ""`, nothing executed.
After: tools dispatch and execute for real — `see` / `click` / `launch_app` invoked, `toolCallCount: 3` in one run and `8` `see` calls in another, `content` populated. (Remaining "didn't finish the task" behavior is small-model reasoning, not plumbing.)

Error messages verified live:
- `--model ollama/qwen2.5vl:latest` → "does not support tool calling, which `peekaboo agent` requires… Use it for vision instead"
- `--model totally-fake-model` → unchanged "Unsupported model … Allowed values: …"

Regression test asserts both message paths. `pnpm run test:safe` 707 green; lint/format clean.

## Not in this PR

#245 item 4 (the shipped default provider list names `ollama/qwen2.5vl:latest`, which the agent correctly rejects for lacking tools while the vision analyzer uses it well) — that is a default-config split between agent and vision models, tracked separately in #245.
