### PR TITLE
fix(mac): pin status bar menu to system light/dark appearance

### DIFF
--- a/Apps/Mac/Peekaboo/Features/StatusBar/StatusBarController.swift
+++ b/Apps/Mac/Peekaboo/Features/StatusBar/StatusBarController.swift
@@ -23,6 +23,23 @@ enum AgentSessionUI {
     }
 }
 
+/// Pins status bar menus to the app's effective appearance.
+///
+/// Menus popped from a status item inherit the menu bar's vibrant appearance, which is derived
+/// from the wallpaper behind it rather than the system light/dark mode. Pinning the exact
+/// effective appearance (not just its name) keeps accessibility attributes intact; submenus
+/// inherit it automatically.
+@MainActor
+enum StatusMenuAppearance {
+    static func pin(_ menu: NSMenu) {
+        self.pin(menu, to: NSApplication.shared.effectiveAppearance)
+    }
+
+    static func pin(_ menu: NSMenu, to appearance: NSAppearance) {
+        menu.appearance = appearance
+    }
+}
+
 /// Controls the Peekaboo status bar item and popover interface.
 ///
 /// Manages the macOS status bar integration with animated icon states and popover UI.
@@ -263,6 +280,9 @@ final class StatusBarController: NSObject, NSMenuDelegate {
         // macOS may apply “standard” images for common items (Settings/Quit).
         // Strip any images right before display.
         Self.stripMenuItemImages(menu)
+
+        // Follow the system light/dark mode instead of the menu bar's wallpaper-tinted appearance.
+        StatusMenuAppearance.pin(menu)
 
         // Avoid temporarily attaching `statusItem.menu` (which can cause AppKit to inject standard item images,
         // notably for “Settings…”). Instead, pop up the menu directly anchored to the status item button.

--- a/Apps/Mac/PeekabooTests/Controllers/StatusBarControllerTests.swift
+++ b/Apps/Mac/PeekabooTests/Controllers/StatusBarControllerTests.swift
@@ -65,6 +65,34 @@ struct StatusBarControllerTests {
     }
 
     @Test
+    func `Status menu pins the exact application effective appearance`() {
+        let menu = NSMenu()
+
+        StatusMenuAppearance.pin(menu)
+
+        #expect(menu.appearance === NSApplication.shared.effectiveAppearance)
+    }
+
+    @Test
+    func `Submenus inherit the pinned root appearance`() throws {
+        let menu = NSMenu()
+        let submenu = NSMenu()
+        let item = NSMenuItem(title: "Agent", action: nil, keyEquivalent: "")
+        item.submenu = submenu
+        menu.addItem(item)
+
+        let light = try #require(NSAppearance(named: .aqua))
+        StatusMenuAppearance.pin(menu, to: light)
+        #expect(menu.appearance === light)
+        #expect(submenu.appearance == nil)
+        #expect(submenu.effectiveAppearance.bestMatch(from: [.aqua, .darkAqua]) == .aqua)
+
+        let dark = try #require(NSAppearance(named: .darkAqua))
+        StatusMenuAppearance.pin(menu, to: dark)
+        #expect(submenu.effectiveAppearance.bestMatch(from: [.aqua, .darkAqua]) == .darkAqua)
+    }
+
+    @Test
     func `Popover presentation`() {
         _ = self.makeController()
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - The accessibility element boxes drawn during `peekaboo see` are off by default now; they were visual clutter on every capture. Re-enable them in Peekaboo.app under Settings › Visualizer › Element Detection Boxes, by setting `visualizer.elementDetectionEnabled` in `~/.peekaboo/config.json`, or per-run with `PEEKABOO_VISUAL_ELEMENT_BOXES=true`. The app toggle and the config file now stay in sync, and a running MCP server picks up the change without a restart.
 
 ### Fixed
+- The Mac app's status bar menu now follows the system light/dark mode. It previously inherited the menu bar's wallpaper-derived vibrant appearance, which could render a dark menu while the system was in light mode (and vice versa).
 - OpenRouter, Together, and OpenAI-compatible GPT-5.6 routes now preserve the 372K context/128K output capability profile, omit unsupported temperature, and recognize routing suffixes such as `:online`.
 - Adding a macOS application bundle to the Dock now places it with applications instead of mistaking its on-disk directory for a folder.
 - Synchronous default MCP tool-context access now fails fast off the main thread, with an async main-actor accessor for background callers. Thanks @SebTardif for #253.


### PR DESCRIPTION
## Summary

The Mac app's status bar context menu rendered in the wrong appearance: it inherited the menu bar's wallpaper-derived vibrant appearance instead of the system light/dark mode. With a dark wallpaper region behind the menu bar, the menu came up dark (and tinted by the wallpaper) even though the system was in Light mode.

Fix mirrors CodexBar's approach: pin the menu to the exact application effective appearance (preserving accessibility attributes) right before presenting it. Submenus inherit the pinned root appearance automatically.

## Verification

- Reproduced the mechanism live on a Light-mode system with a dark wallpaper behind the menu bar, via a standalone AppKit harness:
  - app effectiveAppearance: Aqua
  - status item button appearance: DarkAqua (what an unpinned menu anchored to it inherits)
  - menu pinned to app appearance: Aqua
- Built the Mac app (debug) successfully.
- SwiftFormat/SwiftLint clean on touched files.
- Added tests in StatusBarControllerTests covering exact-appearance pinning and submenu inheritance. Note: the PeekabooTests folder is not wired into any test target/scheme (pre-existing), so these document intent until the target exists.
