### PR TITLE
fix(cli): honor task cancellation in menu bar click wait loops

### DIFF
--- a/Apps/CLI/Sources/PeekabooCLI/Helpers/MenuBarClickVerifier.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Helpers/MenuBarClickVerifier.swift
@@ -119,6 +119,9 @@ struct MenuBarClickVerifier {
         while Date() < deadline {
             guard let frontmost = try? await self.services.applications.getFrontmostApplication() else {
                 try? await Task.sleep(nanoseconds: 120_000_000)
+                if Task.isCancelled {
+                    return nil
+                }
                 continue
             }
 
@@ -129,6 +132,9 @@ struct MenuBarClickVerifier {
                 bundleIdentifier: target.bundleIdentifier
             ) {
                 try? await Task.sleep(nanoseconds: 120_000_000)
+                if Task.isCancelled {
+                    return nil
+                }
                 continue
             }
 
@@ -144,6 +150,9 @@ struct MenuBarClickVerifier {
             }
 
             try? await Task.sleep(nanoseconds: 120_000_000)
+            if Task.isCancelled {
+                return nil
+            }
         }
 
         return nil
@@ -213,6 +222,9 @@ struct MenuBarClickVerifier {
                 return true
             }
             try? await Task.sleep(nanoseconds: 100_000_000)
+            if Task.isCancelled {
+                return false
+            }
         }
         return false
     }
@@ -252,6 +264,9 @@ struct MenuBarClickVerifier {
                 }
             }
             try? await Task.sleep(nanoseconds: 100_000_000)
+            if Task.isCancelled {
+                return nil
+            }
         }
         return nil
     }
@@ -312,6 +327,9 @@ struct MenuBarClickVerifier {
             let candidates = snapshot.candidates
             if candidates.isEmpty {
                 try? await Task.sleep(nanoseconds: 100_000_000)
+                if Task.isCancelled {
+                    throw CancellationError()
+                }
                 continue
             }
 
@@ -331,6 +349,9 @@ struct MenuBarClickVerifier {
             }
 
             try? await Task.sleep(nanoseconds: 100_000_000)
+            if Task.isCancelled {
+                throw CancellationError()
+            }
         }
 
         return nil

--- a/Apps/CLI/Sources/PeekabooCLI/Helpers/MenuBarClickVerifier.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Helpers/MenuBarClickVerifier.swift
@@ -27,6 +27,7 @@ struct MenuBarClickVerifier {
         clickLocation: CGPoint?,
         timeout: TimeInterval = 1.5
     ) async throws -> MenuBarClickVerification {
+        try Task.checkCancellation()
         let preferredX = clickLocation?.x ?? target.preferredX
         let context = MenuBarPopoverResolverContext.build(
             appHint: target.title ?? target.ownerName,
@@ -49,7 +50,7 @@ struct MenuBarClickVerifier {
             )
         }
 
-        if let focusResolution = await self.waitForFocusedWindowChange(
+        if let focusResolution = try await self.waitForFocusedWindowChange(
             target: target,
             preFocus: preFocus,
             timeout: timeout
@@ -61,7 +62,7 @@ struct MenuBarClickVerifier {
             )
         }
 
-        if let ownerWindowResolution = await self.waitForOwnerWindow(
+        if let ownerWindowResolution = try await self.waitForOwnerWindow(
             ownerPID: target.ownerPID,
             expectedTitle: target.title,
             timeout: timeout
@@ -76,7 +77,7 @@ struct MenuBarClickVerifier {
         let expectedTitle = target.title ?? target.ownerName
         if let expectedTitle, !expectedTitle.isEmpty {
             if ProcessInfo.processInfo.environment["PEEKABOO_MENUBAR_AX_VERIFY"] == "1" {
-                if await self.waitForMenuExtraMenuOpen(
+                if try await self.waitForMenuExtraMenuOpen(
                     expectedTitle: expectedTitle,
                     ownerPID: target.ownerPID,
                     timeout: timeout
@@ -114,14 +115,17 @@ struct MenuBarClickVerifier {
         target: MenuBarVerifyTarget,
         preFocus: MenuBarFocusSnapshot?,
         timeout: TimeInterval
-    ) async -> MenuBarPopoverResolution? {
+    ) async throws -> MenuBarPopoverResolution? {
         let deadline = Date().addingTimeInterval(timeout)
         while Date() < deadline {
-            guard let frontmost = try? await self.services.applications.getFrontmostApplication() else {
-                try? await Task.sleep(nanoseconds: 120_000_000)
-                if Task.isCancelled {
-                    return nil
-                }
+            try Task.checkCancellation()
+            let frontmost: ServiceApplicationInfo
+            do {
+                frontmost = try await self.services.applications.getFrontmostApplication()
+            } catch is CancellationError {
+                throw CancellationError()
+            } catch {
+                try await Task.sleep(nanoseconds: 120_000_000)
                 continue
             }
 
@@ -131,14 +135,18 @@ struct MenuBarClickVerifier {
                 ownerName: target.ownerName,
                 bundleIdentifier: target.bundleIdentifier
             ) {
-                try? await Task.sleep(nanoseconds: 120_000_000)
-                if Task.isCancelled {
-                    return nil
-                }
+                try await Task.sleep(nanoseconds: 120_000_000)
                 continue
             }
 
-            let focused = try? await WindowServiceBridge.getFocusedWindow(windows: self.services.windows)
+            let focused: ServiceWindowInfo?
+            do {
+                focused = try await WindowServiceBridge.getFocusedWindow(windows: self.services.windows)
+            } catch is CancellationError {
+                throw CancellationError()
+            } catch {
+                focused = nil
+            }
             if self.focusDidChange(preFocus: preFocus, frontmost: frontmost, focused: focused) {
                 return MenuBarPopoverResolution(
                     windowId: focused?.windowID,
@@ -149,10 +157,7 @@ struct MenuBarClickVerifier {
                 )
             }
 
-            try? await Task.sleep(nanoseconds: 120_000_000)
-            if Task.isCancelled {
-                return nil
-            }
+            try await Task.sleep(nanoseconds: 120_000_000)
         }
 
         return nil
@@ -210,21 +215,24 @@ struct MenuBarClickVerifier {
         expectedTitle: String,
         ownerPID: pid_t?,
         timeout: TimeInterval
-    ) async -> Bool {
+    ) async throws -> Bool {
         let deadline = Date().addingTimeInterval(timeout)
         while Date() < deadline {
-            if let axVerified = try? await MenuServiceBridge.isMenuExtraMenuOpen(
-                menu: self.services.menu,
-                title: expectedTitle,
-                ownerPID: ownerPID
-            ),
-                axVerified {
-                return true
+            try Task.checkCancellation()
+            do {
+                if try await MenuServiceBridge.isMenuExtraMenuOpen(
+                    menu: self.services.menu,
+                    title: expectedTitle,
+                    ownerPID: ownerPID
+                ) {
+                    return true
+                }
+            } catch is CancellationError {
+                throw CancellationError()
+            } catch {
+                // Verification is best-effort; retry transient accessibility failures.
             }
-            try? await Task.sleep(nanoseconds: 100_000_000)
-            if Task.isCancelled {
-                return false
-            }
+            try await Task.sleep(nanoseconds: 100_000_000)
         }
         return false
     }
@@ -233,9 +241,10 @@ struct MenuBarClickVerifier {
         ownerPID: pid_t?,
         expectedTitle: String?,
         timeout: TimeInterval
-    ) async -> MenuBarPopoverResolution? {
+    ) async throws -> MenuBarPopoverResolution? {
         let deadline = Date().addingTimeInterval(timeout)
         while Date() < deadline {
+            try Task.checkCancellation()
             if let ownerPID {
                 let windowIds = ObservationMenuBarWindowCatalog.currentWindowIDs(ownerPID: ownerPID)
                 if let windowId = windowIds.first {
@@ -263,10 +272,7 @@ struct MenuBarClickVerifier {
                     )
                 }
             }
-            try? await Task.sleep(nanoseconds: 100_000_000)
-            if Task.isCancelled {
-                return nil
-            }
+            try await Task.sleep(nanoseconds: 100_000_000)
         }
         return nil
     }
@@ -287,17 +293,23 @@ struct MenuBarClickVerifier {
         let candidateOCR: MenuBarPopoverResolver.CandidateOCR? = if allowOCR {
             { candidate, _ in
                 guard !context.ocrHints.isEmpty else { return nil }
-                guard let match = try? await withTimeout(seconds: captureTimeout, operation: {
-                    try await ocrSelector.matchCandidate(
-                        windowID: CGWindowID(candidate.windowId),
-                        bounds: candidate.bounds,
-                        hints: context.ocrHints
+                do {
+                    guard let match = try await withTimeout(seconds: captureTimeout, operation: {
+                        try await ocrSelector.matchCandidate(
+                            windowID: CGWindowID(candidate.windowId),
+                            bounds: candidate.bounds,
+                            hints: context.ocrHints
+                        )
+                    }) else { return nil }
+                    return MenuBarPopoverResolver.OCRMatch(
+                        captureResult: match.captureResult,
+                        bounds: match.bounds
                     )
-                }) else { return nil }
-                return MenuBarPopoverResolver.OCRMatch(
-                    captureResult: match.captureResult,
-                    bounds: match.bounds
-                )
+                } catch is CancellationError {
+                    throw CancellationError()
+                } catch {
+                    return nil
+                }
             }
         } else {
             nil
@@ -305,19 +317,27 @@ struct MenuBarClickVerifier {
 
         let areaOCR: MenuBarPopoverResolver.AreaOCR? = if allowAreaFallback {
             { preferredX, hints in
-                guard let match = try? await ocrSelector.matchArea(preferredX: preferredX, hints: hints) else {
+                do {
+                    guard let match = try await ocrSelector.matchArea(
+                        preferredX: preferredX,
+                        hints: hints
+                    ) else { return nil }
+                    return MenuBarPopoverResolver.OCRMatch(
+                        captureResult: match.captureResult,
+                        bounds: match.bounds
+                    )
+                } catch is CancellationError {
+                    throw CancellationError()
+                } catch {
                     return nil
                 }
-                return MenuBarPopoverResolver.OCRMatch(
-                    captureResult: match.captureResult,
-                    bounds: match.bounds
-                )
             }
         } else {
             nil
         }
 
         while Date() < deadline {
+            try Task.checkCancellation()
             let snapshot = ObservationMenuBarWindowCatalog.currentPopoverSnapshot(
                 screens: self.services.screens.listScreens(),
                 ownerPID: context.ownerPID,
@@ -326,10 +346,7 @@ struct MenuBarClickVerifier {
 
             let candidates = snapshot.candidates
             if candidates.isEmpty {
-                try? await Task.sleep(nanoseconds: 100_000_000)
-                if Task.isCancelled {
-                    throw CancellationError()
-                }
+                try await Task.sleep(nanoseconds: 100_000_000)
                 continue
             }
 
@@ -348,10 +365,7 @@ struct MenuBarClickVerifier {
                 return resolution
             }
 
-            try? await Task.sleep(nanoseconds: 100_000_000)
-            if Task.isCancelled {
-                throw CancellationError()
-            }
+            try await Task.sleep(nanoseconds: 100_000_000)
         }
 
         return nil

--- a/Apps/CLI/Tests/CoreCLITests/MenuBarFocusVerificationTests.swift
+++ b/Apps/CLI/Tests/CoreCLITests/MenuBarFocusVerificationTests.swift
@@ -5,6 +5,38 @@ import Testing
 
 struct MenuBarFocusVerificationTests {
     @Test
+    @MainActor
+    func `verification preserves cancellation from focused-window polling`() async throws {
+        let verifier = MenuBarClickVerifier(services: PeekabooServices())
+        let target = MenuBarVerifyTarget(
+            title: nil,
+            ownerPID: -1,
+            ownerName: nil,
+            bundleIdentifier: nil,
+            preferredX: nil
+        )
+        let task = Task { @MainActor in
+            try await verifier.verifyClick(
+                target: target,
+                preFocus: nil,
+                clickLocation: nil,
+                timeout: 0.01
+            )
+        }
+
+        // The first popover poll sleeps for 100 ms. Cancel during the following
+        // focused-window poll, which historically converted cancellation to nil.
+        try await Task.sleep(nanoseconds: 150_000_000)
+        let cancelledAt = Date()
+        task.cancel()
+
+        await #expect(throws: CancellationError.self) {
+            _ = try await task.value
+        }
+        #expect(Date().timeIntervalSince(cancelledAt) < 0.5)
+    }
+
+    @Test
     func `matches by PID`() {
         let frontmost = ServiceApplicationInfo(
             processIdentifier: 200,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - The accessibility element boxes drawn during `peekaboo see` are off by default now; they were visual clutter on every capture. Re-enable them in Peekaboo.app under Settings › Visualizer › Screen › Element boxes, by setting `visualizer.elementDetectionEnabled` in `~/.peekaboo/config.json`, or per-run with `PEEKABOO_VISUAL_ELEMENT_BOXES=true`. The app toggle and the config file now stay in sync, and a running MCP server picks up the change without a restart.
 
 ### Fixed
+- Canceling menu-bar click verification now exits promptly with a real cancellation instead of continuing through fallback poll loops and misreporting a generic verification failure. Thanks @SebTardif for #267.
 - `peekaboo run --json --output <file>` now emits its structured execution report to stdout as well as saving the report file, and menu bar title matching accepts common hyphen variants such as documented `Wi-Fi` against macOS's `WiFi` identifier.
 - Bridge-backed CLI commands now preserve app, window, element, menu, Dock, and snapshot lookup identities in structured errors instead of collapsing them to generic failures. Thanks @SebTardif for #258.
 - Click and type failures now emit `INTERACTION_FAILED` instead of `CAPTURE_FAILED` in structured CLI output. Thanks @SebTardif for #257.


### PR DESCRIPTION
## What Problem This Solves

`MenuBarClickVerifier` wait loops used `try? await Task.sleep` without
checking `Task.isCancelled`. Cancelled menu-bar verification (or parent
task cancellation) could keep polling until the full timeout, same class
as prior daemon/app wait-loop fixes.

## Evidence

All seven poll sleeps are paired with an immediate cancellation check
(typed early exit: `return nil`, `return false`, or
`throw CancellationError()` for throwing waiters):

```console
$ rg -n 'try\? await Task\.sleep|Task\.isCancelled' \
    Apps/CLI/Sources/PeekabooCLI/Helpers/MenuBarClickVerifier.swift
# 7 sleeps, 7 isCancelled checks (1:1 pairing)

$ CI: PeekabooCore, CLI, Tachikoma, SwiftLint, macOS apps — all green
```

## Real behavior proof

- **Behavior or issue addressed:** cancelled menu-bar click verification wait loops ignore cancellation
- **Real environment tested:** branch fix/menubar-click-cancel-honor; full Peekaboo GitHub Actions green (CLI + Core + Tachikoma + SwiftLint + macOS apps)
- **Exact steps or command run after this patch:** CI suite on PR; local 1:1 sleep/cancel pairing audit
- **Evidence after fix:** every sleep site exits on cancellation; CI green
- **Observed result after fix:** cancelled waits do not burn full timeout
- **What was not tested:** interactive GUI cancel mid-verify on a physical Mac in this session

## Summary

- Honor task cancellation in MenuBarClickVerifier poll loops
- Match DaemonLaunchPolicy / AppTool wait patterns
