### PR TITLE
feat(cli): add long-press clicks

### DIFF
--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Base/CommandRuntime.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Base/CommandRuntime.swift
@@ -35,6 +35,7 @@ struct CommandRuntimeOptions {
     var usesPerToolSnapshotInvalidation = false
     var requiresExactWindowTargetedClicks = false
     var requiresPostEventClickPermission = false
+    var requiresLongPressClick = false
     /// Set for commands that acquire screen pixels (capture/detection/desktop observation) so a
     /// remote host that explicitly lacks Screen Recording is rejected during selection. Not set for
     /// interaction commands (click/scroll/type) that operate on cached snapshots.

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Base/CommanderBinder.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Base/CommanderBinder.swift
@@ -65,6 +65,8 @@ enum CommanderCLIBinder {
             commandType,
             parsedValues: parsedValues
         )
+        options.requiresLongPressClick = commandType == ClickCommand.self &&
+            CommanderBindableValues(parsedValues: parsedValues).flag("longPress")
         options.requiresScreenCapturePermission = Self.requiresScreenCapturePermission(commandType)
         options.requestsHostPermissionGrant = Self.isInteractivePermissionRequest(commandType)
         options.usesPerToolSnapshotInvalidation = commandType == AgentCommand.self ||
@@ -358,6 +360,9 @@ enum CommanderCLIBinder {
     ) -> Bool {
         guard commandType == ClickCommand.self else { return false }
         let values = CommanderBindableValues(parsedValues: parsedValues)
+        if values.flag("longPress") {
+            return true
+        }
         guard self.usesBackgroundClickDelivery(values) else { return false }
         if values.singleOption("coords") != nil {
             return true
@@ -369,6 +374,9 @@ enum CommanderCLIBinder {
     private static func usesBackgroundClickDelivery(_ values: CommanderBindableValues) -> Bool {
         if values.flag("focusBackground") {
             return true
+        }
+        if values.flag("longPress") {
+            return false
         }
         return !values.flag("foreground") &&
             !values.flag("noAutoFocus") &&

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Base/Runtime/BridgeCapabilityPolicy.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Base/Runtime/BridgeCapabilityPolicy.swift
@@ -60,6 +60,11 @@ enum BridgeCapabilityPolicy {
             return false
         }
 
+        if options.requiresLongPressClick,
+           !self.supportsLongPressClicks(for: handshake) {
+            return false
+        }
+
         if options.requiresImplicitSnapshotInvalidation || options.usesPerToolSnapshotInvalidation,
            !self.supportsImplicitSnapshotInvalidation(for: handshake) {
             return false
@@ -128,6 +133,15 @@ enum BridgeCapabilityPolicy {
 
     static func supportsTargetedClicks(for handshake: PeekabooBridgeHandshakeResponse) -> Bool {
         self.targetedClickAvailability(for: handshake).isEnabled
+    }
+
+    static func supportsLongPressClicks(for handshake: PeekabooBridgeHandshakeResponse) -> Bool {
+        guard handshake.negotiatedVersion >= PeekabooBridgeProtocolVersion(major: 1, minor: 10),
+              handshake.supportedOperations.contains(.click)
+        else {
+            return false
+        }
+        return (handshake.enabledOperations ?? handshake.supportedOperations).contains(.click)
     }
 
     static func supportsApplicationLaunchOptions(for handshake: PeekabooBridgeHandshakeResponse) -> Bool {

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Interaction/ClickCommand+CommanderMetadata.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Interaction/ClickCommand+CommanderMetadata.swift
@@ -31,6 +31,7 @@ extension ClickCommand: CommanderBindableCommand {
         }
         self.double = values.flag("double")
         self.right = values.flag("right")
+        self.longPress = values.flag("longPress")
         self.foreground = values.flag("foreground")
         self.focusOptions = try values.makeFocusOptions(includeBackgroundDelivery: true)
     }
@@ -83,6 +84,11 @@ extension ClickCommand: CommanderSignatureProviding {
                     "right",
                     help: "Right-click (secondary click)",
                     long: "right"
+                ),
+                .commandFlag(
+                    "longPress",
+                    help: "Press and hold for 1.2 seconds at a stationary point",
+                    long: "long-press"
                 ),
                 .commandFlag(
                     "foreground",

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Interaction/ClickCommand+Validation.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Interaction/ClickCommand+Validation.swift
@@ -30,6 +30,14 @@ extension ClickCommand {
             throw ValidationError("--foreground cannot be combined with --focus-background")
         }
 
+        if self.longPress && (self.double || self.right) {
+            throw ValidationError("--long-press cannot be combined with --double or --right")
+        }
+
+        if self.longPress && self.focusOptions.backgroundDeliveryExplicitlyRequested {
+            throw ValidationError("--long-press requires foreground delivery")
+        }
+
         if self.focusOptions.backgroundDeliveryExplicitlyRequested &&
             self.focusOptions.hasForegroundFocusOverrides {
             throw ValidationError("--focus-background cannot be combined with focus options")

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Interaction/ClickCommand.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Interaction/ClickCommand.swift
@@ -37,6 +37,9 @@ struct ClickCommand: ErrorHandlingCommand, OutputFormattable, RuntimeOptionsConf
     @Flag(help: "Right-click (secondary click)")
     var right = false
 
+    @Flag(help: "Press and hold for 1.2 seconds at a stationary point")
+    var longPress = false
+
     @Flag(help: "Focus target and send a foreground mouse click")
     var foreground = false
 
@@ -72,7 +75,7 @@ struct ClickCommand: ErrorHandlingCommand, OutputFormattable, RuntimeOptionsConf
         if self.focusOptions.backgroundDeliveryExplicitlyRequested {
             return .background
         }
-        if self.foreground || self.focusOptions.hasForegroundFocusOverrides {
+        if self.foreground || self.longPress || self.focusOptions.hasForegroundFocusOverrides {
             return .foreground
         }
         return .background
@@ -244,42 +247,55 @@ struct ClickCommand: ErrorHandlingCommand, OutputFormattable, RuntimeOptionsConf
             )
             try Task.checkCancellation()
 
-            let appName = await resultApplicationName(
-                snapshotId: activeSnapshotId,
-                coordinateResolution: coordinateResolution
-            )
-
-            let details = try await clickOutputDetails(
+            try await self.outputClickResult(
                 clickTarget: clickTarget,
                 waitResult: waitResult,
                 snapshotId: activeSnapshotId,
-                coordinateResolution: coordinateResolution
+                resolutions: (coordinateResolution, explicitWindowResolution),
+                startTime: startTime
             )
-
-            // Output results
-            let result = ClickResult(
-                success: true,
-                clickedElement: details.clickedElement,
-                clickLocation: details.location,
-                waitTime: waitResult.waitTime,
-                executionTime: Date().timeIntervalSince(startTime),
-                targetApp: appName,
-                targetWindowId: explicitWindowResolution?.windowInfo.windowID ?? coordinateResolution?.targetWindowID,
-                targetWindowTitle: explicitWindowResolution?.windowInfo.title ?? coordinateResolution?
-                    .targetWindowTitle,
-                coordinateSpace: coordinateResolution?.coordinateSpace.rawValue,
-                inputCoordinates: coordinateResolution?.inputPoint,
-                screenCoordinates: coordinateResolution?.screenPoint,
-                targetPoint: details.targetPointDiagnostics,
-                deliveryMode: self.deliveryMode.rawValue
-            )
-
-            self.outputSuccess(result)
 
         } catch {
             handleError(error)
             throw ExitCode.failure
         }
+    }
+
+    private func outputClickResult(
+        clickTarget: ClickTarget,
+        waitResult: WaitForElementResult,
+        snapshotId: String,
+        resolutions: (coordinate: InteractionCoordinateResolution?, window: InteractionWindowResolution?),
+        startTime: Date
+    ) async throws {
+        let coordinateResolution = resolutions.coordinate
+        let explicitWindowResolution = resolutions.window
+        let appName = await resultApplicationName(
+            snapshotId: snapshotId,
+            coordinateResolution: coordinateResolution
+        )
+        let details = try await clickOutputDetails(
+            clickTarget: clickTarget,
+            waitResult: waitResult,
+            snapshotId: snapshotId,
+            coordinateResolution: coordinateResolution
+        )
+        let result = ClickResult(
+            success: true,
+            clickedElement: details.clickedElement,
+            clickLocation: details.location,
+            waitTime: waitResult.waitTime,
+            executionTime: Date().timeIntervalSince(startTime),
+            targetApp: appName,
+            targetWindowId: explicitWindowResolution?.windowInfo.windowID ?? coordinateResolution?.targetWindowID,
+            targetWindowTitle: explicitWindowResolution?.windowInfo.title ?? coordinateResolution?.targetWindowTitle,
+            coordinateSpace: coordinateResolution?.coordinateSpace.rawValue,
+            inputCoordinates: coordinateResolution?.inputPoint,
+            screenCoordinates: coordinateResolution?.screenPoint,
+            targetPoint: details.targetPointDiagnostics,
+            deliveryMode: self.deliveryMode.rawValue
+        )
+        self.outputSuccess(result)
     }
 
     private func clickOutputDetails(
@@ -601,7 +617,15 @@ struct ClickCommand: ErrorHandlingCommand, OutputFormattable, RuntimeOptionsConf
             nil
         }
 
-        let clickType: ClickType = self.right ? .right : (self.double ? .double : .single)
+        let clickType: ClickType = if self.longPress {
+            .longPress
+        } else if self.right {
+            .right
+        } else if self.double {
+            .double
+        } else {
+            .single
+        }
         self.resolvedRuntime.beginInteractionMutation()
         try await self.performClick(
             clickTarget,

--- a/Apps/CLI/Tests/CLIAutomationTests/ClickCommandTests.swift
+++ b/Apps/CLI/Tests/CLIAutomationTests/ClickCommandTests.swift
@@ -43,6 +43,30 @@ struct ClickCommandTests {
     }
 
     @Test
+    func `Long press uses foreground stationary click type`() async throws {
+        let context = await makeContext()
+        let result = try await InProcessCommandRunner.run(
+            ["click", "--coords", "100,200", "--long-press", "--json"],
+            services: context.services
+        )
+
+        #expect(result.exitStatus == 0)
+        let calls = await automationState(context) { $0.clickCalls }
+        let call = try #require(calls.first)
+        #expect(call.clickType == .longPress)
+        #expect(await self.automationState(context) { $0.targetedClickCalls }.isEmpty)
+    }
+
+    @Test
+    func `Long press rejects conflicting click variants`() throws {
+        var command = try ClickCommand.parse(["--coords", "100,200", "--long-press", "--right"])
+
+        #expect(throws: (any Error).self) {
+            try command.validate()
+        }
+    }
+
+    @Test
     func `Click command defaults to background coordinate clicks when pid is supplied`() async throws {
         let context = await makeContext()
         let result = try await InProcessCommandRunner.run(

--- a/Apps/CLI/Tests/CoreCLITests/CommanderBinderCommandBindingTests.swift
+++ b/Apps/CLI/Tests/CoreCLITests/CommanderBinderCommandBindingTests.swift
@@ -412,7 +412,7 @@ struct CommanderBinderCommandBindingTests {
                 "waitFor": ["2500"],
                 "inputStrategy": ["actionOnly"]
             ],
-            flags: ["double", "noAutoFocus"]
+            flags: ["longPress", "noAutoFocus"]
         )
         let command = try CommanderCLIBinder.instantiateCommand(ofType: ClickCommand.self, parsedValues: parsed)
         #expect(command.query == "Submit")
@@ -420,7 +420,7 @@ struct CommanderBinderCommandBindingTests {
         #expect(command.on == "B1")
         #expect(command.target.app == "Safari")
         #expect(command.waitFor == 2500)
-        #expect(command.double == true)
+        #expect(command.longPress == true)
         #expect(command.focusOptions.noAutoFocus == true)
         #expect(command.runtimeOptions.inputStrategy == .actionOnly)
     }

--- a/Apps/CLI/Tests/CoreCLITests/CommanderBinderTests.swift
+++ b/Apps/CLI/Tests/CoreCLITests/CommanderBinderTests.swift
@@ -590,6 +590,14 @@ struct CommanderBinderTests {
             ),
             commandType: ClickCommand.self
         )
+        let longPress = try CommanderCLIBinder.makeRuntimeOptions(
+            from: ParsedValues(
+                positional: [],
+                options: ["on": ["B1"]],
+                flags: ["longPress"]
+            ),
+            commandType: ClickCommand.self
+        )
         let doubleClick = try CommanderCLIBinder.makeRuntimeOptions(
             from: ParsedValues(
                 positional: [],
@@ -642,6 +650,8 @@ struct CommanderBinderTests {
         #expect(coordinate.requiresPostEventClickPermission)
         #expect(coordinateDouble.requiresPostEventClickPermission)
         #expect(coordinateRight.requiresPostEventClickPermission)
+        #expect(longPress.requiresPostEventClickPermission)
+        #expect(longPress.requiresLongPressClick)
         #expect(doubleClick.requiresPostEventClickPermission)
         #expect(!singleClick.requiresPostEventClickPermission)
         #expect(!rightClick.requiresPostEventClickPermission)
@@ -725,11 +735,20 @@ extension CommanderBinderTests {
             ),
             commandType: ClickCommand.self
         )
+        let longPressWindow = try CommanderCLIBinder.makeRuntimeOptions(
+            from: ParsedValues(
+                positional: [],
+                options: ["windowId": ["42"]],
+                flags: ["longPress"]
+            ),
+            commandType: ClickCommand.self
+        )
 
         #expect(explicitWindow.requiresExactWindowTargetedClicks)
         #expect(relativeAppCoordinates.requiresExactWindowTargetedClicks)
         #expect(!globalAppCoordinates.requiresExactWindowTargetedClicks)
         #expect(!foregroundWindow.requiresExactWindowTargetedClicks)
+        #expect(!longPressWindow.requiresExactWindowTargetedClicks)
 
         let operations: [PeekabooBridgeOperation] = [
             .captureScreen,

--- a/Apps/CLI/Tests/CoreCLITests/RuntimeHostResolverTests.swift
+++ b/Apps/CLI/Tests/CoreCLITests/RuntimeHostResolverTests.swift
@@ -264,6 +264,53 @@ struct RuntimeHostResolverTests {
         ) != nil)
     }
 
+    @Test
+    func `Candidate validation rejects pre-long-press bridge hosts`() async {
+        let candidate = RuntimeHostResolver.ImplicitRemoteCandidate(
+            socketPath: "/tmp/bridge.sock",
+            requireReusableDaemon: false,
+            requiredHostKind: nil,
+            requiresValidatedHistoricalDaemon: false
+        )
+        var options = CommandRuntimeOptions()
+        options.requiresPostEventClickPermission = true
+        options.requiresLongPressClick = true
+
+        func handshake(minor: Int, supportsClick: Bool = true) -> PeekabooBridgeHandshakeResponse {
+            let operations: [PeekabooBridgeOperation] = supportsClick
+                ? [.captureScreen, .click, .targetedClick]
+                : [.captureScreen, .targetedClick]
+            return PeekabooBridgeHandshakeResponse(
+                negotiatedVersion: PeekabooBridgeProtocolVersion(major: 1, minor: minor),
+                hostKind: .gui,
+                build: nil,
+                supportedOperations: operations,
+                permissions: PermissionsStatus(
+                    screenRecording: true,
+                    accessibility: true,
+                    postEvent: true
+                ),
+                enabledOperations: operations
+            )
+        }
+
+        #expect(await RuntimeHostResolver.validateRemoteCandidate(
+            candidate,
+            handshake: handshake(minor: 9),
+            options: options
+        ) == nil)
+        #expect(await RuntimeHostResolver.validateRemoteCandidate(
+            candidate,
+            handshake: handshake(minor: 10),
+            options: options
+        ) != nil)
+        #expect(await RuntimeHostResolver.validateRemoteCandidate(
+            candidate,
+            handshake: handshake(minor: 10, supportsClick: false),
+            options: options
+        ) == nil)
+    }
+
     private static func captureOptions() -> CommandRuntimeOptions {
         var options = CommandRuntimeOptions()
         options.requiresScreenCapturePermission = true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [3.8.1] - Unreleased
 
 ### Added
+- `peekaboo click --long-press` performs a stationary 1.2-second mouse down/hold/up gesture for controls such as SwiftUI `LongPressGesture`; it uses foreground delivery so the press cannot be misrouted to a background window.
 - `peekaboo agent` supports GPT-5.6 (`gpt-5.6`, `gpt-5.6-sol`, `gpt-5.6-terra`, `gpt-5.6-luna`) and Claude Sonnet 5 (`claude-sonnet-5`, `sonnet`) alongside Fable 5, with current context/output/sampling limits and matching choices in the Mac app's assistant pickers, Settings, and session view.
 - Bare `peekaboo paste` now pastes the current clipboard into the focused (or targeted background) app instead of erroring; payload flags without a payload still fail validation even when `--restore-delay-ms` explicitly uses its 150ms default, and the current clipboard's contents are never echoed into structured output.
 - `peekaboo list apps` accepts `--include-hidden`/`--include-background` for parity with `app list`, and `list apps`, `list menubar`, and `dock list` JSON now emit snake_case keys (`apps`, `menu_bar_items`, `dock_items`) alongside the legacy keys.

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/ClickService.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/ClickService.swift
@@ -185,6 +185,8 @@ public final class ClickService {
             return try await self.actionInputDriver.tryRightClick(element: element)
         case .double:
             throw ActionInputError.unsupported(.actionUnsupported)
+        case .longPress:
+            throw ActionInputError.unsupported(.actionUnsupported)
         }
     }
 
@@ -796,6 +798,12 @@ public final class ClickService {
                 count: 2,
                 targetProcessIdentifier: targetProcessIdentifier,
                 targetWindowID: targetWindowID)
+        case .longPress:
+            guard targetProcessIdentifier == nil else {
+                throw PeekabooError.serviceUnavailable(
+                    "Long press requires foreground delivery")
+            }
+            try await self.performLongPress(at: point)
         }
     }
 
@@ -818,10 +826,10 @@ public final class ClickService {
         }
     }
 
-    private func performForceClick(at point: CGPoint) async throws {
+    private func performLongPress(at point: CGPoint) async throws {
         try self.syntheticInputDriver.move(to: point)
         try await Task.sleep(nanoseconds: 50_000_000) // 50ms
-        try self.syntheticInputDriver.pressHold(at: point, button: .left, duration: 0.5)
+        try await self.syntheticInputDriver.pressHold(at: point, button: .left, duration: 1.2)
     }
 }
 

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/SyntheticInputDriver.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/SyntheticInputDriver.swift
@@ -15,7 +15,7 @@ protocol SyntheticInputDriving: Sendable {
         targetWindowID: CGWindowID?) async throws
     func move(to point: CGPoint) throws
     func currentLocation() -> CGPoint?
-    func pressHold(at point: CGPoint, button: MouseButton, duration: TimeInterval) throws
+    func pressHold(at point: CGPoint, button: MouseButton, duration: TimeInterval) async throws
     func scroll(deltaX: Double, deltaY: Double, at point: CGPoint?) throws
     func type(_ text: String, delayPerCharacter: TimeInterval) throws
     func tapKey(_ key: SpecialKey, modifiers: CGEventFlags) throws
@@ -45,6 +45,26 @@ extension SyntheticInputDriving {
 /// Thin injectable wrapper over AXorcist's low-level synthetic input helpers.
 @MainActor
 struct SyntheticInputDriver: SyntheticInputDriving {
+    private let postEventAccessEvaluator: @MainActor @Sendable () -> Bool
+    private let eventPoster: @MainActor @Sendable (CGEvent) -> Void
+    private let holdSleeper: @MainActor @Sendable (TimeInterval) async throws -> Void
+
+    init(
+        postEventAccessEvaluator: @escaping @MainActor @Sendable () -> Bool = {
+            CGPreflightPostEventAccess()
+        },
+        eventPoster: @escaping @MainActor @Sendable (CGEvent) -> Void = { event in
+            event.post(tap: .cghidEventTap)
+        },
+        holdSleeper: @escaping @MainActor @Sendable (TimeInterval) async throws -> Void = { duration in
+            try await ContinuousClock().sleep(for: .seconds(duration))
+        })
+    {
+        self.postEventAccessEvaluator = postEventAccessEvaluator
+        self.eventPoster = eventPoster
+        self.holdSleeper = holdSleeper
+    }
+
     func click(at point: CGPoint, button: MouseButton = .left, count: Int = 1) throws {
         try InputDriver.click(at: point, button: button, count: count)
     }
@@ -86,8 +106,39 @@ struct SyntheticInputDriver: SyntheticInputDriving {
         InputDriver.currentLocation()
     }
 
-    func pressHold(at point: CGPoint, button: MouseButton = .left, duration: TimeInterval) throws {
-        try InputDriver.pressHold(at: point, button: button, duration: duration)
+    func pressHold(at point: CGPoint, button: MouseButton = .left, duration: TimeInterval) async throws {
+        guard self.postEventAccessEvaluator() else {
+            throw PeekabooError.permissionDeniedEventSynthesizing
+        }
+        let events = try Self.makePressHoldEvents(at: point, button: button)
+        self.eventPoster(events.down)
+        defer { self.eventPoster(events.up) }
+        if duration > 0 {
+            try await self.holdSleeper(duration)
+        }
+    }
+
+    static func makePressHoldEvents(
+        at point: CGPoint,
+        button: MouseButton) throws -> (down: CGEvent, up: CGEvent)
+    {
+        let cgButton: CGMouseButton = button == .left ? .left : .right
+        let downType: CGEventType = button == .left ? .leftMouseDown : .rightMouseDown
+        let upType: CGEventType = button == .left ? .leftMouseUp : .rightMouseUp
+        guard let down = CGEvent(
+            mouseEventSource: nil,
+            mouseType: downType,
+            mouseCursorPosition: point,
+            mouseButton: cgButton),
+            let up = CGEvent(
+                mouseEventSource: nil,
+                mouseType: upType,
+                mouseCursorPosition: point,
+                mouseButton: cgButton)
+        else {
+            throw UIAutomationError.failedToCreateEvent
+        }
+        return (down, up)
     }
 
     func scroll(deltaX: Double = 0, deltaY: Double, at point: CGPoint? = nil) throws {

--- a/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/ClickServiceTargetResolutionTests.swift
+++ b/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/ClickServiceTargetResolutionTests.swift
@@ -1073,7 +1073,7 @@ final class ClickRecordingSyntheticInputDriver: SyntheticInputDriving {
         return nil
     }
 
-    func pressHold(at _: CGPoint, button _: MouseButton, duration _: TimeInterval) throws {}
+    func pressHold(at _: CGPoint, button _: MouseButton, duration _: TimeInterval) async throws {}
 
     func scroll(deltaX: Double, deltaY: Double, at point: CGPoint?) throws {
         self.events.append(.scroll(deltaX: deltaX, deltaY: deltaY, at: point))

--- a/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/DialogServiceGoToFolderTests.swift
+++ b/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/DialogServiceGoToFolderTests.swift
@@ -63,7 +63,7 @@ private final class FailingDialogSyntheticInputDriver: SyntheticInputDriving {
         nil
     }
 
-    func pressHold(at _: CGPoint, button _: MouseButton, duration _: TimeInterval) throws {}
+    func pressHold(at _: CGPoint, button _: MouseButton, duration _: TimeInterval) async throws {}
     func scroll(deltaX _: Double, deltaY _: Double, at _: CGPoint?) throws {}
 
     func type(_ text: String, delayPerCharacter: TimeInterval) throws {

--- a/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/ScrollServiceTargetResolutionTests.swift
+++ b/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/ScrollServiceTargetResolutionTests.swift
@@ -184,7 +184,7 @@ private final class ScrollRecordingSyntheticInputDriver: SyntheticInputDriving {
         return nil
     }
 
-    func pressHold(at _: CGPoint, button _: MouseButton, duration _: TimeInterval) throws {}
+    func pressHold(at _: CGPoint, button _: MouseButton, duration _: TimeInterval) async throws {}
 
     func scroll(deltaX: Double, deltaY: Double, at point: CGPoint?) throws {
         self.events.append(.scroll(deltaX: deltaX, deltaY: deltaY, at: point))

--- a/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/SyntheticInputDriverTests.swift
+++ b/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/SyntheticInputDriverTests.swift
@@ -1,11 +1,66 @@
 @preconcurrency import AXorcist
 import CoreGraphics
 import Foundation
+import enum PeekabooFoundation.PeekabooError
 import Testing
 @testable import PeekabooAutomationKit
 
 @MainActor
 struct SyntheticInputDriverTests {
+    @Test
+    func `long press uses ordinary mouse pressure`() throws {
+        let point = CGPoint(x: 12, y: 34)
+        let events = try SyntheticInputDriver.makePressHoldEvents(at: point, button: .left)
+
+        #expect(events.down.type == .leftMouseDown)
+        #expect(events.up.type == .leftMouseUp)
+        #expect(events.down.location == point)
+        #expect(events.up.location == point)
+        #expect(events.down.getDoubleValueField(.mouseEventPressure) == 1)
+    }
+
+    @Test
+    func `long press yields and always releases after cancellation`() async throws {
+        let recorder = PressHoldRecorder()
+        let driver = SyntheticInputDriver(
+            eventPoster: { event in
+                recorder.eventTypes.append(event.type)
+            },
+            holdSleeper: { duration in
+                recorder.durations.append(duration)
+                await Task.yield()
+                throw CancellationError()
+            })
+
+        do {
+            try await driver.pressHold(at: CGPoint(x: 12, y: 34), button: .left, duration: 1.2)
+            Issue.record("Expected the hold to be cancelled")
+        } catch is CancellationError {
+            // Expected. The deferred mouse-up must still be posted.
+        }
+
+        #expect(recorder.durations == [1.2])
+        #expect(recorder.eventTypes == [.leftMouseDown, .leftMouseUp])
+    }
+
+    @Test
+    func `long press rejects missing event synthesizing permission before mouse down`() async throws {
+        let recorder = PressHoldRecorder()
+        let driver = SyntheticInputDriver(
+            postEventAccessEvaluator: { false },
+            eventPoster: { event in recorder.eventTypes.append(event.type) },
+            holdSleeper: { _ in Issue.record("Denied long press must not start its hold") })
+
+        do {
+            try await driver.pressHold(at: CGPoint(x: 12, y: 34), button: .left, duration: 1.2)
+            Issue.record("Expected Event Synthesizing permission error")
+        } catch PeekabooError.permissionDeniedEventSynthesizing {
+            // Expected.
+        }
+
+        #expect(recorder.eventTypes.isEmpty)
+    }
+
     @Test
     func `click service uses injected synthetic driver`() async throws {
         let synthetic = RecordingSyntheticInputDriver()
@@ -21,6 +76,26 @@ struct SyntheticInputDriverTests {
         #expect(result.path == UIInputExecutionPath.synth)
         #expect(synthetic.events == [
             .click(point: CGPoint(x: 12, y: 34), button: .left, count: 2),
+        ])
+    }
+
+    @Test
+    func `long press stays stationary for the native gesture interval`() async throws {
+        let synthetic = RecordingSyntheticInputDriver()
+        let service = ClickService(
+            inputPolicy: UIInputPolicy(defaultStrategy: .synthOnly),
+            syntheticInputDriver: synthetic)
+        let point = CGPoint(x: 12, y: 34)
+
+        let result = try await service.click(
+            target: .coordinates(point),
+            clickType: .longPress,
+            snapshotId: nil)
+
+        #expect(result.path == UIInputExecutionPath.synth)
+        #expect(synthetic.events == [
+            .move(point),
+            .pressHold(point: point, button: .left, duration: 1.2),
         ])
     }
 
@@ -129,6 +204,12 @@ struct SyntheticInputDriverTests {
 }
 
 @MainActor
+private final class PressHoldRecorder {
+    var eventTypes: [CGEventType] = []
+    var durations: [TimeInterval] = []
+}
+
+@MainActor
 private final class RecordingSyntheticInputDriver: SyntheticInputDriving {
     enum Event: Equatable {
         case click(point: CGPoint, button: MouseButton, count: Int)
@@ -165,7 +246,7 @@ private final class RecordingSyntheticInputDriver: SyntheticInputDriving {
         return self.location
     }
 
-    func pressHold(at point: CGPoint, button: MouseButton, duration: TimeInterval) throws {
+    func pressHold(at point: CGPoint, button: MouseButton, duration: TimeInterval) async throws {
         self.events.append(.pressHold(point: point, button: button, duration: duration))
     }
 

--- a/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeConstants.swift
+++ b/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeConstants.swift
@@ -28,7 +28,7 @@ public enum PeekabooBridgeConstants {
     }
 
     /// Current protocol version supported by this build.
-    public static let protocolVersion = PeekabooBridgeProtocolVersion(major: 1, minor: 9)
+    public static let protocolVersion = PeekabooBridgeProtocolVersion(major: 1, minor: 10)
 
     /// Oldest protocol version this build can serve without changing request semantics.
     public static let minimumProtocolVersion = PeekabooBridgeProtocolVersion(major: 1, minor: 0)

--- a/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgePayloads.swift
+++ b/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgePayloads.swift
@@ -184,7 +184,7 @@ public struct PeekabooBridgeTargetedClickRequest: Codable, Sendable {
 
     public static func requiresPostEventPermission(target: ClickTarget, clickType: ClickType) -> Bool {
         switch (target, clickType) {
-        case (.coordinates, _), (_, .double):
+        case (.coordinates, _), (_, .double), (_, .longPress):
             true
         case (_, .single), (_, .right):
             false

--- a/Core/PeekabooCore/Tests/PeekabooTests/ClickServiceTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/ClickServiceTests.swift
@@ -106,7 +106,7 @@ struct ClickServiceTests {
     @MainActor
     struct ClickTypeTests {
         @Test
-        func `Click supports single, double, and right-click types`() async throws {
+        func `Click supports single, double, right-click, and long-press types`() async throws {
             let snapshotManager = MockSnapshotManager()
             let service = ClickService(snapshotManager: snapshotManager)
 
@@ -128,6 +128,11 @@ struct ClickServiceTests {
             try await service.click(
                 target: .coordinates(point),
                 clickType: .double,
+                snapshotId: nil)
+
+            try await service.click(
+                target: .coordinates(point),
+                clickType: .longPress,
                 snapshotId: nil)
         }
     }

--- a/Core/PeekabooFoundation/Sources/PeekabooFoundation/BasicTypes.swift
+++ b/Core/PeekabooFoundation/Sources/PeekabooFoundation/BasicTypes.swift
@@ -32,6 +32,7 @@ public enum ClickType: String, Sendable, Codable {
     case single
     case right
     case double
+    case longPress
 }
 
 // MARK: - Scroll & Swipe
@@ -232,6 +233,7 @@ extension ClickType: CustomStringConvertible {
         case .single: "single"
         case .right: "right"
         case .double: "double"
+        case .longPress: "long press"
         }
     }
 }

--- a/docs/commands/click.md
+++ b/docs/commands/click.md
@@ -20,6 +20,7 @@ read_when:
 | Target flags | `--app <name>`, `--pid <pid>`, `--window-id <id>`, `--window-title <title>`, `--window-index <n>` — resolve the app/window that should receive the click. In background mode this does not focus the app; with `--foreground` it focuses before clicking. (`--window-title`/`--window-index` require `--app` or `--pid`; `--window-id` does not.) |
 | `--wait-for <ms>` | Millisecond timeout while waiting for the element to appear (default 5000). |
 | `--double` / `--right` | Perform double-click or secondary-click instead of the default single click. `--double` requires `--foreground`; background delivery cannot position a double-click and fails with a clear error. |
+| `--long-press` | Send mouse-down, hold stationary for 1.2 seconds, then mouse-up. Long press implies foreground delivery and cannot be combined with `--double`, `--right`, or `--focus-background`. |
 | `--foreground` | Focus target and send a foreground mouse click. Focus flags also imply foreground delivery. |
 | Focus flags | `--no-auto-focus`, `--focus-timeout-seconds`, `--focus-retry-count`, `--space-switch`, `--bring-to-current-space` (foreground mode only; see `FocusCommandOptions`). |
 | `--focus-background` | Legacy alias for the default background delivery. Use `--app`, `--pid`, `--window-id`, or a snapshot with process metadata. |
@@ -28,6 +29,7 @@ read_when:
 - **Background** is the default when Peekaboo can resolve a target process from target flags or snapshot metadata. Every background click is delivered through accessibility actions and never activates or focuses the app: element/query clicks invoke the matching AX action on the cached element; coordinate clicks hit-test the AX element at the point (`AXUIElementCopyElementAtPosition`), then press (or show the menu on) the pressable element at that point — the hit result itself if it is pressable, otherwise a pressable descendant, otherwise a pressable ancestor. Pressability is checked with `AXUIElementCopyActionNames` (the actions API), not the `AXActionNames` attribute, so SwiftUI buttons that expose no action attribute are still pressed. Positioned process-targeted mouse events are never used — macOS delivers them at the window's top-left corner regardless of the requested point, so that path was removed.
 - Background clicks fail with an actionable error instead of guessing: if no pressable AX element exists at the target point (an empty spot, a custom-drawn view, or an element exposing no press action), or the click type cannot be delivered via accessibility (`--double`, middle-click), the command reports the limitation and suggests `--foreground`. A reported background success means the AX action was actually invoked at the resolved target.
 - **Foreground** (`--foreground`) focuses the target first (via `ensureFocused`, hopping Spaces if needed) and then synthesizes a real mouse click at the resolved screen point — element and query targets are resolved to their adjusted center and clicked with genuine mouse events, so double- and right-click semantics match hardware clicks. If the target app is still not frontmost after the focus step, the command fails rather than clicking into whichever app is in front.
+- Long press (`--long-press`) uses the foreground path and emits a stationary mouse-down/1.2-second hold/mouse-up sequence. It does not synthesize drag or micro-move events, because those can cancel native long-press recognizers.
 - Background coordinate clicks need `--app`, `--pid`, or `--window-id` so Peekaboo knows which process/window owns the coordinate. Without a target, use global coordinates with foreground delivery.
 - Right-click (`--right`) issues `AXShowMenu` without waiting for the context menu to close: a successfully opened menu runs a nested tracking runloop in the target app, so the command reports success once the menu is up instead of timing out behind it.
 
@@ -50,6 +52,9 @@ peekaboo click "Allow" --foreground --wait-for 8000 --space-switch
 
 # Issue a right-click at global screen coordinates
 peekaboo click --coords 1024,88 --right --foreground --no-auto-focus
+
+# Trigger a SwiftUI long-press gesture
+peekaboo click --coords 640,420 --long-press
 
 # Click 20,40 inside a resolved app window
 peekaboo click --app Safari --coords 20,40


### PR DESCRIPTION
## Summary

- add `peekaboo click --long-press` with a stationary 1.2-second foreground hold
- reject incompatible click and background-focus flags
- keep GUI bridge hosts responsive with an asynchronous, cancellation-safe mouse-up
- preflight Event Synthesizing permission and require protocol 1.10 plus the enabled `click` operation
- document the flag and add changelog coverage

Closes #240.

## Proof

- `pnpm run test:safe` — 738 tests in 84 suites passed
- focused automation tests — 10 tests passed, including pressure, cancellation cleanup, and permission denial
- focused runtime host tests — 16 tests passed, including stale/malformed bridge rejection
- production CLI live test against Playground — foreground long press succeeded in 1.66 seconds; fresh observation reported `Long press detected`
- source-blind behavior contract — help, successful gesture, incompatible-flag failure, and no-gesture-on-validation-failure passed
- autoreview (`gpt-5.6-sol`, xhigh, fast) — clean, no actionable findings
- SwiftFormat and `git diff --check` — clean
- SwiftLint on changed Swift files — no new violations; retained pre-existing type-length warning in `ClickServiceTargetResolutionTests`
