### PR TITLE
chore(deps): refresh stable dependencies

### DIFF
--- a/Apps/CLI/Package.swift
+++ b/Apps/CLI/Package.swift
@@ -113,9 +113,9 @@ let package = Package(
     ],
     dependencies: [
         .package(path: "../../Commander"),
-        .package(url: "https://github.com/modelcontextprotocol/swift-sdk.git", "0.12.0" ..< "0.13.0"),
-        .package(url: "https://github.com/dominicegginton/Spinner", from: "2.1.0"),
-        .package(url: "https://github.com/swiftlang/swift-subprocess.git", from: "0.2.1"),
+        .package(url: "https://github.com/modelcontextprotocol/swift-sdk.git", "0.12.1" ..< "0.13.0"),
+        .package(url: "https://github.com/dominicegginton/Spinner", from: "2.2.0"),
+        .package(url: "https://github.com/swiftlang/swift-subprocess.git", from: "0.5.0"),
         .package(path: "../../TauTUI"),
         .package(path: "../../Core/PeekabooFoundation"),
         .package(path: "../../Core/PeekabooVisualizer"),

--- a/Apps/Mac/Package.resolved
+++ b/Apps/Mac/Package.resolved
@@ -69,8 +69,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-collections",
       "state" : {
-        "branch" : "main",
-        "revision" : "6c12132eacd79a23b4bf9321e3afe7755d37f0c7"
+        "revision" : "a0cb0954ecb21e4e31b0070e6ed5674e8556685a",
+        "version" : "1.6.0"
       }
     },
     {
@@ -141,8 +141,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-system",
       "state" : {
-        "revision" : "7502b711c92a17741fa625d722b0ccbd595d8ed1",
-        "version" : "1.7.2"
+        "revision" : "b5544ba79a70a0cb3563e75bf26dc198d6b40ed3",
+        "version" : "1.7.4"
       }
     }
   ],

--- a/Core/PeekabooCore/Package.resolved
+++ b/Core/PeekabooCore/Package.resolved
@@ -51,8 +51,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-collections",
       "state" : {
-        "branch" : "main",
-        "revision" : "6c12132eacd79a23b4bf9321e3afe7755d37f0c7"
+        "revision" : "a0cb0954ecb21e4e31b0070e6ed5674e8556685a",
+        "version" : "1.6.0"
       }
     },
     {
@@ -123,8 +123,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-system",
       "state" : {
-        "revision" : "7502b711c92a17741fa625d722b0ccbd595d8ed1",
-        "version" : "1.7.2"
+        "revision" : "b5544ba79a70a0cb3563e75bf26dc198d6b40ed3",
+        "version" : "1.7.4"
       }
     }
   ],

--- a/Core/PeekabooExternalDependencies/Package.swift
+++ b/Core/PeekabooExternalDependencies/Package.swift
@@ -28,8 +28,7 @@ let package = Package(
         .package(path: "../../Commander"),
         .package(url: "https://github.com/apple/swift-log", from: "1.6.4"),
         .package(url: "https://github.com/apple/swift-system", from: "1.6.3"),
-        // Use main to pick up Swift 6 fixes until the next tagged release.
-        .package(url: "https://github.com/apple/swift-collections", branch: "main"),
+        .package(url: "https://github.com/apple/swift-collections", from: "1.6.0"),
     ],
     targets: [
         .target(

--- a/package.json
+++ b/package.json
@@ -81,5 +81,5 @@
   "devDependencies": {
     "chrome-devtools-mcp": "1.5.0"
   },
-  "packageManager": "pnpm@10.34.4"
+  "packageManager": "pnpm@10.34.5"
 }


### PR DESCRIPTION
## Summary

- move CLI dependency floors to the current stable MCP Swift SDK, Spinner, and Swift Subprocess releases
- replace the temporary Swift Collections `main` dependency with stable 1.6.0
- refresh Swift System locks to 1.7.4 and pnpm to the security-fixed 10.34.5 release

## Dependency and security audit

- all direct Swift dependencies are current stable releases; repositories are active and unarchived
- a fresh CLI resolution selects Swift NIO 2.101.2, Swift Crypto 4.5.0, Swift ASN.1 1.7.1, Swift Atomics 1.3.1, Swift Log 1.14.0, and Swift Async Algorithms 1.1.5
- `pnpm audit`: zero vulnerabilities
- GitHub Dependabot: zero open alerts
- the only matching Swift advisory affects Swift Crypto through 4.3.0; this candidate resolves 4.5.0
- pnpm 11.12.0 was evaluated but intentionally deferred because the repository's normal pnpm manager path cannot activate that project pin; 10.34.5 is the current supported security-fixed 10.x release

## Proof for exact head `adea86e891f81dcf8e2675baf20528929fda88eb`

- `swift test --package-path Apps/CLI --no-parallel --filter CLIRuntimeSmokeTests`: 21 tests passed
- `pnpm run test:safe`: 741 tests in 85 suites passed
- fresh-resolution `pnpm run test:all`: 1,331 tests ran; only the two pre-existing See snapshot-publication tests failed with the same known six assertions
- `swift build --package-path Apps/Mac`: passed
- `pnpm run lint`: 0 serious findings, 13 pre-existing warnings
- `swiftformat --lint .`: clean
- AutoReview: clean, no actionable findings, correctness confidence 0.93
- Developer-ID-signed ARM64 build: strict signature verification passed with OpenClaw Foundation Team ID `FWJYW4S8P8`
- signed artifact SHA-256: `9b488a4fa2a6d963567d3539aa307210c7970decf80e3571bdaf4c88a8d2b055`
- real GUI bridge: handshake succeeded and the signed binary listed 77 running applications
- Public Model Identifier Gate: PASS; no identifier delta and the signed artifact's provider-shaped string set exactly matches the cleared baseline

## Scope

Five files, 13 insertions, 14 deletions. No application source, release version, tag, registry, or deployment changes.
