### PR TITLE
test(agent): cover capability-aware provider defaults

### DIFF
--- a/Core/PeekabooCore/Tests/PeekabooTests/PeekabooAgentServiceModelTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/PeekabooAgentServiceModelTests.swift
@@ -1921,6 +1921,20 @@ extension PeekabooAgentServiceTests {
 
     @Test
     @MainActor
+    func `Agent skips vision-only provider before tool-capable provider`() throws {
+        try self.withIsolatedAgentEnvironment([
+            "PEEKABOO_AI_PROVIDERS": "ollama/qwen2.5vl:latest,anthropic/claude-sonnet-4-5-20250929",
+            "ANTHROPIC_API_KEY": "test-anthropic-key",
+        ]) {
+            let services = self.makeServices()
+            let agentService = try #require(services.agent as? PeekabooAgentService)
+
+            #expect(agentService.defaultModel == LanguageModel.anthropic(.sonnet45).description)
+        }
+    }
+
+    @Test
+    @MainActor
     func `Configured Ollama provider tolerates comma whitespace`() throws {
         try self.withIsolatedAgentEnvironment(["PEEKABOO_AI_PROVIDERS": "openai/gpt-5.5, ollama/llama3.3"]) {
             let services = self.makeServices()


### PR DESCRIPTION
## Summary

- cover the shipped mixed provider list where a vision-only Ollama model precedes a tool-capable Anthropic model
- assert the production agent service skips the vision-only entry and selects the usable provider
- preserve the shared provider-list design while locking in capability-aware default selection

Closes #251.

## Proof

- `swift test --package-path Core/PeekabooCore --filter 'Agent skips vision-only provider before tool-capable provider'`
- `swiftlint lint --config .swiftlint.yml Core/PeekabooCore/Tests/PeekabooTests/PeekabooAgentServiceModelTests.swift`
- `pnpm run test:safe` (737 tests, 84 suites)
- autoreview: Codex gpt-5.5, xhigh; no accepted or actionable findings

## Note

The repo-wide lint command currently traverses generated `Apps/Playground/.xcodebuild` dependency sources and exits on their pre-existing violations. The touched file passes focused SwiftLint with zero violations.
