### PR TITLE
fix(cli): validate explicit paste defaults

### DIFF
--- a/Apps/CLI/CHANGELOG.md
+++ b/Apps/CLI/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [3.8.1] - Unreleased
 
 ### Fixed
+- Bare `peekaboo paste` now pastes the current clipboard, while payload-only flags without a payload fail validation even when `--restore-delay-ms` explicitly uses its 150ms default; `list apps` also accepts the `app list` visibility flags and emits preferred snake_case keys alongside legacy keys.
 - `peekaboo clean --snapshot` now rejects empty, traversal, nested-path, absolute-path, and symlink snapshot IDs, keeping cleanup confined to one real snapshot folder directly beneath the cache root.
 - Invoking `peekaboo daemon start` through `PATH` now relaunches the canonical executable instead of looking for a `peekaboo` file in the current directory, startup errors now distinguish launch failures, early exits, and readiness timeouts, and daemon logs honor `PEEKABOO_CONFIG_DIR`. Thanks @mattash for #231.
 - Canceling an app relaunch wait now stops its running-state poll immediately instead of spinning through the remaining timeout budget. Thanks @SebTardif for #230.

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Core/ListCommand+Apps.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Core/ListCommand+Apps.swift
@@ -4,10 +4,10 @@ import PeekabooCore
 extension ListCommand {
     @MainActor
     struct AppsSubcommand: ErrorHandlingCommand, OutputFormattable, RuntimeOptionsConfigurable {
-        @Flag(help: "Accepted for parity with 'app list'; 'list apps' already returns the full inventory")
+        @Flag(help: "Accepted for parity with 'app list'; 'list apps' already includes hidden apps")
         var includeHidden = false
 
-        @Flag(help: "Accepted for parity with 'app list'; 'list apps' already returns the full inventory")
+        @Flag(help: "Accepted for parity with 'app list'; 'list apps' already includes background apps")
         var includeBackground = false
 
         @RuntimeStorage private var runtime: CommandRuntime?
@@ -77,16 +77,16 @@ extension ListCommand.AppsSubcommand: ParsableCommand {
         MainActorCommandDescription.describe {
             CommandDescription(
                 commandName: "apps",
-                abstract: "List all running applications with details",
+                abstract: "List running applications with details",
                 discussion: """
-                Lists all running applications using the ApplicationService from PeekabooCore.
+                Lists running applications exposed by ApplicationService from PeekabooCore.
                 Applications are sorted by name and include process IDs, bundle identifiers,
                 and activation status.
 
-                This is the full inventory form. `peekaboo app list` is the app-management
+                This is the broader inventory form. `peekaboo app list` is the app-management
                 view and filters hidden/background apps by default; `list apps` accepts
-                --include-hidden and --include-background for parity, but its output is already
-                unfiltered.
+                --include-hidden and --include-background for parity, but already includes
+                those applications when ApplicationService exposes them.
 
                 JSON emits both the legacy `applications` key and the preferred `apps` alias.
                 """

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Core/ListCommand+CommanderMetadata.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Core/ListCommand+CommanderMetadata.swift
@@ -30,12 +30,12 @@ extension ListCommand.AppsSubcommand: CommanderSignatureProviding {
             flags: [
                 .commandFlag(
                     "includeHidden",
-                    help: "Accepted for parity with app list; list apps is already unfiltered",
+                    help: "Accepted for parity with app list; list apps already includes hidden apps",
                     long: "include-hidden"
                 ),
                 .commandFlag(
                     "includeBackground",
-                    help: "Accepted for parity with app list; list apps is already unfiltered",
+                    help: "Accepted for parity with app list; list apps already includes background apps",
                     long: "include-background"
                 ),
             ]

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Core/ListCommand.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Core/ListCommand.swift
@@ -13,8 +13,8 @@ struct ListCommand: ParsableCommand {
           peekaboo list SUBCOMMAND [OPTIONS]
 
         EXAMPLES:
-          peekaboo list                                  # List all applications (default)
-          peekaboo list apps                             # List all running applications
+          peekaboo list                                  # List applications (default)
+          peekaboo list apps                             # List running applications
           peekaboo list apps --include-hidden            # Accepted for app-list parity
           peekaboo list apps --json                      # Output as JSON
 
@@ -31,7 +31,7 @@ struct ListCommand: ParsableCommand {
           peekaboo list screens --json                   # Output as JSON
 
         SUBCOMMANDS:
-          apps          List all running applications with process IDs
+          apps          List running applications with process IDs
           windows       List windows for a specific application
           permissions   Check permissions required for Peekaboo
           menubar       List all menu bar items (status icons)
@@ -40,7 +40,7 @@ struct ListCommand: ParsableCommand {
         RELATED COMMANDS:
           peekaboo app list is the app-management view. It filters hidden/background apps
           unless --include-hidden/--include-background is passed. peekaboo list apps is
-          the full inventory view and accepts those flags for parity.
+          the broader inventory view and accepts those flags for parity.
 
           peekaboo window list is the renderable-window view used for window targeting.
           peekaboo list windows is the full per-application enumeration and may include

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Interaction/PasteCommand+CommanderMetadata.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Interaction/PasteCommand+CommanderMetadata.swift
@@ -24,7 +24,7 @@ extension PasteCommand: CommanderSignatureProviding {
                 ),
                 .commandOption(
                     "restoreDelayMs",
-                    help: "Delay before restoring previous clipboard (ms)",
+                    help: "Delay before restoring previous clipboard (ms; default: 150)",
                     long: "restore-delay-ms"
                 ),
             ],

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Interaction/PasteCommand.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Interaction/PasteCommand.swift
@@ -32,8 +32,11 @@ struct PasteCommand: ErrorHandlingCommand, OutputFormattable, RuntimeOptionsConf
     @Flag(name: .long, help: "Allow payloads larger than 10 MB")
     var allowLarge = false
 
-    @Option(name: .customLong("restore-delay-ms"), help: "Delay before restoring the previous clipboard (ms)")
-    var restoreDelayMs: Int = 150
+    @Option(
+        name: .customLong("restore-delay-ms"),
+        help: "Delay before restoring the previous clipboard (ms; default: 150)"
+    )
+    var restoreDelayMs: Int?
 
     @OptionGroup var target: InteractionTargetOptions
     @OptionGroup var focusOptions: FocusCommandOptions
@@ -73,16 +76,20 @@ struct PasteCommand: ErrorHandlingCommand, OutputFormattable, RuntimeOptionsConf
         return self.textOption
     }
 
+    private var resolvedRestoreDelayMs: Int {
+        self.restoreDelayMs ?? 150
+    }
+
     private var hasExplicitPayload: Bool {
         // Any payload source OR payload-modifier flag counts: `paste --uti public.rtf`
         // or `paste --allow-large` without data must fail validation, not silently
         // paste the current clipboard. An explicitly provided empty positional ("")
         // is also an explicit payload. Only targeting/focus/delivery flags may
-        // combine with the bare-paste path. restoreDelayMs uses its default as the
-        // "not provided" proxy since Commander cannot distinguish an explicit 150.
+        // combine with the bare-paste path. Keep restoreDelayMs optional so an
+        // explicitly provided default value remains distinguishable from omission.
         self.text != nil || self.textOption != nil || self.filePath != nil || self.imagePath != nil
             || self.dataBase64 != nil || self.uti != nil || self.alsoText != nil
-            || self.allowLarge || self.restoreDelayMs != 150
+            || self.allowLarge || self.restoreDelayMs != nil
     }
 
     @MainActor
@@ -189,7 +196,7 @@ struct PasteCommand: ErrorHandlingCommand, OutputFormattable, RuntimeOptionsConf
                 restoredSize: restoreResult?.data.count,
                 restoreSucceeded: restoreErrorDescription == nil,
                 restoreError: restoreErrorDescription,
-                restoreDelayMs: self.restoreDelayMs,
+                restoreDelayMs: self.resolvedRestoreDelayMs,
                 deliveryMode: targetPID == nil ? KeyboardDeliveryMode.foreground.rawValue :
                     KeyboardDeliveryMode.background.rawValue,
                 targetPID: targetPID.map(Int.init)
@@ -268,8 +275,8 @@ struct PasteCommand: ErrorHandlingCommand, OutputFormattable, RuntimeOptionsConf
         priorClipboardPresent: Bool,
         slot: String
     ) throws -> ClipboardReadResult? {
-        if self.restoreDelayMs > 0 {
-            usleep(useconds_t(self.restoreDelayMs) * 1000)
+        if self.resolvedRestoreDelayMs > 0 {
+            usleep(useconds_t(self.resolvedRestoreDelayMs) * 1000)
         }
         guard priorClipboardPresent else {
             self.services.clipboard.clear()

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/System/AppCommand+List.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/System/AppCommand+List.swift
@@ -17,7 +17,7 @@ extension AppCommand {
             App-management view of running applications. Hidden and background apps are
             filtered unless --include-hidden or --include-background is passed.
 
-            For a full inventory payload, use `peekaboo list apps`; it accepts the same
+            For a broader inventory payload, use `peekaboo list apps`; it accepts the same
             visibility flags for parity and emits both `applications` and preferred `apps`.
             """
         )

--- a/Apps/CLI/Tests/CLIAutomationTests/PasteCommandTests.swift
+++ b/Apps/CLI/Tests/CLIAutomationTests/PasteCommandTests.swift
@@ -53,6 +53,7 @@ struct PasteCommandTests {
             ["paste", "--uti", "public.rtf", "--json", "--no-remote"],
             ["paste", "--also-text", "fallback", "--json", "--no-remote"],
             ["paste", "--allow-large", "--json", "--no-remote"],
+            ["paste", "--restore-delay-ms", "150", "--json", "--no-remote"],
             ["paste", "--restore-delay-ms", "500", "--json", "--no-remote"],
         ] {
             let result = try await InProcessCommandRunner.run(argv, services: services)

--- a/Apps/CLI/Tests/CoreCLITests/CommanderBinderCommandBindingTests.swift
+++ b/Apps/CLI/Tests/CoreCLITests/CommanderBinderCommandBindingTests.swift
@@ -639,6 +639,12 @@ struct CommanderBinderCommandBindingTests {
 
     @Test
     func `Paste command binding (text + target)`() throws {
+        let defaultCommand = try CommanderCLIBinder.instantiateCommand(
+            ofType: PasteCommand.self,
+            parsedValues: ParsedValues(positional: [], options: [:], flags: [])
+        )
+        #expect(defaultCommand.restoreDelayMs == nil)
+
         let parsed = ParsedValues(
             positional: ["Hello"],
             options: [
@@ -656,6 +662,9 @@ struct CommanderBinderCommandBindingTests {
         #expect(command.target.windowTitle == "Untitled")
         #expect(command.restoreDelayMs == 250)
         #expect(command.allowLarge == true)
+
+        let restoreDelay = PasteCommand.commanderSignature().options.first { $0.label == "restoreDelayMs" }
+        #expect(restoreDelay?.help?.contains("default: 150") == true)
     }
 
     @Test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Added
 - `peekaboo agent` supports GPT-5.6 (`gpt-5.6`, `gpt-5.6-sol`, `gpt-5.6-terra`, `gpt-5.6-luna`) and Claude Sonnet 5 (`claude-sonnet-5`, `sonnet`) alongside Fable 5, with matching display names in the Mac app's session view.
-- Bare `peekaboo paste` now pastes the current clipboard into the focused (or targeted background) app instead of erroring; payload flags without a payload still fail validation, and the current clipboard's contents are never echoed into structured output.
+- Bare `peekaboo paste` now pastes the current clipboard into the focused (or targeted background) app instead of erroring; payload flags without a payload still fail validation even when `--restore-delay-ms` explicitly uses its 150ms default, and the current clipboard's contents are never echoed into structured output.
 - `peekaboo list apps` accepts `--include-hidden`/`--include-background` for parity with `app list`, and `list apps`, `list menubar`, and `dock list` JSON now emit snake_case keys (`apps`, `menu_bar_items`, `dock_items`) alongside the legacy keys.
 
 ### Changed

--- a/docs/commands/app.md
+++ b/docs/commands/app.md
@@ -26,7 +26,7 @@ read_when:
 - `switch --cycle` synthesizes Cmd+Tab events using `CGEvent` so it behaves like the real keyboard shortcut; `switch --to` activates the exact PID resolved via AX.
 - `switch --verify` confirms the requested app is frontmost after activation (only supported with `--to`).
 - `relaunch` sends quit, termination polling (up to 5 s), the requested delay, and launch as one daemon-held transaction, so even a short daemon idle timeout cannot strand the app closed. It refuses to relaunch its own daemon, launches via bundle ID or bundle path, and can wait for `isFinishedLaunching` before reporting success.
-- `app list` is the app-management view and filters hidden/background apps unless `--include-hidden` or `--include-background` is passed. `peekaboo list apps` is the full inventory view; it accepts the same flags for parity and emits both legacy `data.applications` and preferred `data.apps`.
+- `app list` is the app-management view and filters hidden/background apps unless `--include-hidden` or `--include-background` is passed. `peekaboo list apps` is the broader inventory view; it accepts the same flags for parity and emits both legacy `data.applications` and preferred `data.apps`.
 
 ## Examples
 ```bash

--- a/docs/commands/list.md
+++ b/docs/commands/list.md
@@ -12,7 +12,7 @@ read_when:
 ## Subcommands
 | Subcommand | What it does | Notable options |
 | --- | --- | --- |
-| `apps` (default) | Full running-app inventory with bundle ID, PID, and focus status. | Accepts `--include-hidden`, `--include-background` for `app list` parity; output is already unfiltered. |
+| `apps` (default) | Broader running-app inventory with bundle ID, PID, and focus status. | Accepts `--include-hidden`, `--include-background` for `app list` parity; hidden/background apps are already included when exposed by ApplicationService. |
 | `windows` | Full window enumeration for one process with optional bounds/ID metadata. | `--app <name|bundle|PID:1234>` (required), `--pid`, `--include-details bounds,ids,off_screen`. |
 | `menubar` | Dumps every status-item title/index so you can target them via `menubar click`. | Supports `--json` for scripts piping into `jq`; prefer `data.menu_bar_items`. |
 | `screens` | Shows connected displays, resolution, scaling, and whether they are main/secondary. | None. |
@@ -20,7 +20,7 @@ read_when:
 
 ## Implementation notes
 - The root command does nothing; Commander dispatches straight to the subcommand so `peekaboo list` defaults to `list apps`.
-- `list apps` is the full inventory view. `peekaboo app list` is the app-management view and filters hidden/background apps unless `--include-hidden` or `--include-background` is passed. `list apps` accepts those flags so sibling invocations do not fail, but they do not narrow the already-unfiltered payload.
+- `list apps` is the broader inventory view. `peekaboo app list` is the app-management view and filters hidden/background apps unless `--include-hidden` or `--include-background` is passed. `list apps` accepts those flags so sibling invocations do not fail, but they do not change its broader payload.
 - `list apps --json` keeps the legacy `data.applications` key and also emits preferred `data.apps`.
 - Application inventory prefers the GUI bridge host so sandboxed CLI callers see the GUI session’s complete process list. Other read-only inventory stays local by default unless its command needs host state or you pass `--bridge-socket <path>`.
 - `windows` calls `requireScreenRecordingPermission` before crawling AX so macOS doesn’t silently strip metadata; `apps` does not require Screen Recording.


### PR DESCRIPTION
## Summary

- distinguish an explicitly supplied `--restore-delay-ms 150` from an omitted option
- reject every payload-modifier-only paste invocation before sending Cmd+V
- show the 150ms runtime default in production help
- replace inaccurate “full/unfiltered” application-list wording with the actual broader-inventory contract
- add the missing CLI changelog coverage for the original paste/list changes

## Proof

- `PasteCommandTests|CommanderBinderCommandBindingTests`: 61 tests passed
- `ListCommandTests`: 29 tests passed
- `pnpm run test:safe`: 707 tests in 80 suites passed
- strict SwiftLint on all changed Swift files: zero violations
- `pnpm run lint:docs`: passed
- rebuilt production CLI returned `VALIDATION_ERROR` and exit 1 for `paste --restore-delay-ms 150 --json --no-remote`
- rebuilt production help displays `default: 150`
- autoreview: clean, no actionable findings (0.98 confidence)

Follow-up repair for the exact-default edge case left by #246.
