### PR TITLE
fix(cli): complete issue 242 live follow-ups

### DIFF
--- a/Apps/CLI/Sources/PeekabooCLI/Commands/System/MenuBarCommand.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/System/MenuBarCommand.swift
@@ -224,7 +224,7 @@ struct MenuBarCommand: ParsableCommand, ErrorHandlingCommand, OutputFormattable 
             throw PeekabooError.invalidInput("Please provide a menu bar item name or use --index")
         }
 
-        guard let item = self.matchMenuBarItem(named: name, items: items) else {
+        guard let item = matchMenuBarItem(named: name, items: items) else {
             throw PeekabooError.operationError(message: "Unable to resolve '\(name)' for verification")
         }
 
@@ -235,30 +235,6 @@ struct MenuBarCommand: ParsableCommand, ErrorHandlingCommand, OutputFormattable 
             bundleIdentifier: item.bundleIdentifier,
             preferredX: item.frame?.midX
         )
-    }
-
-    private func matchMenuBarItem(named name: String, items: [MenuBarItemInfo]) -> MenuBarItemInfo? {
-        let normalized = name.lowercased()
-        let candidates: [(MenuBarItemInfo, [String])] = items.map { item in
-            let fields = [
-                item.title,
-                item.rawTitle,
-                item.identifier,
-                item.axDescription,
-                item.ownerName,
-            ].compactMap { $0?.trimmingCharacters(in: .whitespacesAndNewlines) }
-            return (item, fields)
-        }
-
-        if let exact = candidates.first(where: { _, fields in
-            fields.contains(where: { $0.lowercased() == normalized })
-        })?.0 {
-            return exact
-        }
-
-        return candidates.first(where: { _, fields in
-            fields.contains(where: { $0.lowercased().contains(normalized) })
-        })?.0
     }
 }
 

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/System/MenuCommand+ClickExtra.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/System/MenuCommand+ClickExtra.swift
@@ -121,7 +121,7 @@ extension MenuCommand {
                 includeRaw: true
             )
             let normalized = self.title.trimmingCharacters(in: .whitespacesAndNewlines)
-            guard let item = self.matchMenuBarItem(named: normalized, items: items) else {
+            guard let item = matchMenuBarItem(named: normalized, items: items) else {
                 throw PeekabooError.operationError(message: "Unable to resolve '\(self.title)' for verification")
             }
 
@@ -132,30 +132,6 @@ extension MenuCommand {
                 bundleIdentifier: item.bundleIdentifier,
                 preferredX: item.frame?.midX
             )
-        }
-
-        private func matchMenuBarItem(named name: String, items: [MenuBarItemInfo]) -> MenuBarItemInfo? {
-            let normalized = name.lowercased()
-            let candidates: [(MenuBarItemInfo, [String])] = items.map { item in
-                let fields = [
-                    item.title,
-                    item.rawTitle,
-                    item.identifier,
-                    item.axDescription,
-                    item.ownerName,
-                ].compactMap { $0?.trimmingCharacters(in: .whitespacesAndNewlines) }
-                return (item, fields)
-            }
-
-            if let exact = candidates.first(where: { _, fields in
-                fields.contains(where: { $0.lowercased() == normalized })
-            })?.0 {
-                return exact
-            }
-
-            return candidates.first(where: { _, fields in
-                fields.contains(where: { $0.lowercased().contains(normalized) })
-            })?.0
         }
     }
 }

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/System/RunCommand.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/System/RunCommand.swift
@@ -18,7 +18,7 @@ struct RunCommand: OutputFormattable {
     @Argument(help: "Path to the script file (.peekaboo.json)")
     var scriptPath: String
 
-    @Option(help: "Save results to file instead of stdout")
+    @Option(help: "Save results to file (JSON mode also emits stdout)")
     var output: String?
 
     @Flag(help: "Continue execution even if a step fails")
@@ -100,11 +100,13 @@ struct RunCommand: OutputFormattable {
             if let outputPath = self.output {
                 let resolvedOutputPath = resolvedOutputPath(from: outputPath)
                 let data = try JSONEncoder().encode(output)
-                try data.write(to: URL(fileURLWithPath: resolvedOutputPath))
+                try data.write(to: URL(fileURLWithPath: resolvedOutputPath), options: .atomic)
                 if !self.jsonOutput {
                     print("✅ Script completed. Results saved to: \(resolvedOutputPath)")
                 }
-            } else if self.jsonOutput {
+            }
+
+            if self.jsonOutput {
                 let response = CodableJSONResponse(
                     success: output.success,
                     data: output,
@@ -113,7 +115,7 @@ struct RunCommand: OutputFormattable {
                 )
                 outputJSONCodable(response, logger: self.outputLogger)
                 didEmitJSONResponse = true
-            } else {
+            } else if self.output == nil {
                 self.printSummary(output)
             }
 

--- a/Apps/CLI/Sources/PeekabooCLI/Helpers/MenuBarVerificationTypes.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Helpers/MenuBarVerificationTypes.swift
@@ -1,5 +1,6 @@
 import CoreGraphics
 import Foundation
+import PeekabooCore
 
 struct MenuBarVerifyTarget {
     let title: String?
@@ -22,4 +23,37 @@ struct MenuBarFocusSnapshot {
     let windowId: Int?
     let windowTitle: String?
     let windowBounds: CGRect?
+}
+
+func matchMenuBarItem(named name: String, items: [MenuBarItemInfo]) -> MenuBarItemInfo? {
+    let normalized = name.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+    let candidates: [(MenuBarItemInfo, [String])] = items.map { item in
+        let fields = [
+            item.title,
+            item.rawTitle,
+            item.identifier,
+            item.axDescription,
+            item.ownerName,
+        ].compactMap { $0?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() }
+        return (item, fields)
+    }
+
+    if let exact = candidates.first(where: { _, fields in fields.contains(normalized) })?.0 {
+        return exact
+    }
+
+    let hyphens = "-‐‑‒–—"
+    func foldingHyphens(_ value: String) -> String {
+        String(value.filter { !hyphens.contains($0) })
+    }
+    let foldedName = foldingHyphens(normalized)
+    if let folded = candidates.first(where: { _, fields in
+        fields.contains(where: { foldingHyphens($0) == foldedName })
+    })?.0 {
+        return folded
+    }
+
+    return candidates.first(where: { _, fields in
+        fields.contains(where: { $0.contains(normalized) })
+    })?.0
 }

--- a/Apps/CLI/Tests/CLIAutomationTests/AgentCommandValidationIntegrationTests.swift
+++ b/Apps/CLI/Tests/CLIAutomationTests/AgentCommandValidationIntegrationTests.swift
@@ -457,12 +457,12 @@ private final class CLIResumableStepLimitProvider: PeekabooCustomProviderIdentit
         }
     }
 
-    private func nextToolCall() -> AgentToolCall {
+    private func nextToolCall() -> Tachikoma.AgentToolCall {
         let requestNumber = self.lock.withLock {
             self.requests += 1
             return self.requests
         }
-        return AgentToolCall(
+        return Tachikoma.AgentToolCall(
             id: "sleep-\(requestNumber)",
             name: "sleep",
             arguments: ["duration": AnyAgentToolValue(double: 1)]

--- a/Apps/CLI/Tests/CLIAutomationTests/RunCommandTests.swift
+++ b/Apps/CLI/Tests/CLIAutomationTests/RunCommandTests.swift
@@ -208,6 +208,36 @@ struct RunCommandCLIHarnessTests {
     }
 
     @Test
+    func `run command writes output file and emits JSON response`() async throws {
+        let scriptPath = "/tmp/json-output-script.peekaboo.json"
+        let script = PeekabooScript(description: "Write and emit output", steps: [])
+        let process = StubProcessService()
+        process.scriptsByPath[scriptPath] = script
+        process.nextExecuteScriptResults = []
+
+        let outputURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("run-json-results-\(UUID().uuidString).json")
+        defer { try? FileManager.default.removeItem(at: outputURL) }
+
+        let services = self.makeServices(process: process)
+        let result = try await InProcessCommandRunner.run([
+            "run",
+            scriptPath,
+            "--output", outputURL.path,
+            "--json",
+        ], services: services)
+
+        #expect(result.exitStatus == 0)
+        let stdoutData = try #require(result.stdout.data(using: .utf8))
+        let response = try JSONDecoder().decode(CodableJSONResponse<ScriptExecutionResult>.self, from: stdoutData)
+        #expect(response.data.scriptPath == scriptPath)
+
+        let fileData = try Data(contentsOf: outputURL)
+        let filePayload = try JSONDecoder().decode(ScriptExecutionResult.self, from: fileData)
+        #expect(filePayload.scriptPath == scriptPath)
+    }
+
+    @Test
     func `run command expands home directory script and output paths`() async throws {
         let scriptRelativePath = "Library/Caches/peekaboo-script-\(UUID().uuidString).peekaboo.json"
         let outputRelativePath = "Library/Caches/peekaboo-run-results-\(UUID().uuidString).json"

--- a/Apps/CLI/Tests/CoreCLITests/MenuBarItemMatcherTests.swift
+++ b/Apps/CLI/Tests/CoreCLITests/MenuBarItemMatcherTests.swift
@@ -1,0 +1,22 @@
+import PeekabooAutomationKit
+import Testing
+@testable import PeekabooCLI
+
+struct MenuBarItemMatcherTests {
+    @Test func `hyphen-folded menu bar title matches`() throws {
+        let item = MenuBarItemInfo(title: "WiFi", index: 0)
+
+        let matched = try #require(matchMenuBarItem(named: "Wi-Fi", items: [item]))
+
+        #expect(matched.index == 0)
+    }
+
+    @Test func `exact menu bar title wins over earlier folded match`() throws {
+        let folded = MenuBarItemInfo(title: "WiFi", index: 0)
+        let exact = MenuBarItemInfo(title: "Wi-Fi", index: 1)
+
+        let matched = try #require(matchMenuBarItem(named: "Wi-Fi", items: [folded, exact]))
+
+        #expect(matched.index == 1)
+    }
+}

--- a/Apps/Playground/README.md
+++ b/Apps/Playground/README.md
@@ -86,12 +86,15 @@ All actions are logged using Apple's OSLog framework with the subsystem `boo.pee
 ## Building and Running
 
 ```bash
-# Build the app
-cd Playground
-swift build
+# From the repository root, build the app with its Xcode project
+xcodebuild -project Apps/Playground/Playground.xcodeproj \
+  -scheme Playground \
+  -configuration Release \
+  -derivedDataPath Apps/Playground/.build \
+  build
 
 # Run the app
-./.build/debug/Playground
+open Apps/Playground/.build/Build/Products/Release/Playground.app
 ```
 
 ## Using with Peekaboo

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - The accessibility element boxes drawn during `peekaboo see` are off by default now; they were visual clutter on every capture. Re-enable them in Peekaboo.app under Settings › Visualizer › Screen › Element boxes, by setting `visualizer.elementDetectionEnabled` in `~/.peekaboo/config.json`, or per-run with `PEEKABOO_VISUAL_ELEMENT_BOXES=true`. The app toggle and the config file now stay in sync, and a running MCP server picks up the change without a restart.
 
 ### Fixed
+- `peekaboo run --json --output <file>` now emits its structured execution report to stdout as well as saving the report file, and menu bar title matching accepts common hyphen variants such as documented `Wi-Fi` against macOS's `WiFi` identifier.
 - Bridge-backed CLI commands now preserve app, window, element, menu, Dock, and snapshot lookup identities in structured errors instead of collapsing them to generic failures. Thanks @SebTardif for #258.
 - Click and type failures now emit `INTERACTION_FAILED` instead of `CAPTURE_FAILED` in structured CLI output. Thanks @SebTardif for #257.
 - The Mac app's status bar menu now follows the system light/dark mode. It previously inherited the menu bar's wallpaper-derived vibrant appearance, which could render a dark menu while the system was in light mode (and vice versa).

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/MenuService+Extras.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/MenuService+Extras.swift
@@ -43,28 +43,30 @@ extension MenuService {
 
         let extras = menuExtrasGroup.children(strict: true) ?? []
         let normalizedTarget = normalizedMenuTitle(title)
-        guard let menuExtra = extras.first(where: { element in
-            let candidates = [
+        func candidates(for element: Element) -> [String?] {
+            [
                 element.title(),
                 element.help(),
                 element.descriptionText(),
                 element.identifier(),
             ]
-            if candidates
-                .contains(where: { titlesMatch(candidate: $0, target: title, normalizedTarget: normalizedTarget) })
-            {
-                return true
-            }
-            if self.partialMatchEnabled,
-               candidates.contains(where: { titlesMatchPartial(
-                   candidate: $0,
-                   target: title,
-                   normalizedTarget: normalizedTarget) })
-            {
-                return true
-            }
-            return false
-        }) else {
+        }
+
+        let menuExtra = extras.first(where: { element in
+            candidates(for: element).contains(where: {
+                titlesMatch(candidate: $0, target: title, normalizedTarget: normalizedTarget)
+            })
+        }) ?? extras.first(where: { element in
+            candidates(for: element).contains(where: { menuExtraTitlesMatch(candidate: $0, target: title) })
+        }) ?? extras.first(where: { element in
+            guard self.partialMatchEnabled else { return false }
+            return candidates(for: element).contains(where: { titlesMatchPartial(
+                candidate: $0,
+                target: title,
+                normalizedTarget: normalizedTarget) })
+        })
+
+        guard let menuExtra else {
             var context = ErrorContext()
             context.add("menuExtra", title)
             context.add("availableExtras", extras.count)
@@ -203,11 +205,13 @@ extension MenuService {
             let items = try await listMenuBarItems(includeRaw: false)
             let normalizedName = normalizedMenuTitle(name)
 
-            if let item = items.first(where: { titlesMatch(
-                candidate: $0.title,
-                target: name,
-                normalizedTarget: normalizedName) })
-            {
+            if let item = items.first(where: {
+                titlesMatch(candidate: $0.title, target: name, normalizedTarget: normalizedName)
+            }) {
+                return try await self.clickMenuBarItem(at: item.index)
+            }
+
+            if let item = items.first(where: { menuExtraTitlesMatch(candidate: $0.title, target: name) }) {
                 return try await self.clickMenuBarItem(at: item.index)
             }
 

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/UIAXHelpers.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/UIAXHelpers.swift
@@ -68,6 +68,24 @@ func sanitizedMenuText(_ value: String?) -> String? {
     return candidateNormalized == targetNormalized
 }
 
+@_spi(Testing) public func menuExtraTitlesMatch(candidate: String?, target: String) -> Bool {
+    if titlesMatch(candidate: candidate, target: target) {
+        return true
+    }
+
+    func foldingHyphens(_ value: String?) -> String? {
+        normalizedMenuTitle(value)?.replacingOccurrences(
+            of: #"[-‐‑‒–—]"#,
+            with: "",
+            options: .regularExpression)
+    }
+
+    guard let candidateNormalized = foldingHyphens(candidate),
+          let targetNormalized = foldingHyphens(target)
+    else { return false }
+    return candidateNormalized == targetNormalized
+}
+
 @_spi(Testing) public func titlesMatchPartial(
     candidate: String?,
     target: String,

--- a/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/MenuTitleMatchTests.swift
+++ b/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/MenuTitleMatchTests.swift
@@ -19,4 +19,13 @@ final class MenuTitleMatchTests: XCTestCase {
             normalizedTarget: normalized ?? "")
         XCTAssertFalse(matches)
     }
+
+    func testMenuExtraTitlesMatchIgnoresHyphenVariants() {
+        XCTAssertTrue(menuExtraTitlesMatch(candidate: "WiFi", target: "Wi-Fi"))
+        XCTAssertTrue(menuExtraTitlesMatch(candidate: "Wi‑Fi", target: "WiFi"))
+    }
+
+    func testApplicationMenuTitlesKeepHyphensSignificant() {
+        XCTAssertFalse(titlesMatch(candidate: "Re-sign", target: "Resign"))
+    }
 }

--- a/docs/commands/run.md
+++ b/docs/commands/run.md
@@ -13,14 +13,14 @@ read_when:
 | Flag | Description |
 | --- | --- |
 | `<scriptPath>` | Positional argument pointing at a `.peekaboo.json` file. |
-| `--output <file>` | Write the JSON execution report to disk instead of stdout. |
+| `--output <file>` | Write the JSON execution report to disk. With `--json`, the report is also emitted to stdout. |
 | `--no-fail-fast` | Continue executing the remaining steps even if one fails (default behavior is fail-fast). |
 | `--json` | Emit machine-readable JSON to stdout (wrapper + `ScriptExecutionResult`). (Alias: `--json-output` / `-j`) |
 
 ## Implementation notes
 - Scripts are parsed on the main actor via `services.process.loadScript`, so relative paths (`~/`, `./`) resolve exactly as they do when agents run scripts.
 - Execution delegates to `services.process.executeScript`, which returns a `[StepResult]` containing individual timings, success flags, and error strings; the command wraps those in a summary with total durations and counts.
-- `--output` writes via `JSONEncoder().encode` + atomic file replacement; if the write succeeds but the script fails, you still get the partial data for debugging.
+- `--output` writes via `JSONEncoder().encode` + atomic file replacement; if the write succeeds but the script fails, you still get the partial data for debugging. Pairing it with `--json` also emits the structured response to stdout.
 - `<scriptPath>` and `--output` accept `~/...`.
 - Script-level `see` screenshot paths and clipboard file/output paths also accept `~/...`.
 - In JSON mode (`--json` / `--json-output` / `-j`), stdout is a single `CodableJSONResponse<ScriptExecutionResult>` payload (top-level `success` tracks overall script success).


### PR DESCRIPTION
Fixes #242.

## Summary

- emit structured stdout when `peekaboo run --json` is combined with `--output`, while retaining the bare execution report in the output file
- accept hyphen variants for menu extras without weakening application-menu matching; exact titles retain precedence
- apply the same menu-extra resolution to verified click paths
- replace stale Playground SwiftPM instructions with a runnable ad-hoc Release Xcode build
- qualify the automation-test `AgentToolCall` fixture so that target compiles

The issue's snapshot-cleaning and hidden-app-list observations are already fixed/accepted on current main and were rechecked live.

## Proof

- `pnpm run test:safe` — 740 tests, 85 suites
- `swift test --package-path Core/PeekabooAutomationKit --filter MenuTitleMatchTests`
- `swift test --package-path Apps/CLI --filter MenuBarItemMatcherTests`
- `pnpm run build:cli`
- live `menubar click "Wi-Fi" --no-remote --verify --json` — clicked `WiFi`, `verified: true`
- source-blind behavior contract — all five #242 clauses passed
- Playground Release bundle built and passed strict ad-hoc codesign verification
- autoreview — clean (`gpt-5.6-sol`, `xhigh`, fast tier)
