### PR TITLE
fix(agent): complete GPT-5.6 model support

### DIFF
--- a/Apps/CLI/CHANGELOG.md
+++ b/Apps/CLI/CHANGELOG.md
@@ -7,7 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [3.8.1] - Unreleased
 
+### Added
+- `peekaboo agent --model` now accepts GPT-5.6 Sol, Terra, and Luna (`gpt-5.6` selects Sol) plus Claude Sonnet 5.
+
 ### Fixed
+- OpenRouter, Together, and OpenAI-compatible GPT-5.6 routes now preserve the 372K context/128K output capability profile, omit unsupported temperature, and recognize routing suffixes such as `:online`.
 - Adding a macOS application bundle to the Dock now places it with applications instead of mistaking its on-disk directory for a folder.
 - Bare `peekaboo paste` now pastes the current clipboard, while payload-only flags without a payload fail validation even when `--restore-delay-ms` explicitly uses its 150ms default; `list apps` also accepts the `app list` visibility flags and emits preferred snake_case keys alongside legacy keys.
 - `peekaboo clean --snapshot` now rejects empty, traversal, nested-path, absolute-path, and symlink snapshot IDs, keeping cleanup confined to one real snapshot folder directly beneath the cache root.

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/AI/AgentCommand.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/AI/AgentCommand.swift
@@ -89,7 +89,7 @@ struct AgentCommand: RuntimeOptionsConfigurable {
     @Option(
         name: .long,
         help: """
-        AI model to use (for example: gpt-5.5, claude-fable-5, \
+        AI model to use (for example: gpt-5.6, gpt-5.5, claude-fable-5, claude-sonnet-5, \
         gemini-3.5-flash, grok-4.3, minimax-m2.7, minimax-cn/m2.7, \
         ollama/<model>, lmstudio/<model>, or <custom-provider>/<model>)
         """

--- a/Apps/CLI/Tests/CLIAutomationTests/AgentCommandBasicTests.swift
+++ b/Apps/CLI/Tests/CLIAutomationTests/AgentCommandBasicTests.swift
@@ -11,4 +11,13 @@ struct AgentCommandBasicTests {
         #expect(config.commandName == "agent")
         #expect(config.abstract == "Execute complex automation tasks using the Peekaboo agent")
     }
+
+    @Test
+    func `Agent help lists current model examples`() async throws {
+        let result = try await InProcessCommandRunner.runShared(["agent", "--help"])
+
+        #expect(result.exitStatus == 0)
+        #expect(result.combinedOutput.contains("gpt-5.6"))
+        #expect(result.combinedOutput.contains("claude-sonnet-5"))
+    }
 }

--- a/Apps/Mac/Peekaboo/Features/AI/AIAssistantWindow.swift
+++ b/Apps/Mac/Peekaboo/Features/AI/AIAssistantWindow.swift
@@ -18,6 +18,27 @@ private enum AIAssistantPrompts {
     static let compactDefault = "You are a helpful assistant."
 }
 
+struct AIAssistantModelOption: Identifiable, Sendable {
+    let title: String
+    let model: Model
+
+    var id: Model {
+        self.model
+    }
+}
+
+enum AIAssistantModelCatalog {
+    static let options = [
+        AIAssistantModelOption(title: "GPT-5.6 Sol", model: .openai(.gpt56Sol)),
+        AIAssistantModelOption(title: "GPT-5.6 Terra", model: .openai(.gpt56Terra)),
+        AIAssistantModelOption(title: "GPT-5.6 Luna", model: .openai(.gpt56Luna)),
+        AIAssistantModelOption(title: "GPT-5.5", model: .openai(.gpt55)),
+        AIAssistantModelOption(title: "Claude Fable 5", model: .anthropic(.fable5)),
+        AIAssistantModelOption(title: "Claude Sonnet 5", model: .anthropic(.sonnet5)),
+        AIAssistantModelOption(title: "Claude Opus 4.8", model: .anthropic(.opus48)),
+    ]
+}
+
 // MARK: - AI Assistant Window
 
 @available(macOS 14.0, *)
@@ -39,8 +60,9 @@ public struct AIAssistantWindow: View {
                         .font(.headline)
 
                     Picker("Model", selection: self.$selectedModel) {
-                        Text("GPT-5.5").tag(Model.openai(.gpt55))
-                        Text("Claude Opus 4.8").tag(Model.anthropic(.opus48))
+                        ForEach(AIAssistantModelCatalog.options) { option in
+                            Text(option.title).tag(option.model)
+                        }
                     }
                     .pickerStyle(.menu)
                 }
@@ -139,8 +161,9 @@ public struct CompactAIAssistant: View {
                 Spacer()
 
                 Picker("Model", selection: self.$model) {
-                    Text("GPT-5.5").tag(Model.openai(.gpt55))
-                    Text("Claude Opus 4.8").tag(Model.anthropic(.opus48))
+                    ForEach(AIAssistantModelCatalog.options) { option in
+                        Text(option.title).tag(option.model)
+                    }
                 }
                 .pickerStyle(.menu)
                 .controlSize(.small)

--- a/Apps/Mac/Peekaboo/Features/Settings/SettingsWindow.swift
+++ b/Apps/Mac/Peekaboo/Features/Settings/SettingsWindow.swift
@@ -227,6 +227,9 @@ struct AISettingsView: View {
 
     static let builtinProviderCatalog: [(provider: String, models: [(id: String, name: String)])] = [
         ("openai", [
+            ("gpt-5.6-sol", "GPT-5.6 Sol"),
+            ("gpt-5.6-terra", "GPT-5.6 Terra"),
+            ("gpt-5.6-luna", "GPT-5.6 Luna"),
             ("gpt-5.5", "GPT-5.5"),
             ("gpt-5.4", "GPT-5.4"),
             ("gpt-5.4-mini", "GPT-5.4 mini"),
@@ -236,6 +239,7 @@ struct AISettingsView: View {
         ]),
         ("anthropic", [
             ("claude-fable-5", "Claude Fable 5"),
+            ("claude-sonnet-5", "Claude Sonnet 5"),
             ("claude-opus-4-8", "Claude Opus 4.8"),
             ("claude-opus-4-7", "Claude Opus 4.7"),
             ("claude-sonnet-4-6", "Claude Sonnet 4.6"),
@@ -360,6 +364,9 @@ struct AISettingsView: View {
     private var modelDescriptions: [String: String] {
         [
             // OpenAI models
+            "gpt-5.6-sol": "GPT-5.6 Sol with 372K context and up to 128K output.",
+            "gpt-5.6-terra": "GPT-5.6 Terra with 372K context and up to 128K output.",
+            "gpt-5.6-luna": "GPT-5.6 Luna with 372K context and up to 128K output.",
             "gpt-5.5": "Flagship GPT-5.5 model with 400K context and upgraded tool " +
                 "usage + reasoning.",
             "gpt-5.4": "GPT-5.4 model with 400K context and upgraded tool " +
@@ -375,6 +382,7 @@ struct AISettingsView: View {
             // Anthropic models
             "claude-fable-5": "Claude Fable 5 with 1M context for demanding " +
                 "reasoning and long-horizon agent tasks.",
+            "claude-sonnet-5": "Claude Sonnet 5 with 1M context for fast, capable agent tasks.",
             "claude-opus-4-8": "Claude Opus 4.8 with 1M context for long-running " +
                 "automation and computer-use tasks.",
             "claude-sonnet-4-6": "Claude Sonnet 4.6 with new tools + computer use, " +

--- a/Apps/Mac/PeekabooTests/Models/SessionTests.swift
+++ b/Apps/Mac/PeekabooTests/Models/SessionTests.swift
@@ -27,8 +27,17 @@ struct ConversationSessionTests {
 
     @Test
     func `Supported Anthropic model names remain human readable`() {
+        #expect(formatModelName("claude-fable-5") == "Claude Fable 5")
+        #expect(formatModelName("claude-sonnet-5") == "Claude Sonnet 5")
         #expect(formatModelName("claude-opus-4-7") == "Claude Opus 4.7")
         #expect(formatModelName("claude-sonnet-4-5-20250929") == "Claude Sonnet 4.5")
+    }
+
+    @Test
+    func `GPT-5_6 model names remain human readable`() {
+        #expect(formatModelName("gpt-5.6-sol") == "GPT-5.6 Sol")
+        #expect(formatModelName("gpt-5.6-terra") == "GPT-5.6 Terra")
+        #expect(formatModelName("gpt-5.6-luna") == "GPT-5.6 Luna")
     }
 
     @Test

--- a/Apps/Mac/PeekabooTests/Services/SettingsServiceTests.swift
+++ b/Apps/Mac/PeekabooTests/Services/SettingsServiceTests.swift
@@ -818,6 +818,37 @@ struct PeekabooSettingsConfigHydrationTests {
     }
 
     @Test
+    func `Built-in model picker includes current frontier models in tier order`() throws {
+        #expect(AISettingsView.builtinName(forModelId: "gpt-5.6-sol") == "GPT-5.6 Sol")
+        #expect(AISettingsView.builtinName(forModelId: "gpt-5.6-terra") == "GPT-5.6 Terra")
+        #expect(AISettingsView.builtinName(forModelId: "gpt-5.6-luna") == "GPT-5.6 Luna")
+        #expect(AISettingsView.builtinName(forModelId: "claude-fable-5") == "Claude Fable 5")
+        #expect(AISettingsView.builtinName(forModelId: "claude-sonnet-5") == "Claude Sonnet 5")
+
+        let openAI = try #require(AISettingsView.builtinProviderCatalog.first { $0.provider == "openai" })
+        let anthropic = try #require(AISettingsView.builtinProviderCatalog.first { $0.provider == "anthropic" })
+        #expect(openAI.models.prefix(4).map(\.id) == [
+            "gpt-5.6-sol",
+            "gpt-5.6-terra",
+            "gpt-5.6-luna",
+            "gpt-5.5",
+        ])
+        #expect(anthropic.models.prefix(2).map(\.id) == [
+            "claude-fable-5",
+            "claude-sonnet-5",
+        ])
+        #expect(AIAssistantModelCatalog.options.map(\.model.modelId) == [
+            "gpt-5.6-sol",
+            "gpt-5.6-terra",
+            "gpt-5.6-luna",
+            "gpt-5.5",
+            "claude-fable-5",
+            "claude-sonnet-5",
+            "claude-opus-4-8",
+        ])
+    }
+
+    @Test
     func `Hydrated OpenRouter model remains available in model picker`() {
         let modelGroups = AISettingsView.appendingSelectedOpenRouterModel(
             to: [("openai", [(id: "gpt-5.5", name: "GPT-5.5")])],

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## [3.8.1] - Unreleased
 
 ### Added
-- `peekaboo agent` supports GPT-5.6 (`gpt-5.6`, `gpt-5.6-sol`, `gpt-5.6-terra`, `gpt-5.6-luna`) and Claude Sonnet 5 (`claude-sonnet-5`, `sonnet`) alongside Fable 5, with matching display names in the Mac app's session view.
+- `peekaboo agent` supports GPT-5.6 (`gpt-5.6`, `gpt-5.6-sol`, `gpt-5.6-terra`, `gpt-5.6-luna`) and Claude Sonnet 5 (`claude-sonnet-5`, `sonnet`) alongside Fable 5, with current context/output/sampling limits and matching choices in the Mac app's assistant pickers, Settings, and session view.
 - Bare `peekaboo paste` now pastes the current clipboard into the focused (or targeted background) app instead of erroring; payload flags without a payload still fail validation even when `--restore-delay-ms` explicitly uses its 150ms default, and the current clipboard's contents are never echoed into structured output.
 - `peekaboo list apps` accepts `--include-hidden`/`--include-background` for parity with `app list`, and `list apps`, `list menubar`, and `dock list` JSON now emit snake_case keys (`apps`, `menu_bar_items`, `dock_items`) alongside the legacy keys.
 
@@ -13,6 +13,7 @@
 - The accessibility element boxes drawn during `peekaboo see` are off by default now; they were visual clutter on every capture. Re-enable them in Peekaboo.app under Settings › Visualizer › Element Detection Boxes, by setting `visualizer.elementDetectionEnabled` in `~/.peekaboo/config.json`, or per-run with `PEEKABOO_VISUAL_ELEMENT_BOXES=true`. The app toggle and the config file now stay in sync, and a running MCP server picks up the change without a restart.
 
 ### Fixed
+- OpenRouter, Together, and OpenAI-compatible GPT-5.6 routes now preserve the 372K context/128K output capability profile, omit unsupported temperature, and recognize routing suffixes such as `:online`.
 - Adding a macOS application bundle to the Dock now places it with applications instead of mistaking its on-disk directory for a folder.
 - Synchronous default MCP tool-context access now fails fast off the main thread, with an async main-actor accessor for background callers. Thanks @SebTardif for #253.
 - Default `PeekabooMCPServer` startup now throws an actionable configuration error instead of terminating the process when no default tool context was installed. Thanks @SebTardif for #252.

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/Agent/PeekabooAgentService+Execution.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/Agent/PeekabooAgentService+Execution.swift
@@ -14,7 +14,8 @@ extension PeekabooAgentService {
         let temperature = self.shouldOmitTemperature(for: model) ? nil : self.configuredTemperature(for: model)
 
         return switch model {
-        case .openai(.gpt55), .openai(.gpt54), .openai(.gpt54Mini), .openai(.gpt54Nano), .openai(.gpt5):
+        case .openai(.gpt56Sol), .openai(.gpt56Terra), .openai(.gpt56Luna),
+             .openai(.gpt55), .openai(.gpt54), .openai(.gpt54Mini), .openai(.gpt54Nano), .openai(.gpt5):
             GenerationSettings(
                 maxTokens: maxTokens,
                 temperature: temperature,
@@ -70,7 +71,7 @@ extension PeekabooAgentService {
 
     private func shouldOmitTemperature(for model: LanguageModel) -> Bool {
         switch model {
-        case let .openaiCompatible(modelId, _):
+        case let .openRouter(modelId), let .together(modelId), let .openaiCompatible(modelId, _):
             return self.isOpenAIGPT5TemperatureExcludedModel(modelId)
         case let .custom(provider):
             guard let parsed = ProviderParser.parse(provider.modelId) else {
@@ -86,7 +87,11 @@ extension PeekabooAgentService {
     }
 
     private func isOpenAIGPT5TemperatureExcludedModel(_ modelId: String) -> Bool {
-        switch self.normalizedOpenAIModelID(modelId) {
+        if LanguageModel.OpenAI.gpt56Model(for: modelId) != nil {
+            return true
+        }
+
+        return switch self.normalizedOpenAIModelID(modelId) {
         case "chat-latest",
              "gpt-5.5",
              "gpt-5.4",
@@ -151,7 +156,11 @@ extension PeekabooAgentService {
         case .mistral, .groq, .grok, .ollama, .lmstudio, .azureOpenAI, .replicate:
             4096
         case let .openRouter(modelId), let .together(modelId), let .openaiCompatible(modelId, _):
-            AnthropicModelCapabilityInference.capabilities(for: modelId)?.maxOutputTokens ?? 4096
+            if let maxOutputTokens = AnthropicModelCapabilityInference.capabilities(for: modelId)?.maxOutputTokens {
+                maxOutputTokens
+            } else {
+                LanguageModel.OpenAI.gpt56Model(for: modelId) == nil ? 4096 : 128_000
+            }
         case let .anthropicCompatible(modelId, _):
             AnthropicModelCapabilityInference.capabilities(for: modelId)?.maxOutputTokens ?? 8192
         }

--- a/Core/PeekabooCore/Sources/PeekabooAutomation/Services/AI/PeekabooAIService.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAutomation/Services/AI/PeekabooAIService.swift
@@ -80,14 +80,18 @@ private final class PeekabooCustomProviderModel: ModelProvider, @unchecked Senda
         let inferredAnthropicCapabilities = kind == .anthropic
             ? AnthropicModelCapabilityInference.capabilities(for: resolvedModelID)
             : nil
-        let inferredMaxOutputTokens = inferredAnthropicCapabilities?.maxOutputTokens ?? 4096
+        let inferredGPT56Model = kind == .openai
+            ? LanguageModel.OpenAI.gpt56Model(for: resolvedModelID)
+            : nil
+        let inferredMaxOutputTokens = inferredAnthropicCapabilities?.maxOutputTokens ??
+            (inferredGPT56Model == nil ? 4096 : 128_000)
         let hasStreamingRefusalRisk = inferredAnthropicCapabilities.map { !$0.supportsStreaming } ??
             LanguageModel.Anthropic.hasStreamingRefusalRisk(modelId: resolvedModelID)
         self.capabilities = ModelCapabilities(
             supportsVision: supportsVision,
             supportsTools: supportsTools,
             supportsStreaming: !hasStreamingRefusalRisk,
-            contextLength: inferredAnthropicCapabilities?.contextLength ?? 128_000,
+            contextLength: inferredAnthropicCapabilities?.contextLength ?? inferredGPT56Model?.contextLength ?? 128_000,
             maxOutputTokens: maxOutputTokens ?? inferredMaxOutputTokens)
     }
 

--- a/Core/PeekabooCore/Tests/PeekabooTests/PeekabooAgentGenerationSettingsTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/PeekabooAgentGenerationSettingsTests.swift
@@ -86,6 +86,76 @@ struct PeekabooAgentGenerationSettingsTests {
 
     @Test
     @MainActor
+    func `GPT-5_6 compatible routes preserve limits and omit unsupported temperature`() throws {
+        try self.withTemporaryConfig(
+            """
+            {
+              "agent": { "temperature": 0.7, "maxTokens": 128000 }
+            }
+            """) {
+                let agentService = try PeekabooAgentService(services: PeekabooServices())
+                let models: [LanguageModel] = [
+                    .openaiCompatible(
+                        modelId: "gpt-5.6-sol",
+                        baseURL: "https://openai-compatible.example"),
+                    .openaiCompatible(
+                        modelId: "openai/gpt-5.6-terra",
+                        baseURL: "https://openai-compatible.example"),
+                    .openRouter(modelId: "openai/gpt-5.6-terra:online"),
+                    .together(modelId: "openai/gpt-5.6-luna"),
+                ]
+
+                for model in models {
+                    let settings = agentService.generationSettings(for: model)
+                    #expect(settings.temperature == nil)
+                    #expect(settings.maxTokens == 128_000)
+                }
+            }
+    }
+
+    @Test
+    @MainActor
+    func `Configured custom OpenAI GPT-5_6 model infers current limits`() throws {
+        try self.withTemporaryConfig(
+            """
+            {
+              "aiProviders": { "providers": "local-openai/openai/gpt-5.6-sol" },
+              "agent": { "temperature": 0.7, "maxTokens": 128000 },
+              "customProviders": {
+                "local-openai": {
+                  "name": "Local OpenAI",
+                  "type": "openai",
+                  "enabled": true,
+                  "options": {
+                    "baseURL": "https://openai-compatible.example",
+                    "apiKey": "test-key"
+                  },
+                  "models": {
+                    "openai/gpt-5.6-sol": {
+                      "name": "GPT-5.6 Sol",
+                      "supportsTools": true
+                    }
+                  }
+                }
+              }
+            }
+            """) {
+                let configuration = ConfigurationManager.shared
+                _ = configuration.loadConfiguration()
+                let aiService = PeekabooAIService(configuration: configuration)
+                let model = try #require(aiService.availableModels().first)
+                let agentService = try PeekabooAgentService(services: PeekabooServices())
+                let settings = agentService.generationSettings(for: model)
+
+                #expect(model.modelId == "local-openai/openai/gpt-5.6-sol")
+                #expect(model.contextLength == 372_000)
+                #expect(settings.maxTokens == 128_000)
+                #expect(settings.temperature == nil)
+            }
+    }
+
+    @Test
+    @MainActor
     func `Configured custom OpenAI GPT 5 provider omits unsupported temperature`() throws {
         try self.withTemporaryConfig(
             """

--- a/Core/PeekabooCore/Tests/PeekabooTests/PeekabooAgentServiceModelTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/PeekabooAgentServiceModelTests.swift
@@ -71,6 +71,37 @@ extension PeekabooAgentServiceTests {
 
     @Test
     @MainActor
+    func `Sonnet 5 and GPT-5_6 preserve current generation capabilities`() throws {
+        try self.withIsolatedAgentEnvironment(
+            [:],
+            configurationJSON: """
+            {
+              "agent": {
+                "maxTokens": 128000,
+                "temperature": 0.2
+              }
+            }
+            """) {
+                let agentService = try PeekabooAgentService(services: self.makeServices())
+                let sonnetSettings = agentService.generationSettings(for: .anthropic(.sonnet5))
+
+                #expect(sonnetSettings.maxTokens == 128_000)
+                #expect(sonnetSettings.temperature == 0.2)
+
+                for model in [
+                    LanguageModel.openai(.gpt56Sol),
+                    .openai(.gpt56Terra),
+                    .openai(.gpt56Luna),
+                ] {
+                    let settings = agentService.generationSettings(for: model)
+                    #expect(settings.maxTokens == 128_000)
+                    #expect(settings.providerOptions.openai?.verbosity == .medium)
+                }
+            }
+    }
+
+    @Test
+    @MainActor
     func `Generation settings clamp max tokens to provider capabilities`() throws {
         try self.withIsolatedAgentEnvironment(
             [:],

--- a/docs/commands/agent.md
+++ b/docs/commands/agent.md
@@ -16,7 +16,7 @@ read_when:
 | `--chat` | Force the interactive chat loop even when stdin/stdout are not TTYs. |
 | `--dry-run` | Emit the planned steps without actually invoking tools. |
 | `--max-steps <n>` | Cap how many tool invocations the agent may issue before aborting (default: 100). |
-| `--model gpt-5.5|claude-fable-5|gemini-3-flash|minimax|minimax-cn/<model>|openrouter/<provider>/<model>|ollama/<model>|lmstudio/<model>` | Override the default model (`gpt-5.5`). Input is validated against supported hosted providers and local model providers. |
+| `--model gpt-5.6|gpt-5.5|claude-fable-5|claude-sonnet-5|gemini-3-flash|minimax|minimax-cn/<model>|openrouter/<provider>/<model>|ollama/<model>|lmstudio/<model>` | Override the default model (`gpt-5.5`). Input is validated against supported hosted providers and local model providers. |
 | `--resume` / `--resume-session <id>` | Continue the most recent session or a specific session ID. |
 | `--list-sessions` | Print cached sessions (id, task, timestamps, message count) instead of running anything. |
 | `--no-cache` | Always create a fresh session even if one is already active. |
@@ -49,6 +49,12 @@ For automation flows that cannot attach to a TTY, pass both `--chat` and standar
 ```bash
 # Let the agent sign into Slack using GPT-5.5 with verbose tracing
 peekaboo agent "Check Slack mentions" --model gpt-5.5 --verbose
+
+# Use GPT-5.6 Sol (the gpt-5.6 shortcut selects Sol)
+peekaboo agent "Check the current window" --model gpt-5.6
+
+# Use Claude Sonnet 5
+peekaboo agent "Check the current window" --model claude-sonnet-5
 
 # Keep the agent loop local through Ollama
 peekaboo agent "Check the current window" --model ollama/llama3.3

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -16,10 +16,10 @@ Peekaboo's agent runtime is provider-agnostic — it talks to any chat-completio
 This table is the central reference for user-facing provider docs. Link here from architecture, install, and README
 pages instead of duplicating provider lists in multiple places.
 
-| Provider | Models we test | Credential |
+| Provider | Example model IDs | Credential |
 | --- | --- | --- |
-| **OpenAI** | gpt-5, gpt-5-mini, gpt-4.1 | `OPENAI_API_KEY` |
-| **Anthropic** | claude-fable-5, claude-opus-4-8, claude-sonnet-4-6, claude-haiku-4-5 | `ANTHROPIC_API_KEY` |
+| **OpenAI** | gpt-5.6-sol, gpt-5.6-terra, gpt-5.6-luna, gpt-5.5, gpt-5-mini, gpt-4.1 | `OPENAI_API_KEY` |
+| **Anthropic** | claude-fable-5, claude-sonnet-5, claude-opus-4-8, claude-sonnet-4-6, claude-haiku-4-5 | `ANTHROPIC_API_KEY` |
 | **xAI** | grok-4 | `XAI_API_KEY` |
 | **Google** | gemini-3.1-pro-preview, gemini-3-flash | `GEMINI_API_KEY` |
 | **MiniMax** | MiniMax-M3, MiniMax-M2.7, MiniMax-M2.7-highspeed | `MINIMAX_API_KEY` |
@@ -56,7 +56,10 @@ See [configuration.md](configuration.md) for the full precedence table.
 ## Picking a model
 
 ```bash
+peekaboo agent --model gpt-5.6 "summarize this window"
+peekaboo agent --model gpt-5.6-terra "summarize this window"
 peekaboo agent --model claude-fable-5 "summarize this window"
+peekaboo agent --model claude-sonnet-5 "summarize this window"
 peekaboo agent --model claude-opus-4-8 "summarize this window"
 peekaboo agent --model gemini-3-flash "summarize this window"
 peekaboo agent --model minimax/MiniMax-M3 "summarize this window"
@@ -68,15 +71,15 @@ peekaboo agent --model ollama/llama3.1:8b "describe this screenshot"
 peekaboo agent --model lmstudio/openai/gpt-oss-120b "summarize this window"
 ```
 
-Defaults come from `agent.defaultModel` in `~/.peekaboo/config.json`. Anthropic defaults stay on Opus 4.8 for zero-retention compatibility; select Fable explicitly when your Anthropic organization allows it. Set a per-project default with `PEEKABOO_AGENT_MODEL`.
+Defaults come from `agent.defaultModel` in `~/.peekaboo/config.json`. Anthropic defaults stay on Opus 4.8 for zero-retention compatibility; select Fable 5 or Sonnet 5 explicitly when your Anthropic organization allows it. Set a per-project default with `PEEKABOO_AGENT_MODEL`.
 
 The app and CLI share `agent.temperature` and `agent.maxTokens`. Peekaboo clamps those requests to provider
-capabilities; Fable supports a 1M context window and up to 128K output. See
+capabilities; Peekaboo currently catalogs Fable 5 and Sonnet 5 with 1M context windows and up to 128K output. See
 [configuration.md](configuration.md#agent-generation-settings).
 
 ## Tool calling
 
-The agent expects tool-calling capable models. If your provider doesn't support it (some tiny local models), Peekaboo falls back to a structured-output prompt — slower and less reliable. Stick with mainstream tool-calling models for production runs.
+The agent requires a tool-calling capable model. If the selected model does not support tools, Peekaboo rejects it and points to `peekaboo image --analyze` / `see --analyze` for vision-only use. Choose a tool-capable model for agent runs.
 
 ## Local-only mode
 

--- a/docs/providers/README.md
+++ b/docs/providers/README.md
@@ -8,7 +8,7 @@ read_when:
 # Providers index
 
 - **OpenAI** — `openai.md`: architecture, migration status, and guidance for adding models.
-- **Anthropic** — `anthropic.md`: Fable/Claude models, output limits, generation settings, and credentials.
+- **Anthropic** — `anthropic.md`: Fable 5, Sonnet 5, and other Claude models, output limits, generation settings, and credentials.
 - **Google** — configured with `GEMINI_API_KEY`; supports Gemini 3.1 Pro Preview and Gemini 3 Flash.
 - **MiniMax** — configured with `MINIMAX_API_KEY`; supports MiniMax M3 and M2.7 through the Anthropic-compatible API.
 - **MiniMax China** — use `minimax-cn/...` with `MINIMAX_CN_API_KEY` or the shared `MINIMAX_API_KEY`; routes to `api.minimaxi.com`.
@@ -24,7 +24,7 @@ configuration syntax, and environment variable reference.
 | Provider | Tools | Vision | Streaming | Local/offline | Auth |
 | --- | --- | --- | --- | --- | --- |
 | OpenAI | Yes (function/tool calling) | Yes | Yes | No | API key or OAuth |
-| Anthropic | Yes | Yes | Model-dependent; Fable/Opus 4.8 currently non-streaming | No | API key or OAuth (Claude Pro/Max) |
+| Anthropic | Yes | Yes | Model-dependent; Fable 5, Sonnet 5, and Opus 4.8 currently non-streaming | No | API key or OAuth (Claude Pro/Max) |
 | Google | Yes | Yes | Yes | No | API key |
 | MiniMax | Yes | Model-dependent | Yes | No | API key |
 | MiniMax China | Yes | Model-dependent | Yes | No | API key |

--- a/docs/providers/anthropic.md
+++ b/docs/providers/anthropic.md
@@ -15,14 +15,17 @@ tool calls, vision, thinking blocks, and provider-specific event handling.
 | Model | Context | Max output | Notes |
 | --- | ---: | ---: | --- |
 | `claude-fable-5` | 1M | 128K | Explicit opt-in for long-horizon agent work. |
+| `claude-sonnet-5` | 1M | 128K | Explicit opt-in; not the automatic Anthropic default. |
 | `claude-opus-4-8` | 1M | 128K | Default Anthropic choice; compatible with zero-retention organizations. |
 | `claude-sonnet-4-6` | 1M | 64K | Balanced speed and capability. |
 | `claude-haiku-4-5` | 200K | 64K | Fast, lower-cost tasks. |
 
-Fable is not the automatic Anthropic default. Select it explicitly when your Anthropic organization allows the model:
+Fable 5 and Sonnet 5 are not the automatic Anthropic default. Select either explicitly when your Anthropic
+organization allows the model:
 
 ```bash
 peekaboo agent --model claude-fable-5 "inspect this app and summarize its workflow"
+peekaboo agent --model claude-sonnet-5 "inspect this app and summarize its workflow"
 ```
 
 ## Credentials
@@ -46,12 +49,13 @@ The app and CLI read the same `agent.temperature` and `agent.maxTokens` values f
 `~/.peekaboo/config.json`. Peekaboo clamps the token request to the selected model's output capability and strips
 sampling parameters from current adaptive-thinking models when the Anthropic API does not accept them.
 
-Fable and Opus 4.8 currently use the non-streaming generation path so signed thinking history and rollback behavior
-remain valid. Agent progress events still report start, assistant output, tool activity, completion, and errors.
+Fable 5, Sonnet 5, and Opus 4.8 currently use the non-streaming generation path so signed thinking history and
+rollback behavior remain valid. Agent progress events still report start, assistant output, tool activity, completion,
+and errors.
 
-Anthropic-compatible custom providers inherit known Fable capability limits when their model ID is
-`claude-fable-5` (including provider-qualified forms). A custom model's explicit `maxTokens` value takes precedence
-for other IDs.
+Anthropic-compatible custom providers inherit known Fable 5 and Sonnet 5 capability limits when their model ID is
+`claude-fable-5` or `claude-sonnet-5` (including provider-qualified forms). A custom model's explicit `maxTokens`
+value takes precedence for other IDs.
 
 See [configuration.md](../configuration.md) for the shared settings schema and [providers.md](../providers.md) for
 the full provider catalog.


### PR DESCRIPTION
## Summary

- complete the GPT-5.6 generation policy for native, OpenRouter, Together, OpenAI-compatible, and configured custom-provider routes
- expose GPT-5.6 Sol/Terra/Luna and Claude Sonnet 5 consistently in the Mac assistant pickers, Settings, rendered CLI help, and provider docs
- bump Tachikoma to openclaw/Tachikoma#35 so suffixed routing variants retain their capability inference without rewriting the requested model ID

## Why

#247 restored the native model identifiers and output limits, but the earlier compatible-route sampling policy, custom-provider limits, and Mac selection surfaces remained absent. As a result, compatible GPT-5.6 routes could keep unsupported temperature, clamp output to 4K, or report only 128K context.

## Proof

- `swift test --package-path Core/PeekabooCore --filter PeekabooAgentGenerationSettingsTests --no-parallel` (7 tests)
- targeted native GPT-5.6/Sonnet capability test (1 test)
- `PEEKABOO_INCLUDE_AUTOMATION_TESTS=true swift test --package-path Apps/CLI --filter AgentCommandBasicTests --no-parallel` (2 tests, including rendered help)
- Mac SwiftPM suites: `ConversationSessionTests` (5 tests) and `PeekabooSettingsConfigHydrationTests` (30 tests)
- `pnpm run test:safe` (707 tests)
- `pnpm run lint:docs`
- `pnpm run format`
- autoreview: clean, no actionable findings (0.86 confidence)
