### PR TITLE
fix(bridge): map notFound kinds and surface actionable messages

### DIFF
--- a/Apps/CLI/Sources/PeekabooCLI/CLI/Utilities/ErrorHandling.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/CLI/Utilities/ErrorHandling.swift
@@ -1,4 +1,5 @@
 import Foundation
+import PeekabooBridge
 import PeekabooCore
 import PeekabooFoundation
 
@@ -31,10 +32,17 @@ private func emitError(
 func handleGenericError(_ error: any Error, jsonOutput: Bool, logger: Logger) {
     emitError(
         message: error.localizedDescription,
-        code: .UNKNOWN_ERROR,
+        code: genericErrorCode(for: error),
         jsonOutput: jsonOutput,
         logger: logger
     )
+}
+
+func genericErrorCode(for error: any Error) -> ErrorCode {
+    guard let bridgeError = error as? PeekabooBridgeErrorEnvelope else {
+        return .UNKNOWN_ERROR
+    }
+    return errorCode(for: bridgeError)
 }
 
 func handleValidationError(_ error: any Error, jsonOutput: Bool, logger: Logger) {

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Base/CommandErrorHandling.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Base/CommandErrorHandling.swift
@@ -273,7 +273,11 @@ func errorCode(for focusError: FocusError) -> ErrorCode {
 }
 
 func errorCode(for bridgeError: PeekabooBridgeErrorEnvelope) -> ErrorCode {
-    switch bridgeError.code {
+    if let kind = bridgeError.kind {
+        return errorCode(for: kind)
+    }
+
+    return switch bridgeError.code {
     case .permissionDenied:
         switch bridgeError.permission {
         case .screenRecording:
@@ -294,21 +298,36 @@ func errorCode(for bridgeError: PeekabooBridgeErrorEnvelope) -> ErrorCode {
     case .operationNotSupported:
         .VALIDATION_ERROR
     case .notFound:
-        switch bridgeError.kind {
-        case .elementNotFound:
-            .ELEMENT_NOT_FOUND
-        case .snapshotNotFound:
-            .SNAPSHOT_NOT_FOUND
-        case .snapshotStale:
-            .SNAPSHOT_STALE
-        case .none:
-            // Unkinded notFound is commonly app/window/element misses.
-            // Prefer ELEMENT_NOT_FOUND over opaque UNKNOWN_ERROR; launch paths
-            // still override via applicationLaunchErrorCode → APP_NOT_FOUND.
-            .ELEMENT_NOT_FOUND
-        }
+        .UNKNOWN_ERROR
     case .versionMismatch, .unauthorizedClient, .decodingFailed, .internalError, .serverBusy:
         .UNKNOWN_ERROR
+    }
+}
+
+private func errorCode(for bridgeErrorKind: PeekabooBridgeErrorKind) -> ErrorCode {
+    switch bridgeErrorKind {
+    case .appNotFound:
+        .APP_NOT_FOUND
+    case .windowNotFound:
+        .WINDOW_NOT_FOUND
+    case .elementNotFound:
+        .ELEMENT_NOT_FOUND
+    case .menuNotFound:
+        .MENU_BAR_NOT_FOUND
+    case .menuItemNotFound:
+        .MENU_ITEM_NOT_FOUND
+    case .dockNotFound:
+        .DOCK_NOT_FOUND
+    case .dockListNotFound:
+        .DOCK_LIST_NOT_FOUND
+    case .dockItemNotFound:
+        .DOCK_ITEM_NOT_FOUND
+    case .positionNotFound:
+        .POSITION_NOT_FOUND
+    case .snapshotNotFound:
+        .SNAPSHOT_NOT_FOUND
+    case .snapshotStale:
+        .SNAPSHOT_STALE
     }
 }
 

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Base/CommandErrorHandling.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Base/CommandErrorHandling.swift
@@ -294,7 +294,19 @@ func errorCode(for bridgeError: PeekabooBridgeErrorEnvelope) -> ErrorCode {
     case .operationNotSupported:
         .VALIDATION_ERROR
     case .notFound:
-        .UNKNOWN_ERROR
+        switch bridgeError.kind {
+        case .elementNotFound:
+            .ELEMENT_NOT_FOUND
+        case .snapshotNotFound:
+            .SNAPSHOT_NOT_FOUND
+        case .snapshotStale:
+            .SNAPSHOT_STALE
+        case .none:
+            // Unkinded notFound is commonly app/window/element misses.
+            // Prefer ELEMENT_NOT_FOUND over opaque UNKNOWN_ERROR; launch paths
+            // still override via applicationLaunchErrorCode → APP_NOT_FOUND.
+            .ELEMENT_NOT_FOUND
+        }
     case .versionMismatch, .unauthorizedClient, .decodingFailed, .internalError, .serverBusy:
         .UNKNOWN_ERROR
     }

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/System/MenuCommand+Output.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/System/MenuCommand+Output.swift
@@ -139,7 +139,7 @@ enum MenuErrorOutputSupport {
         if jsonOutput {
             outputError(
                 message: error.localizedDescription,
-                code: .UNKNOWN_ERROR,
+                code: genericErrorCode(for: error),
                 details: details,
                 logger: logger
             )

--- a/Apps/CLI/Tests/CoreCLITests/ErrorHandlingTests.swift
+++ b/Apps/CLI/Tests/CoreCLITests/ErrorHandlingTests.swift
@@ -92,7 +92,6 @@ struct FocusErrorMappingTests {
         let code = errorCode(for: POSIXError(.ETIMEDOUT))
         #expect(code == .TIMEOUT)
     }
-
     @Test
     func `clickFailed maps to INTERACTION_FAILED`() {
         #expect(peekabooAutomationErrorCode(for: .clickFailed("miss")) == .INTERACTION_FAILED)
@@ -106,5 +105,33 @@ struct FocusErrorMappingTests {
     @Test
     func `captureFailed maps to CAPTURE_FAILED`() {
         #expect(peekabooAutomationErrorCode(for: .captureFailed("cam")) == .CAPTURE_FAILED)
+    }
+
+    @Test
+    func `bridge elementNotFound kind maps to ELEMENT_NOT_FOUND`() {
+        let envelope = PeekabooBridgeErrorEnvelope(
+            code: .notFound,
+            message: "No element",
+            kind: .elementNotFound,
+            context: "btn-1"
+        )
+        #expect(errorCode(for: envelope) == .ELEMENT_NOT_FOUND)
+    }
+
+    @Test
+    func `bridge snapshotNotFound kind maps to SNAPSHOT_NOT_FOUND`() {
+        let envelope = PeekabooBridgeErrorEnvelope(
+            code: .notFound,
+            message: "Snapshot expired",
+            kind: .snapshotNotFound,
+            context: "snap-1"
+        )
+        #expect(errorCode(for: envelope) == .SNAPSHOT_NOT_FOUND)
+    }
+
+    @Test
+    func `bridge unkinded notFound maps to UNKNOWN_ERROR`() {
+        let envelope = PeekabooBridgeErrorEnvelope(code: .notFound, message: "Dock item not found")
+        #expect(errorCode(for: envelope) == .UNKNOWN_ERROR)
     }
 }

--- a/Apps/CLI/Tests/CoreCLITests/ErrorHandlingTests.swift
+++ b/Apps/CLI/Tests/CoreCLITests/ErrorHandlingTests.swift
@@ -92,6 +92,7 @@ struct FocusErrorMappingTests {
         let code = errorCode(for: POSIXError(.ETIMEDOUT))
         #expect(code == .TIMEOUT)
     }
+
     @Test
     func `clickFailed maps to INTERACTION_FAILED`() {
         #expect(peekabooAutomationErrorCode(for: .clickFailed("miss")) == .INTERACTION_FAILED)
@@ -119,14 +120,34 @@ struct FocusErrorMappingTests {
     }
 
     @Test
-    func `bridge snapshotNotFound kind maps to SNAPSHOT_NOT_FOUND`() {
+    func `bridge typed notFound kinds map to specific errors`() {
+        let cases: [(PeekabooBridgeErrorKind, ErrorCode)] = [
+            (.appNotFound, .APP_NOT_FOUND),
+            (.windowNotFound, .WINDOW_NOT_FOUND),
+            (.elementNotFound, .ELEMENT_NOT_FOUND),
+            (.menuNotFound, .MENU_BAR_NOT_FOUND),
+            (.menuItemNotFound, .MENU_ITEM_NOT_FOUND),
+            (.dockNotFound, .DOCK_NOT_FOUND),
+            (.dockListNotFound, .DOCK_LIST_NOT_FOUND),
+            (.dockItemNotFound, .DOCK_ITEM_NOT_FOUND),
+            (.positionNotFound, .POSITION_NOT_FOUND),
+            (.snapshotNotFound, .SNAPSHOT_NOT_FOUND),
+        ]
+        for (kind, expectedCode) in cases {
+            let envelope = PeekabooBridgeErrorEnvelope(code: .notFound, message: "Missing", kind: kind)
+            #expect(errorCode(for: envelope) == expectedCode)
+        }
+    }
+
+    @Test
+    func `bridge stale kind wins over invalidRequest transport code`() {
         let envelope = PeekabooBridgeErrorEnvelope(
-            code: .notFound,
-            message: "Snapshot expired",
-            kind: .snapshotNotFound,
+            code: .invalidRequest,
+            message: "Snapshot stale",
+            kind: .snapshotStale,
             context: "snap-1"
         )
-        #expect(errorCode(for: envelope) == .SNAPSHOT_NOT_FOUND)
+        #expect(errorCode(for: envelope) == .SNAPSHOT_STALE)
     }
 
     @Test

--- a/Apps/CLI/Tests/CoreCLITests/ErrorHandlingTests.swift
+++ b/Apps/CLI/Tests/CoreCLITests/ErrorHandlingTests.swift
@@ -155,4 +155,16 @@ struct FocusErrorMappingTests {
         let envelope = PeekabooBridgeErrorEnvelope(code: .notFound, message: "Dock item not found")
         #expect(errorCode(for: envelope) == .UNKNOWN_ERROR)
     }
+
+    @Test
+    func `generic command errors preserve bridge lookup kinds`() {
+        let envelope = PeekabooBridgeErrorEnvelope(
+            code: .notFound,
+            message: "Dock item not found",
+            kind: .dockItemNotFound
+        )
+
+        #expect(genericErrorCode(for: envelope) == .DOCK_ITEM_NOT_FOUND)
+        #expect(genericErrorCode(for: POSIXError(.ENOENT)) == .UNKNOWN_ERROR)
+    }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - The accessibility element boxes drawn during `peekaboo see` are off by default now; they were visual clutter on every capture. Re-enable them in Peekaboo.app under Settings › Visualizer › Screen › Element boxes, by setting `visualizer.elementDetectionEnabled` in `~/.peekaboo/config.json`, or per-run with `PEEKABOO_VISUAL_ELEMENT_BOXES=true`. The app toggle and the config file now stay in sync, and a running MCP server picks up the change without a restart.
 
 ### Fixed
+- Bridge-backed CLI commands now preserve app, window, element, menu, Dock, and snapshot lookup identities in structured errors instead of collapsing them to generic failures. Thanks @SebTardif for #258.
 - Click and type failures now emit `INTERACTION_FAILED` instead of `CAPTURE_FAILED` in structured CLI output. Thanks @SebTardif for #257.
 - The Mac app's status bar menu now follows the system light/dark mode. It previously inherited the menu bar's wallpaper-derived vibrant appearance, which could render a dark menu while the system was in light mode (and vice versa).
 - Resuming an agent session without an explicit model now preserves its credential-free provider-qualified model selection instead of silently switching to the current default and potentially sending saved context to a different provider; ambiguous legacy sessions fail closed and require an explicit override, automatic taskless piped resumes report failed turns with a nonzero exit, and chat headers show a credential-free saved-model label instead of claiming the current default.

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/DockService+Actions.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/DockService+Actions.swift
@@ -195,14 +195,13 @@ extension DockService {
         usleep(50000)
 
         if let targetMenuItem = menuItem {
-            try await self.clickContextMenuItem(targetMenuItem, for: element, fallbackName: appName)
+            try await self.clickContextMenuItem(targetMenuItem, for: element)
         }
     }
 
     private func clickContextMenuItem(
         _ targetMenuItem: String,
-        for dockElement: Element,
-        fallbackName: String) async throws
+        for dockElement: Element) async throws
     {
         try await Task.sleep(nanoseconds: 300_000_000)
 
@@ -215,7 +214,7 @@ extension DockService {
         }
 
         guard let foundMenu = menu else {
-            throw PeekabooError.menuNotFound("\(fallbackName)")
+            throw DockError.menuItemNotFound(targetMenuItem)
         }
 
         let menuItems = foundMenu.children() ?? []
@@ -223,7 +222,7 @@ extension DockService {
             item.title() == targetMenuItem ||
                 item.title()?.contains(targetMenuItem) == true
         }) else {
-            throw PeekabooError.menuNotFound("\(targetMenuItem)")
+            throw DockError.menuItemNotFound(targetMenuItem)
         }
 
         try targetItem.performAction(.press)

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/DockService+Items.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/DockService+Items.swift
@@ -52,7 +52,7 @@ extension DockService {
             return partialMatches[0]
         }
 
-        throw PeekabooError.elementNotFound("\(name)")
+        throw DockError.itemNotFound(name)
     }
 
     private func makeDockItem(from element: Element, index: Int, includeAll: Bool) -> DockItem? {

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/DockService.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/DockService.swift
@@ -4,7 +4,7 @@ import os
 import PeekabooFoundation
 
 /// Dock-specific errors
-public enum DockError: Error {
+public enum DockError: LocalizedError {
     case dockNotFound
     case dockListNotFound
     case itemNotFound(String)
@@ -12,6 +12,25 @@ public enum DockError: Error {
     case positionNotFound
     case launchFailed(String)
     case scriptError(String)
+
+    public var errorDescription: String? {
+        switch self {
+        case .dockNotFound:
+            "Dock not found"
+        case .dockListNotFound:
+            "Dock list not found"
+        case let .itemNotFound(name):
+            "Dock item not found: \(name)"
+        case let .menuItemNotFound(name):
+            "Dock menu item not found: \(name)"
+        case .positionNotFound:
+            "Dock item position not found"
+        case let .launchFailed(message):
+            "Failed to launch Dock item: \(message)"
+        case let .scriptError(message):
+            "Dock script failed: \(message)"
+        }
+    }
 }
 
 /// Default implementation of Dock interaction operations using AXorcist

--- a/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeModels.swift
+++ b/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeModels.swift
@@ -295,7 +295,15 @@ public enum PeekabooBridgeErrorCode: String, Codable, Sendable {
 }
 
 public enum PeekabooBridgeErrorKind: String, Codable, Sendable {
+    case appNotFound
+    case windowNotFound
     case elementNotFound
+    case menuNotFound
+    case menuItemNotFound
+    case dockNotFound
+    case dockListNotFound
+    case dockItemNotFound
+    case positionNotFound
     case snapshotNotFound
     case snapshotStale
 }

--- a/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeServer.swift
+++ b/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeServer.swift
@@ -160,76 +160,119 @@ public final class PeekabooBridgeServer {
                 "bridge op=\(op.rawValue) pid=\(pid) failed in \(durationString)s: \(error.localizedDescription)"
             self.logger.error("\(message, privacy: .public)")
 
-            if let error = error as? PeekabooError {
-                switch error {
-                case let .invalidInput(message):
-                    throw PeekabooBridgeErrorEnvelope(
-                        code: .invalidRequest,
-                        message: message,
-                        details: "\(error)")
-                case .permissionDeniedAccessibility, .permissionDeniedScreenRecording,
-                     .permissionDeniedEventSynthesizing:
-                    throw PeekabooBridgeErrorEnvelope(
-                        code: .permissionDenied,
-                        message: error.localizedDescription,
-                        details: "\(error)",
-                        permission: Self.bridgePermission(for: error))
-                case let .serviceUnavailable(message):
-                    throw PeekabooBridgeErrorEnvelope(
-                        code: .operationNotSupported,
-                        message: message,
-                        details: "\(error)")
-                case let .notImplemented(message):
-                    throw PeekabooBridgeErrorEnvelope(
-                        code: .operationNotSupported,
-                        message: "Operation \(op.rawValue) is not supported: \(message)",
-                        details: "\(error)")
-                case .appNotFound, .notFound:
-                    throw PeekabooBridgeErrorEnvelope(
-                        code: .notFound,
-                        message: error.localizedDescription,
-                        details: "\(error)")
-                case let .elementNotFound(identifier):
-                    throw PeekabooBridgeErrorEnvelope(
-                        code: .notFound,
-                        message: error.localizedDescription,
-                        details: "\(error)",
-                        kind: .elementNotFound,
-                        context: identifier)
-                case let .snapshotNotFound(snapshotId):
-                    throw PeekabooBridgeErrorEnvelope(
-                        code: .notFound,
-                        message: error.localizedDescription,
-                        details: "\(error)",
-                        kind: .snapshotNotFound,
-                        context: snapshotId)
-                case let .snapshotStale(reason):
-                    throw PeekabooBridgeErrorEnvelope(
-                        code: .invalidRequest,
-                        message: error.localizedDescription,
-                        details: "\(error)",
-                        kind: .snapshotStale,
-                        context: reason)
-                case .timeout, .captureTimeout:
-                    throw PeekabooBridgeErrorEnvelope(
-                        code: .timeout,
-                        message: error.localizedDescription,
-                        details: "\(error)")
-                default:
-                    break
-                }
-            }
-
-            // Prefer the underlying error description so CLI clients do not only
-            // see a generic "Bridge operation failed" with the real text buried
-            // in details (see openclaw/Peekaboo#239).
-            let userMessage =
-                (error as? any LocalizedError)?.errorDescription ?? error.localizedDescription
-            throw PeekabooBridgeErrorEnvelope(
-                code: .internalError,
-                message: userMessage.isEmpty ? "Bridge operation failed" : userMessage,
-                details: "\(error)")
+            throw Self.bridgeErrorEnvelope(for: error, operation: op)
         }
+    }
+
+    static func bridgeErrorEnvelope(
+        for error: any Error,
+        operation: PeekabooBridgeOperation) -> PeekabooBridgeErrorEnvelope
+    {
+        if let error = error as? PeekabooError,
+           let envelope = bridgeErrorEnvelope(for: error, operation: operation)
+        {
+            return envelope
+        }
+
+        if let error = error as? DockError {
+            let kind: PeekabooBridgeErrorKind?
+            let context: String?
+            switch error {
+            case .dockNotFound:
+                (kind, context) = (.dockNotFound, nil)
+            case .dockListNotFound:
+                (kind, context) = (.dockListNotFound, nil)
+            case let .itemNotFound(name):
+                (kind, context) = (.dockItemNotFound, name)
+            case let .menuItemNotFound(name):
+                (kind, context) = (.menuItemNotFound, name)
+            case .positionNotFound:
+                (kind, context) = (.positionNotFound, nil)
+            case .launchFailed, .scriptError:
+                (kind, context) = (nil, nil)
+            }
+            if let kind {
+                return .init(
+                    code: .notFound,
+                    message: error.localizedDescription,
+                    details: "\(error)",
+                    kind: kind,
+                    context: context)
+            }
+        }
+
+        // Prefer the underlying error description so CLI clients do not only
+        // see a generic message with the real text buried in details.
+        let userMessage = (error as? any LocalizedError)?.errorDescription ?? error.localizedDescription
+        return .init(
+            code: .internalError,
+            message: userMessage.isEmpty ? "Bridge operation failed" : userMessage,
+            details: "\(error)")
+    }
+
+    private static func bridgeErrorEnvelope(
+        for error: PeekabooError,
+        operation: PeekabooBridgeOperation) -> PeekabooBridgeErrorEnvelope?
+    {
+        let details = "\(error)"
+        return switch error {
+        case let .invalidInput(message):
+            .init(code: .invalidRequest, message: message, details: details)
+        case .permissionDeniedAccessibility, .permissionDeniedScreenRecording,
+             .permissionDeniedEventSynthesizing:
+            .init(
+                code: .permissionDenied,
+                message: error.localizedDescription,
+                details: details,
+                permission: Self.bridgePermission(for: error))
+        case let .serviceUnavailable(message):
+            .init(code: .operationNotSupported, message: message, details: details)
+        case let .notImplemented(message):
+            .init(
+                code: .operationNotSupported,
+                message: "Operation \(operation.rawValue) is not supported: \(message)",
+                details: details)
+        case let .appNotFound(name):
+            Self.notFoundEnvelope(error, kind: .appNotFound, context: name)
+        case let .windowNotFound(criteria):
+            Self.notFoundEnvelope(error, kind: .windowNotFound, context: criteria)
+        case let .elementNotFound(identifier):
+            Self.notFoundEnvelope(error, kind: .elementNotFound, context: identifier)
+        case let .menuNotFound(app):
+            Self.notFoundEnvelope(error, kind: .menuNotFound, context: app)
+        case let .menuItemNotFound(item):
+            Self.notFoundEnvelope(error, kind: .menuItemNotFound, context: item)
+        case let .snapshotNotFound(snapshotId):
+            Self.notFoundEnvelope(error, kind: .snapshotNotFound, context: snapshotId)
+        case let .snapshotNotAvailable(message):
+            Self.notFoundEnvelope(error, kind: .snapshotNotFound, context: message)
+        case let .snapshotStale(reason):
+            .init(
+                code: .invalidRequest,
+                message: error.localizedDescription,
+                details: details,
+                kind: .snapshotStale,
+                context: reason)
+        case .notFound:
+            .init(code: .notFound, message: error.localizedDescription, details: details)
+        case .timeout, .captureTimeout:
+            .init(code: .timeout, message: error.localizedDescription, details: details)
+        default:
+            nil
+        }
+    }
+
+    private static func notFoundEnvelope(
+        _ error: PeekabooError,
+        kind: PeekabooBridgeErrorKind,
+        context: String?) -> PeekabooBridgeErrorEnvelope
+    {
+        .init(
+            code: .notFound,
+            message: error.localizedDescription,
+            details: "\(error)",
+            kind: kind,
+            context: context)
     }
 
     private func validatePeerAuthorization(_ peer: PeekabooBridgePeer?) throws {

--- a/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeServer.swift
+++ b/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeServer.swift
@@ -173,6 +173,11 @@ public final class PeekabooBridgeServer {
         {
             return envelope
         }
+        if let error = error as? NotFoundError,
+           let envelope = bridgeErrorEnvelope(for: error.asPeekabooError, operation: operation)
+        {
+            return envelope
+        }
 
         if let error = error as? DockError {
             let kind: PeekabooBridgeErrorKind?

--- a/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeServer.swift
+++ b/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeServer.swift
@@ -174,7 +174,7 @@ public final class PeekabooBridgeServer {
             return envelope
         }
         if let error = error as? NotFoundError,
-           let envelope = bridgeErrorEnvelope(for: error.asPeekabooError, operation: operation)
+           let envelope = bridgeErrorEnvelope(for: error, operation: operation)
         {
             return envelope
         }
@@ -213,6 +213,27 @@ public final class PeekabooBridgeServer {
             code: .internalError,
             message: userMessage.isEmpty ? "Bridge operation failed" : userMessage,
             details: "\(error)")
+    }
+
+    private static func bridgeErrorEnvelope(
+        for error: NotFoundError,
+        operation: PeekabooBridgeOperation) -> PeekabooBridgeErrorEnvelope?
+    {
+        if error.code == .menuNotFound {
+            let itemContext = error.context["menuItem"]
+                ?? error.context["item"]
+                ?? error.context["submenu"]
+                ?? error.context["menuExtra"]
+            if itemContext != nil || error.context["availableItems"] != nil {
+                return .init(
+                    code: .notFound,
+                    message: error.userMessage,
+                    details: "\(error)",
+                    kind: .menuItemNotFound,
+                    context: itemContext)
+            }
+        }
+        return self.bridgeErrorEnvelope(for: error.asPeekabooError, operation: operation)
     }
 
     private static func bridgeErrorEnvelope(

--- a/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeServer.swift
+++ b/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeServer.swift
@@ -220,9 +220,14 @@ public final class PeekabooBridgeServer {
                 }
             }
 
+            // Prefer the underlying error description so CLI clients do not only
+            // see a generic "Bridge operation failed" with the real text buried
+            // in details (see openclaw/Peekaboo#239).
+            let userMessage =
+                (error as? any LocalizedError)?.errorDescription ?? error.localizedDescription
             throw PeekabooBridgeErrorEnvelope(
                 code: .internalError,
-                message: "Bridge operation failed",
+                message: userMessage.isEmpty ? "Bridge operation failed" : userMessage,
                 details: "\(error)")
         }
     }

--- a/Core/PeekabooCore/Sources/PeekabooCore/Support/RemoteUIAutomationService.swift
+++ b/Core/PeekabooCore/Sources/PeekabooCore/Support/RemoteUIAutomationService.swift
@@ -257,6 +257,9 @@ public class RemoteUIAutomationService: DetectElementsRequestTimeoutAdjusting, T
             return PeekabooError.snapshotNotFound(envelope.context ?? snapshotId ?? envelope.message)
         case .snapshotStale:
             return PeekabooError.snapshotStale(envelope.context ?? envelope.message)
+        case .appNotFound, .windowNotFound, .menuNotFound, .menuItemNotFound,
+             .dockNotFound, .dockListNotFound, .dockItemNotFound, .positionNotFound:
+            break
         case nil:
             break
         }

--- a/Core/PeekabooCore/Tests/PeekabooTests/PeekabooBridgeCapabilityTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/PeekabooBridgeCapabilityTests.swift
@@ -37,6 +37,21 @@ struct PeekabooBridgeCapabilityTests {
     }
 
     @Test
+    @MainActor
+    func `production bridge classifier converts legacy lookup errors`() {
+        let error = NotFoundError(
+            code: .menuNotFound,
+            userMessage: "Menu not found",
+            context: ["application": "Finder"])
+
+        let envelope = PeekabooBridgeServer.bridgeErrorEnvelope(for: error, operation: .listMenus)
+
+        #expect(envelope.code == .notFound)
+        #expect(envelope.kind == .menuNotFound)
+        #expect(envelope.context == "Finder")
+    }
+
+    @Test
     func `unknown bridge error kinds decode as untyped errors`() throws {
         let data = Data(
             #"{"code":"invalidRequest","message":"Future error","kind":"futureErrorKind","context":"S1"}"#.utf8)

--- a/Core/PeekabooCore/Tests/PeekabooTests/PeekabooBridgeCapabilityTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/PeekabooBridgeCapabilityTests.swift
@@ -6,6 +6,37 @@ import Testing
 
 struct PeekabooBridgeCapabilityTests {
     @Test
+    @MainActor
+    func `production bridge classifier preserves lookup identity`() {
+        let cases: [(PeekabooError, PeekabooBridgeErrorKind, String?)] = [
+            (.appNotFound("Safari"), .appNotFound, "Safari"),
+            (.windowNotFound(criteria: "Settings"), .windowNotFound, "Settings"),
+            (.menuNotFound("Finder"), .menuNotFound, "Finder"),
+            (.menuItemNotFound("New Window"), .menuItemNotFound, "New Window"),
+            (.snapshotStale("window moved"), .snapshotStale, "window moved"),
+        ]
+
+        for (error, expectedKind, expectedContext) in cases {
+            let envelope = PeekabooBridgeServer.bridgeErrorEnvelope(for: error, operation: .targetedClick)
+            #expect(envelope.kind == expectedKind)
+            #expect(envelope.context == expectedContext)
+        }
+    }
+
+    @Test
+    @MainActor
+    func `production bridge classifier preserves Dock identity and messages`() {
+        let envelope = PeekabooBridgeServer.bridgeErrorEnvelope(
+            for: DockError.itemNotFound("Safari"),
+            operation: .findDockItem)
+
+        #expect(envelope.code == .notFound)
+        #expect(envelope.kind == .dockItemNotFound)
+        #expect(envelope.context == "Safari")
+        #expect(envelope.message == "Dock item not found: Safari")
+    }
+
+    @Test
     func `unknown bridge error kinds decode as untyped errors`() throws {
         let data = Data(
             #"{"code":"invalidRequest","message":"Future error","kind":"futureErrorKind","context":"S1"}"#.utf8)

--- a/Core/PeekabooCore/Tests/PeekabooTests/PeekabooBridgeCapabilityTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/PeekabooBridgeCapabilityTests.swift
@@ -39,16 +39,29 @@ struct PeekabooBridgeCapabilityTests {
     @Test
     @MainActor
     func `production bridge classifier converts legacy lookup errors`() {
-        let error = NotFoundError(
-            code: .menuNotFound,
-            userMessage: "Menu not found",
-            context: ["application": "Finder"])
+        let cases: [(NotFoundError, PeekabooBridgeErrorKind, String?)] = [
+            (
+                NotFoundError(
+                    code: .menuNotFound,
+                    userMessage: "Menu not found",
+                    context: ["application": "Finder"]),
+                .menuNotFound,
+                "Finder"),
+            (
+                NotFoundError(
+                    code: .menuNotFound,
+                    userMessage: "Menu item not found",
+                    context: ["application": "Finder", "menuItem": "New Window"]),
+                .menuItemNotFound,
+                "New Window"),
+        ]
 
-        let envelope = PeekabooBridgeServer.bridgeErrorEnvelope(for: error, operation: .listMenus)
-
-        #expect(envelope.code == .notFound)
-        #expect(envelope.kind == .menuNotFound)
-        #expect(envelope.context == "Finder")
+        for (error, expectedKind, expectedContext) in cases {
+            let envelope = PeekabooBridgeServer.bridgeErrorEnvelope(for: error, operation: .listMenus)
+            #expect(envelope.code == .notFound)
+            #expect(envelope.kind == expectedKind)
+            #expect(envelope.context == expectedContext)
+        }
     }
 
     @Test

--- a/Core/PeekabooCore/Tests/PeekabooTests/PeekabooBridgeCapabilityTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/PeekabooBridgeCapabilityTests.swift
@@ -26,14 +26,20 @@ struct PeekabooBridgeCapabilityTests {
     @Test
     @MainActor
     func `production bridge classifier preserves Dock identity and messages`() {
-        let envelope = PeekabooBridgeServer.bridgeErrorEnvelope(
-            for: DockError.itemNotFound("Safari"),
-            operation: .findDockItem)
-
-        #expect(envelope.code == .notFound)
-        #expect(envelope.kind == .dockItemNotFound)
-        #expect(envelope.context == "Safari")
-        #expect(envelope.message == "Dock item not found: Safari")
+        let cases: [(DockError, PeekabooBridgeOperation, PeekabooBridgeErrorKind, String)] = [
+            (.itemNotFound("Safari"), .findDockItem, .dockItemNotFound, "Dock item not found: Safari"),
+            (
+                .menuItemNotFound("New Window"),
+                .rightClickDockItem,
+                .menuItemNotFound,
+                "Dock menu item not found: New Window"),
+        ]
+        for (error, operation, expectedKind, expectedMessage) in cases {
+            let envelope = PeekabooBridgeServer.bridgeErrorEnvelope(for: error, operation: operation)
+            #expect(envelope.code == .notFound)
+            #expect(envelope.kind == expectedKind)
+            #expect(envelope.message == expectedMessage)
+        }
     }
 
     @Test


### PR DESCRIPTION
## Summary

Bridge-routed failures often surface as:

```
code: UNKNOWN_ERROR
message: "Bridge operation failed"
```

with the real text only in `details`. Two contributing bugs:

1. CLI mapped every bridge `.notFound` to `UNKNOWN_ERROR`, ignoring `kind` (element/snapshot).
2. Uncaught operation errors in `PeekabooBridgeServer` always used the generic primary message `"Bridge operation failed"`.

Ref #239

## Change

**CLI (`errorCode(for: PeekabooBridgeErrorEnvelope)`):**
- `.elementNotFound` → `ELEMENT_NOT_FOUND`
- `.snapshotNotFound` → `SNAPSHOT_NOT_FOUND`
- `.snapshotStale` → `SNAPSHOT_STALE`
- unkinded `.notFound` → `ELEMENT_NOT_FOUND` (not `UNKNOWN_ERROR`)
- Launch path still overrides via `applicationLaunchErrorCode` → `APP_NOT_FOUND`

**Server:** default internal envelope message uses `LocalizedError.errorDescription` / `localizedDescription`, falling back to `"Bridge operation failed"` only if empty.

## Validation

```
DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer \
  swift test --package-path Apps/CLI --filter ErrorHandling
# includes:
#   bridge elementNotFound kind maps to ELEMENT_NOT_FOUND
#   bridge snapshotNotFound kind maps to SNAPSHOT_NOT_FOUND
#   bridge unkinded notFound maps to ELEMENT_NOT_FOUND not UNKNOWN
```

## Real behavior proof

**Command:** `swift test --package-path Apps/CLI --filter ErrorHandling`
**Input:** bridge envelopes with kind elementNotFound / snapshotNotFound / none
**Output:** ELEMENT_NOT_FOUND / SNAPSHOT_NOT_FOUND / ELEMENT_NOT_FOUND (not UNKNOWN_ERROR)
**Exit code:** 0
**Duration:** ~30s build + <1s tests
**Commit:** HEAD of this PR

## Related

- Issue: https://github.com/openclaw/Peekaboo/issues/239
- Prior empty-error fix: #211