### PR TITLE
fix(cli): map clickFailed/typeFailed to INTERACTION_FAILED

### DIFF
--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Base/CommandErrorHandling.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Base/CommandErrorHandling.swift
@@ -145,14 +145,7 @@ extension ErrorHandlingCommand {
     }
 
     private func automationErrorCode(for error: PeekabooError) -> ErrorCode? {
-        switch error {
-        case .captureFailed, .clickFailed, .typeFailed:
-            .CAPTURE_FAILED
-        case .serviceUnavailable, .networkError, .apiError, .commandFailed, .encodingError:
-            .UNKNOWN_ERROR
-        default:
-            nil
-        }
+        peekabooAutomationErrorCode(for: error)
     }
 
     private func inputErrorCode(for error: PeekabooError) -> ErrorCode? {
@@ -222,6 +215,20 @@ extension ErrorHandlingCommand {
 
     private func mapFocusErrorToCode(_ error: FocusError) -> ErrorCode {
         errorCode(for: error)
+    }
+}
+
+
+func peekabooAutomationErrorCode(for error: PeekabooError) -> ErrorCode? {
+    switch error {
+    case .captureFailed:
+        .CAPTURE_FAILED
+    case .clickFailed, .typeFailed:
+        .INTERACTION_FAILED
+    case .serviceUnavailable, .networkError, .apiError, .commandFailed, .encodingError:
+        .UNKNOWN_ERROR
+    default:
+        nil
     }
 }
 

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Base/CommandErrorHandling.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Base/CommandErrorHandling.swift
@@ -218,7 +218,6 @@ extension ErrorHandlingCommand {
     }
 }
 
-
 func peekabooAutomationErrorCode(for error: PeekabooError) -> ErrorCode? {
     switch error {
     case .captureFailed:

--- a/Apps/CLI/Tests/CoreCLITests/ErrorHandlingTests.swift
+++ b/Apps/CLI/Tests/CoreCLITests/ErrorHandlingTests.swift
@@ -92,4 +92,19 @@ struct FocusErrorMappingTests {
         let code = errorCode(for: POSIXError(.ETIMEDOUT))
         #expect(code == .TIMEOUT)
     }
+
+    @Test
+    func `clickFailed maps to INTERACTION_FAILED`() {
+        #expect(peekabooAutomationErrorCode(for: .clickFailed("miss")) == .INTERACTION_FAILED)
+    }
+
+    @Test
+    func `typeFailed maps to INTERACTION_FAILED`() {
+        #expect(peekabooAutomationErrorCode(for: .typeFailed("stuck")) == .INTERACTION_FAILED)
+    }
+
+    @Test
+    func `captureFailed maps to CAPTURE_FAILED`() {
+        #expect(peekabooAutomationErrorCode(for: .captureFailed("cam")) == .CAPTURE_FAILED)
+    }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - The accessibility element boxes drawn during `peekaboo see` are off by default now; they were visual clutter on every capture. Re-enable them in Peekaboo.app under Settings › Visualizer › Screen › Element boxes, by setting `visualizer.elementDetectionEnabled` in `~/.peekaboo/config.json`, or per-run with `PEEKABOO_VISUAL_ELEMENT_BOXES=true`. The app toggle and the config file now stay in sync, and a running MCP server picks up the change without a restart.
 
 ### Fixed
+- Click and type failures now emit `INTERACTION_FAILED` instead of `CAPTURE_FAILED` in structured CLI output. Thanks @SebTardif for #257.
 - The Mac app's status bar menu now follows the system light/dark mode. It previously inherited the menu bar's wallpaper-derived vibrant appearance, which could render a dark menu while the system was in light mode (and vice versa).
 - Resuming an agent session without an explicit model now preserves its credential-free provider-qualified model selection instead of silently switching to the current default and potentially sending saved context to a different provider; ambiguous legacy sessions fail closed and require an explicit override, automatic taskless piped resumes report failed turns with a nonzero exit, and chat headers show a credential-free saved-model label instead of claiming the current default.
 - Agent tool execution now treats provider terminal events and cancellation as hard boundaries: late or truncated tool calls cannot run, canceled or skipped calls emit failed completions, and final `done` / `need_info` reasons remain visible.


### PR DESCRIPTION
## Summary

`PeekabooError.clickFailed` and `.typeFailed` were mapped to `CAPTURE_FAILED` in CLI error handling. That code is for screen capture failures; click/type are interaction failures and already have `INTERACTION_FAILED` (used by menu/dock/visualizer paths).

## Change

- `captureFailed` → `CAPTURE_FAILED`
- `clickFailed`, `typeFailed` → `INTERACTION_FAILED`
- Extract `peekabooAutomationErrorCode(for:)` for unit tests

## Validation

```
DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer \
  swift test --package-path Apps/CLI --filter ErrorHandling
# 13 tests passed, including:
#   clickFailed maps to INTERACTION_FAILED
#   typeFailed maps to INTERACTION_FAILED
#   captureFailed maps to CAPTURE_FAILED
```

## Real behavior proof

**Command:** `swift test --package-path Apps/CLI --filter ErrorHandling`
**Input:** unit cases for clickFailed / typeFailed / captureFailed
**Output:** codes INTERACTION_FAILED, INTERACTION_FAILED, CAPTURE_FAILED
**Exit code:** 0
**Duration:** ~80s build + <1s tests
**Commit:** HEAD of this PR

## Related

- Menu/dock already emit `.INTERACTION_FAILED`
- Standardized code: `StandardizedErrors.interactionFailed`