### PR TITLE
fix(dock): classify application bundles correctly

### DIFF
--- a/Apps/CLI/CHANGELOG.md
+++ b/Apps/CLI/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [3.8.1] - Unreleased
 
 ### Fixed
+- Adding a macOS application bundle to the Dock now places it with applications instead of mistaking its on-disk directory for a folder.
 - Bare `peekaboo paste` now pastes the current clipboard, while payload-only flags without a payload fail validation even when `--restore-delay-ms` explicitly uses its 150ms default; `list apps` also accepts the `app list` visibility flags and emits preferred snake_case keys alongside legacy keys.
 - `peekaboo clean --snapshot` now rejects empty, traversal, nested-path, absolute-path, and symlink snapshot IDs, keeping cleanup confined to one real snapshot folder directly beneath the cache root.
 - Invoking `peekaboo daemon start` through `PATH` now relaunches the canonical executable instead of looking for a `peekaboo` file in the current directory, startup errors now distinguish launch failures, early exits, and readiness timeouts, and daemon logs honor `PEEKABOO_CONFIG_DIR`. Thanks @mattash for #231.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - The accessibility element boxes drawn during `peekaboo see` are off by default now; they were visual clutter on every capture. Re-enable them in Peekaboo.app under Settings › Visualizer › Element Detection Boxes, by setting `visualizer.elementDetectionEnabled` in `~/.peekaboo/config.json`, or per-run with `PEEKABOO_VISUAL_ELEMENT_BOXES=true`. The app toggle and the config file now stay in sync, and a running MCP server picks up the change without a restart.
 
 ### Fixed
+- Adding a macOS application bundle to the Dock now places it with applications instead of mistaking its on-disk directory for a folder.
 - Synchronous default MCP tool-context access now fails fast off the main thread, with an async main-actor accessor for background callers. Thanks @SebTardif for #253.
 - Default `PeekabooMCPServer` startup now throws an actionable configuration error instead of terminating the process when no default tool context was installed. Thanks @SebTardif for #252.
 - `peekaboo agent` with a local Ollama model now actually runs its tools. Ollama's streaming API returns tool calls alongside empty content, and those were being dropped, so models fell back to printing tool-call JSON as text: the agent executed nothing, reported zero tool calls and empty content, and still claimed success. Asking the agent to click a button now clicks it.

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/DockService+Actions.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/DockService+Actions.swift
@@ -2,6 +2,7 @@
 import CoreGraphics
 import Foundation
 import PeekabooFoundation
+import UniformTypeIdentifiers
 
 struct DockProcessCommand: Equatable, Sendable {
     let executable: String
@@ -27,15 +28,12 @@ extension DockService {
 
     func addToDockImpl(path: String, persistent _: Bool = true) async throws {
         let sanitizedPath = try DockService.validatedDockItemPath(path)
-        var isDirectory: ObjCBool = false
-        _ = FileManager.default.fileExists(atPath: sanitizedPath, isDirectory: &isDirectory)
-        let isFolder = isDirectory.boolValue
 
         // Invoke defaults directly (no shell) so path content cannot break out of
         // a bash -c script. Still XML-escape the path so malformed strings cannot
         // corrupt the Dock plist fragment.
         try DockService.runProcess(
-            DockService.dockDefaultsWriteCommand(forPath: sanitizedPath, isFolder: isFolder))
+            DockService.dockDefaultsWriteCommand(forPath: sanitizedPath))
         try DockService.runProcess(DockService.restartDockCommand)
     }
 
@@ -93,14 +91,24 @@ extension DockService {
 
     static func dockDefaultsWriteCommand(
         forPath path: String,
-        isFolder: Bool,
         domain: String = "com.apple.dock") -> DockProcessCommand
     {
-        let plistKey = isFolder ? "persistent-others" : "persistent-apps"
+        let plistKey = self.dockPlistKey(forPath: path)
         return DockProcessCommand(
             executable: "/usr/bin/defaults",
             arguments: ["write", domain, plistKey, "-array-add", self.dockTilePlistFragment(forPath: path)],
             failurePrefix: "Failed to add item to Dock")
+    }
+
+    private static func dockPlistKey(forPath path: String) -> String {
+        // App bundles are directories on disk but belong in the Dock's application array.
+        // Resolve symlinks only for classification; the tile keeps the exact supplied path.
+        let classificationURL = URL(fileURLWithPath: path).resolvingSymlinksInPath()
+        let values = try? classificationURL.resourceValues(forKeys: [.contentTypeKey, .isDirectoryKey])
+        if values?.contentType?.conforms(to: .applicationBundle) == true {
+            return "persistent-apps"
+        }
+        return values?.isDirectory == true ? "persistent-others" : "persistent-apps"
     }
 
     static let restartDockCommand = DockProcessCommand(

--- a/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/DockAddPathValidationTests.swift
+++ b/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/DockAddPathValidationTests.swift
@@ -53,7 +53,7 @@ struct DockAddPathValidationTests {
     func `shell metacharacter path stays a single non-shell argument payload`() throws {
         let payload = #"/tmp/x'; touch /tmp/pwned; echo '"#
         let path = try DockService.validatedDockItemPath(payload)
-        let command = DockService.dockDefaultsWriteCommand(forPath: path, isFolder: false)
+        let command = DockService.dockDefaultsWriteCommand(forPath: path)
 
         #expect(command.executable == "/usr/bin/defaults")
         #expect(command.arguments == [
@@ -84,7 +84,6 @@ struct DockAddPathValidationTests {
         let domain = temporaryDirectory.appendingPathComponent("dock-domain").path
         let command = DockService.dockDefaultsWriteCommand(
             forPath: payload,
-            isFolder: false,
             domain: domain)
 
         try DockService.runProcess(command)
@@ -99,5 +98,74 @@ struct DockAddPathValidationTests {
         let tileData = try #require(tile["tile-data"] as? [String: Any])
         let fileData = try #require(tileData["file-data"] as? [String: Any])
         #expect(fileData["_CFURLString"] as? String == payload)
+    }
+
+    @Test
+    func `application bundles use the Dock applications array`() {
+        let path = "/System/Applications/Calculator.app"
+        #expect(FileManager.default.fileExists(atPath: path))
+
+        let command = DockService.dockDefaultsWriteCommand(forPath: path)
+
+        #expect(command.arguments[2] == "persistent-apps")
+    }
+
+    @Test
+    func `ordinary directories use the Dock folders array`() throws {
+        let fileManager = FileManager.default
+        let directory = fileManager.temporaryDirectory
+            .appendingPathComponent("peekaboo-dock-folder-\(UUID().uuidString)", isDirectory: true)
+        try fileManager.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? fileManager.removeItem(at: directory) }
+
+        let command = DockService.dockDefaultsWriteCommand(forPath: directory.path)
+
+        #expect(command.arguments[2] == "persistent-others")
+    }
+
+    @Test
+    func `symlinks to application bundles keep their path and use the applications array`() throws {
+        let fileManager = FileManager.default
+        let temporaryDirectory = fileManager.temporaryDirectory
+            .appendingPathComponent("peekaboo-dock-symlink-\(UUID().uuidString)", isDirectory: true)
+        try fileManager.createDirectory(at: temporaryDirectory, withIntermediateDirectories: true)
+        defer { try? fileManager.removeItem(at: temporaryDirectory) }
+
+        let symlink = temporaryDirectory.appendingPathComponent("Calculator Link.app")
+        try fileManager.createSymbolicLink(
+            at: symlink,
+            withDestinationURL: URL(fileURLWithPath: "/System/Applications/Calculator.app"))
+
+        let command = DockService.dockDefaultsWriteCommand(forPath: symlink.path)
+
+        #expect(command.arguments[2] == "persistent-apps")
+        #expect(command.arguments[4].contains("<string>\(symlink.path)</string>"))
+    }
+
+    @Test
+    func `real defaults write places an application bundle in persistent apps`() throws {
+        let fileManager = FileManager.default
+        let temporaryDirectory = fileManager.temporaryDirectory
+            .appendingPathComponent("peekaboo-dock-app-test-\(UUID().uuidString)", isDirectory: true)
+        try fileManager.createDirectory(at: temporaryDirectory, withIntermediateDirectories: true)
+        defer { try? fileManager.removeItem(at: temporaryDirectory) }
+
+        let calculatorPath = "/System/Applications/Calculator.app"
+        let domain = temporaryDirectory.appendingPathComponent("dock-domain").path
+        let command = DockService.dockDefaultsWriteCommand(forPath: calculatorPath, domain: domain)
+
+        try DockService.runProcess(command)
+
+        let plistURL = URL(fileURLWithPath: domain + ".plist")
+        let plistData = try Data(contentsOf: plistURL)
+        let plist = try PropertyListSerialization.propertyList(from: plistData, format: nil)
+        let root = try #require(plist as? [String: Any])
+        let persistentApps = try #require(root["persistent-apps"] as? [[String: Any]])
+        #expect(root["persistent-others"] == nil)
+        #expect(persistentApps.count == 1)
+
+        let tileData = try #require(persistentApps[0]["tile-data"] as? [String: Any])
+        let fileData = try #require(tileData["file-data"] as? [String: Any])
+        #expect(fileData["_CFURLString"] as? String == calculatorPath)
     }
 }


### PR DESCRIPTION
## Summary

Place macOS application bundles in the Dock's `persistent-apps` array instead of treating every on-disk directory as a folder.

## Problem

`.app` bundles are directories. The production add path used only `FileManager.isDirectory`, so adding `/System/Applications/Calculator.app` selected `persistent-others`, the Dock's folder/document array.

## Changes

- Centralize item classification inside the production `dockDefaultsWriteCommand` builder so callers and tests cannot bypass it.
- Resolve symlinks for classification only and use `UTType.applicationBundle` to distinguish applications from ordinary directories.
- Preserve the exact caller-supplied path in the Dock tile.
- Keep the existing regular-file and missing-path fallback in `persistent-apps`.
- Add root and CLI changelog entries.

## Validation

- `swift test --package-path Core/PeekabooAutomationKit --filter DockAddPathValidationTests --no-parallel` — 10 tests passed.
- `pnpm run test:safe` — 707 tests across 80 suites passed.
- `pnpm run format` — clean.
- Changed-file strict SwiftLint — 0 violations.
- Autoreview with Codex `gpt-5.5`, xhigh reasoning — no accepted/actionable findings (0.88 confidence).

## Live production-path proof

The focused suite calls the real command builder and `/usr/bin/defaults` with `/System/Applications/Calculator.app`, but writes to an isolated absolute temporary domain. It parses the resulting plist and verifies:

- exactly one tile under `persistent-apps`;
- no `persistent-others` key;
- the exact Calculator path in `_CFURLString`.

It also covers an ordinary temporary directory, a symlink to Calculator, and the shell-metacharacter regression from #224. The proof never writes `com.apple.dock` and never executes `killall Dock`.

Follow-up found while auditing #224.
