### PR TITLE
feat: improve desktop interaction ergonomics

### DIFF
--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Base/CursorMovementResolver.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Base/CursorMovementResolver.swift
@@ -40,7 +40,7 @@ enum CursorMovementResolver {
             )
         case .human:
             let resolvedDuration = request.durationOverride ?? Self.humanDuration(for: request.distance)
-            let resolvedSteps = max(request.stepsOverride ?? Self.humanSteps(for: request.distance), 30)
+            let resolvedSteps = max(request.stepsOverride ?? Self.humanSteps(for: request.distance), 1)
             return CursorMovementParameters(
                 profile: .human(),
                 duration: resolvedDuration,
@@ -59,7 +59,7 @@ enum CursorMovementResolver {
     }
 
     private static func humanSteps(for distance: CGFloat) -> Int {
-        let scaled = Int(distance * 0.35)
-        return min(max(scaled, 40), 140)
+        let scaled = Int(distance * 0.22)
+        return min(max(scaled, 30), 96)
     }
 }

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Interaction/MoveCommand+CommanderMetadata.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Interaction/MoveCommand+CommanderMetadata.swift
@@ -17,13 +17,13 @@ extension MoveCommand: ParsableCommand {
                       peekaboo move 100,200                 # Move to coordinates
                       peekaboo move --to "Submit Button"    # Move to element by text
                       peekaboo move --on "$ELEMENT_ID"      # ID copied from current output
-                      peekaboo move 500,300 --smooth        # Smooth movement
+                      peekaboo move 500,300 --smooth        # Natural smooth movement
                       peekaboo move --center                # Move to screen center
 
                     MOVEMENT MODES:
                       - Instant (default): Immediate cursor positioning
-                      - Smooth: Animated movement with configurable duration
-                      - Human: Natural arcs with eased velocity, enable via '--profile human'
+                      - Smooth: Natural arcs with eased velocity
+                      - Linear: Deterministic straight-line travel via '--profile linear'
 
                     ELEMENT TARGETING:
                       When targeting elements, the cursor moves to the element's center.
@@ -99,7 +99,7 @@ extension MoveCommand: CommanderSignatureProviding {
                 ),
                 .commandOption(
                     "steps",
-                    help: "Number of steps for smooth movement",
+                    help: "Number of movement samples",
                     long: "steps"
                 ),
                 .commandOption(
@@ -121,7 +121,7 @@ extension MoveCommand: CommanderSignatureProviding {
                 ),
                 .commandFlag(
                     "smooth",
-                    help: "Use smooth movement animation",
+                    help: "Use natural smooth movement",
                     long: "smooth"
                 ),
             ],

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Interaction/MoveCommand+Movement.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Interaction/MoveCommand+Movement.swift
@@ -3,56 +3,28 @@ import Foundation
 import PeekabooCore
 
 extension MoveCommand {
-    var selectedProfile: MovementProfileSelection {
+    var selectedProfile: CursorMovementProfileSelection {
         guard let profileName = self.profile?.lowercased(),
-              let selection = MovementProfileSelection(rawValue: profileName) else {
-            return .linear
+              let selection = CursorMovementProfileSelection(rawValue: profileName) else {
+            return self.smooth || (self.duration ?? 0) > 0 ? .human : .linear
         }
         return selection
     }
 
     func resolveMovementParameters(
-        profileSelection: MovementProfileSelection,
+        profileSelection: CursorMovementProfileSelection,
         distance: CGFloat
-    ) -> MovementParameters {
-        switch profileSelection {
-        case .linear:
-            let wantsSmooth = self.smooth || (self.duration ?? 0) > 0
-            let resolvedDuration: Int = if let customDuration = self.duration {
-                customDuration
-            } else {
-                wantsSmooth ? 500 : 0
-            }
-            let resolvedSteps = wantsSmooth ? max(self.steps, 1) : 1
-            return MovementParameters(
-                profile: .linear,
-                duration: resolvedDuration,
-                steps: resolvedSteps,
-                smooth: wantsSmooth,
-                profileName: profileSelection.rawValue
+    ) -> CursorMovementParameters {
+        CursorMovementResolver.resolve(
+            CursorMovementResolutionRequest(
+                selection: profileSelection,
+                durationOverride: self.duration,
+                stepsOverride: self.steps,
+                baseSmooth: self.smooth || self.duration != nil,
+                distance: distance,
+                defaultDuration: 500,
+                defaultSteps: 20
             )
-        case .human:
-            let resolvedDuration = self.duration ?? self.defaultHumanDuration(for: distance)
-            let resolvedSteps = max(self.steps, self.defaultHumanSteps(for: distance))
-            return MovementParameters(
-                profile: .human(),
-                duration: resolvedDuration,
-                steps: resolvedSteps,
-                smooth: true,
-                profileName: profileSelection.rawValue
-            )
-        }
-    }
-
-    private func defaultHumanDuration(for distance: CGFloat) -> Int {
-        let distanceFactor = log2(Double(distance) + 1) * 90
-        let perPixel = Double(distance) * 0.45
-        let estimate = 240 + distanceFactor + perPixel
-        return min(max(Int(estimate), 280), 1700)
-    }
-
-    private func defaultHumanSteps(for distance: CGFloat) -> Int {
-        let scaled = Int(distance * 0.35)
-        return min(max(scaled, 30), 120)
+        )
     }
 }

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Interaction/MoveCommand+Types.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Interaction/MoveCommand+Types.swift
@@ -39,19 +39,6 @@ struct MoveResult: Codable {
     }
 }
 
-enum MovementProfileSelection: String {
-    case linear
-    case human
-}
-
-struct MovementParameters {
-    let profile: MouseMovementProfile
-    let duration: Int
-    let steps: Int
-    let smooth: Bool
-    let profileName: String
-}
-
 struct MoveTargetResolution {
     let location: CGPoint
     let description: String

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Interaction/MoveCommand.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Interaction/MoveCommand.swift
@@ -29,16 +29,16 @@ struct MoveCommand: ErrorHandlingCommand, OutputFormattable {
     @Flag(help: "Move to screen center")
     var center = false
 
-    @Flag(help: "Use smooth movement animation")
+    @Flag(help: "Use natural smooth movement (equivalent to --profile human)")
     var smooth = false
 
-    @Option(help: "Movement duration in milliseconds (default: 500 for smooth, 0 for instant)")
+    @Option(help: "Movement duration in milliseconds (enables natural movement when no profile is given)")
     var duration: Int?
 
-    @Option(help: "Number of steps for smooth movement (default: 20)")
-    var steps: Int = 20
+    @Option(help: "Number of movement samples (automatic for human, default: 20 for linear)")
+    var steps: Int?
 
-    @Option(help: "Movement profile: linear (default) or human.")
+    @Option(help: "Movement profile: human or linear (default: human for animated moves, otherwise linear)")
     var profile: String?
 
     @Option(help: "Snapshot ID for element resolution, or 'latest'")
@@ -101,8 +101,15 @@ struct MoveCommand: ErrorHandlingCommand, OutputFormattable {
         }
 
         if let profileName = self.profile?.lowercased(),
-           MovementProfileSelection(rawValue: profileName) == nil {
+           CursorMovementProfileSelection(rawValue: profileName) == nil {
             throw ValidationError("Invalid profile '\(profileName)'. Use 'linear' or 'human'.")
+        }
+
+        if let duration, duration < 0 {
+            throw ValidationError("--duration must be zero or greater")
+        }
+        if let steps, steps < 1 {
+            throw ValidationError("--steps must be at least 1")
         }
     }
 

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/MCP/InspectUICommand.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/MCP/InspectUICommand.swift
@@ -27,7 +27,7 @@ struct InspectUICommand: ErrorHandlingCommand, OutputFormattable, RuntimeOptions
         accessibility-tree text inspection when `see` screenshots are too broad.
 
         Examples:
-          peekaboo inspect-ui --app-target TextEdit
+          peekaboo inspect-ui --app TextEdit
           peekaboo inspect-ui --snapshot 1234 --max-elements 200 --json
         """
     )
@@ -117,7 +117,8 @@ extension InspectUICommand: CommanderSignatureProviding {
     static func commanderSignature() -> CommandSignature {
         CommandSignature(
             options: [
-                .commandOption("appTarget", help: "App name, bundle ID, PID, or frontmost", long: "app-target"),
+                .commandOption("app", help: "App name, bundle ID, PID, or frontmost", long: "app"),
+                .commandOption("appTarget", help: "Legacy alias for --app", long: "app-target"),
                 .commandOption("snapshot", help: "Existing UI snapshot ID", long: "snapshot"),
                 .commandOption("maxDepth", help: "Maximum accessibility-tree depth", long: "max-depth"),
                 .commandOption("maxElements", help: "Maximum elements to inspect", long: "max-elements"),
@@ -129,7 +130,12 @@ extension InspectUICommand: CommanderSignatureProviding {
 
 extension InspectUICommand: CommanderBindableCommand {
     mutating func applyCommanderValues(_ values: CommanderBindableValues) throws {
-        self.appTarget = values.singleOption("appTarget")
+        let app = values.singleOption("app")
+        let legacyAppTarget = values.singleOption("appTarget")
+        if app != nil, legacyAppTarget != nil {
+            throw ValidationError("Cannot specify both --app and --app-target")
+        }
+        self.appTarget = app ?? legacyAppTarget
         self.snapshot = values.singleOption("snapshot")
         self.maxDepth = try values.decodeOption("maxDepth", as: Int.self)
         self.maxElements = try values.decodeOption("maxElements", as: Int.self)

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Shared/InteractionObservationInvalidator.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Shared/InteractionObservationInvalidator.swift
@@ -621,8 +621,10 @@ private final class RuntimeMCPToolSnapshotMutationCoordinator: MCPToolSnapshotMu
     @discardableResult
     func completeMutation(_ scope: MCPToolSnapshotMutationScope, succeeded: Bool) async -> Bool {
         let completedPreparedMutation = self.completedPreparedMutationIDs.remove(scope.id) != nil
+        // `see` must observe publication failure before rendering its fresh snapshot.
         let defersToOuterCommandBarrier = !self.hasRemoteSelection &&
             scope.effect == .mutationProducingFreshObservation &&
+            scope.toolName != "see" &&
             !completedPreparedMutation &&
             self.mutationTracker.hasPendingDurableMutation
         if defersToOuterCommandBarrier {

--- a/Apps/CLI/Tests/CLIAutomationTests/MoveCommandTests.swift
+++ b/Apps/CLI/Tests/CLIAutomationTests/MoveCommandTests.swift
@@ -35,7 +35,7 @@ struct MoveCommandTests {
         #expect(call.destination == CGPoint(x: 100, y: 200))
         #expect(call.duration == 750)
         #expect(call.steps == 10)
-        #expect(call.profile == .linear)
+        #expect(call.profile == .human())
     }
 
     @Test
@@ -185,6 +185,61 @@ struct MoveCommandTests {
         #expect(call.profile == .human())
         #expect(call.steps >= 30)
         #expect(call.duration >= 280)
+    }
+
+    @Test
+    func `Smooth defaults to natural human movement`() async throws {
+        let context = await self.makeContext()
+        let result = try await self.runMove(arguments: ["100,200", "--smooth"], context: context)
+
+        #expect(result.exitStatus == 0)
+        let call = try #require(await self.automationState(context) { $0.moveMouseCalls }.first)
+        #expect(call.profile == .human())
+        #expect(call.steps >= 30)
+        #expect(call.steps <= 96)
+    }
+
+    @Test
+    func `Explicit linear profile preserves straight smooth movement`() async throws {
+        let context = await self.makeContext()
+        let result = try await self.runMove(
+            arguments: ["100,200", "--smooth", "--profile", "linear", "--steps", "8"],
+            context: context
+        )
+
+        #expect(result.exitStatus == 0)
+        let call = try #require(await self.automationState(context) { $0.moveMouseCalls }.first)
+        #expect(call.profile == .linear)
+        #expect(call.duration == 500)
+        #expect(call.steps == 8)
+    }
+
+    @Test
+    func `Human profile honors explicit sample count`() async throws {
+        let context = await self.makeContext()
+        let result = try await self.runMove(
+            arguments: ["100,200", "--profile", "human", "--steps", "8"],
+            context: context
+        )
+
+        #expect(result.exitStatus == 0)
+        let call = try #require(await self.automationState(context) { $0.moveMouseCalls }.first)
+        #expect(call.profile == .human())
+        #expect(call.steps == 8)
+    }
+
+    @Test
+    func `Human profile honors explicit zero duration`() async throws {
+        let context = await self.makeContext()
+        let result = try await self.runMove(
+            arguments: ["100,200", "--profile", "human", "--duration", "0"],
+            context: context
+        )
+
+        #expect(result.exitStatus == 0)
+        let call = try #require(await self.automationState(context) { $0.moveMouseCalls }.first)
+        #expect(call.profile == .human())
+        #expect(call.duration == 0)
     }
 
     // MARK: - Helpers

--- a/Apps/CLI/Tests/CoreCLITests/CommanderBinderProgramResolutionTests.swift
+++ b/Apps/CLI/Tests/CoreCLITests/CommanderBinderProgramResolutionTests.swift
@@ -91,13 +91,26 @@ struct CommanderBinderProgramResolutionTests {
         let invocation = try program.resolve(argv: [
             "peekaboo",
             "inspect-ui",
-            "--app-target", "TextEdit",
+            "--app", "TextEdit",
             "--max-elements", "200",
         ])
         let values = invocation.parsedValues
         #expect(invocation.path == ["inspect-ui"])
-        #expect(values.options["appTarget"] == ["TextEdit"])
+        #expect(values.options["app"] == ["TextEdit"])
         #expect(values.options["maxElements"] == ["200"])
+    }
+
+    @Test
+    @MainActor
+    func `Commander program preserves inspect UI app target alias`() throws {
+        let descriptors = CommanderRegistryBuilder.buildDescriptors()
+        let program = Program(descriptors: descriptors.map(\.metadata))
+        let invocation = try program.resolve(argv: [
+            "peekaboo",
+            "inspect-ui",
+            "--app-target", "TextEdit",
+        ])
+        #expect(invocation.parsedValues.options["appTarget"] == ["TextEdit"])
     }
 
     @Test

--- a/Apps/CLI/Tests/CoreCLITests/MCPWrapperCommandBindingTests.swift
+++ b/Apps/CLI/Tests/CoreCLITests/MCPWrapperCommandBindingTests.swift
@@ -52,7 +52,7 @@ struct MCPWrapperCommandBindingTests {
         let parsed = ParsedValues(
             positional: [],
             options: [
-                "appTarget": ["TextEdit"],
+                "app": ["TextEdit"],
                 "snapshot": ["snapshot-123"],
                 "maxDepth": ["4"],
                 "maxElements": ["200"],
@@ -66,6 +66,25 @@ struct MCPWrapperCommandBindingTests {
         #expect(command.maxDepth == 4)
         #expect(command.maxElements == 200)
         #expect(command.maxChildren == 20)
+    }
+
+    @Test
+    func `Inspect UI command preserves app target alias`() throws {
+        let parsed = ParsedValues(positional: [], options: ["appTarget": ["TextEdit"]], flags: [])
+        let command = try CommanderCLIBinder.instantiateCommand(ofType: InspectUICommand.self, parsedValues: parsed)
+        #expect(command.appTarget == "TextEdit")
+    }
+
+    @Test
+    func `Inspect UI command rejects both app spellings`() throws {
+        let parsed = ParsedValues(
+            positional: [],
+            options: ["app": ["TextEdit"], "appTarget": ["Finder"]],
+            flags: []
+        )
+        #expect(throws: ValidationError.self) {
+            _ = try CommanderCLIBinder.instantiateCommand(ofType: InspectUICommand.self, parsedValues: parsed)
+        }
     }
 
     @Test

--- a/Apps/Mac/Peekaboo/Features/Settings/VisualizerSettingsView.swift
+++ b/Apps/Mac/Peekaboo/Features/Settings/VisualizerSettingsView.swift
@@ -64,8 +64,9 @@ struct VisualizerSettingsView: View {
                     settings: self.settings)
 
                 AnimationToggleRow(
-                    title: "Mouse trail",
-                    icon: "scribble",
+                    title: "Pointer motion",
+                    subtitle: "Show a cursor with a short fading tail during smooth moves.",
+                    icon: "cursorarrow.motionlines",
                     isOn: self.$settings.mouseTrailEnabled,
                     isEnabled: self.settings.visualizerEnabled,
                     animationType: "trail",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## [3.9.1] - Unreleased
 
+### Changed
+- `peekaboo inspect-ui` now accepts the standard `--app` target option used by other desktop commands; `--app-target` remains available as a legacy alias.
+- `peekaboo move --smooth` now uses natural eased pointer arcs by default, while `--profile linear` preserves deterministic straight-line travel; explicit `--steps` values are honored and human paths are capped at 96 samples to avoid redundant input events.
+- Pointer-movement feedback now follows the real move with a short fading tail and one coalesced overlay instead of replaying a slow, thick line across the screen after the pointer arrives.
+
+### Fixed
+- Default action-first clicks now synthesize a real pointer click for SwiftUI segmented tabs, whose accessibility `AXPress` action can report success without changing the selected tab.
+- Local `see` now confirms snapshot publication before reporting success, preserving its timeout and failure guarantees when a command-level mutation barrier is active.
+- Human pointer paths now use bounded minimum-jerk Bézier motion, land exactly on the requested coordinate, and drive the real drag/swipe event path instead of calculating an organic path and then discarding it for a linear drag.
+
 ## [3.9.0] - 2026-07-11
 
 ### Added

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/ActionInputDriver.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/ActionInputDriver.swift
@@ -244,6 +244,14 @@ struct ActionInputDriver: ActionInputDriving {
         }
     }
 
+    nonisolated static func tabPressDidNotSelect(
+        subrole: String?,
+        valueBefore: Int?,
+        valueAfter: Int?) -> Bool
+    {
+        subrole == "AXTabButton" && valueBefore == 0 && valueAfter == 0
+    }
+
     nonisolated static func scrollFallbackError(from error: ActionInputError?) -> ActionInputError {
         if error == .targetUnavailable {
             return .unsupported(.actionUnsupported)
@@ -617,6 +625,17 @@ extension ActionInputDriver {
             subrole: subrole,
             isValueSettable: isValueSettable,
             isFocusedSettable: isFocusedSettable)
+    }
+
+    nonisolated static func tabPressDidNotSelectForTesting(
+        subrole: String?,
+        valueBefore: Int?,
+        valueAfter: Int?) -> Bool
+    {
+        self.tabPressDidNotSelect(
+            subrole: subrole,
+            valueBefore: valueBefore,
+            valueAfter: valueAfter)
     }
 
     nonisolated static func shouldContinueTryingScrollActionForTesting(after error: ActionInputError) -> Bool {

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/ClickService.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/ClickService.swift
@@ -175,12 +175,28 @@ public final class ClickService {
 
         switch clickType {
         case .single:
-            if targetProcessIdentifier != nil {
-                return try self.actionInputDriver.tryPerformAction(
+            let valueBefore = element.intAttribute(AXAttributeNames.kAXValueAttribute)
+            let result: ActionInputResult = if targetProcessIdentifier != nil {
+                try self.actionInputDriver.tryPerformAction(
                     element: element,
                     actionName: AXActionNames.kAXPressAction)
+            } else {
+                try self.actionInputDriver.tryClick(element: element)
             }
-            return try self.actionInputDriver.tryClick(element: element)
+            if element.subrole == "AXTabButton", valueBefore == 0 {
+                // SwiftUI tabs can report a successful AXPress without selecting. Give working
+                // native tab controls a brief settle window, then fall back only for a real no-op.
+                try await Task.sleep(for: .milliseconds(50))
+                let valueAfter = element.intAttribute(AXAttributeNames.kAXValueAttribute)
+                if ActionInputDriver.tabPressDidNotSelect(
+                    subrole: element.subrole,
+                    valueBefore: valueBefore,
+                    valueAfter: valueAfter)
+                {
+                    throw ActionInputError.unsupported(.actionUnsupported)
+                }
+            }
+            return result
         case .right:
             return try await self.actionInputDriver.tryRightClick(element: element)
         case .double:

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/GestureService+Paths.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/GestureService+Paths.swift
@@ -63,86 +63,62 @@ struct HumanMousePathGenerator {
 
     func generate() -> HumanMousePath {
         var rng = HumanMouseRandom(seed: self.configuration.randomSeed)
-        var current = self.start
-        var velocity = CGVector(dx: 0, dy: 0)
-        var wind = CGVector(dx: 0, dy: 0)
-        var samples: [CGPoint] = []
+        let sampleCount = min(max(self.stepsHint, 1), 96)
+        guard self.distance > 0.5, sampleCount > 1 else {
+            return HumanMousePath(points: [self.target], duration: self.duration)
+        }
 
-        let resolvedDuration = self.resolvedDuration()
-        let minimumSamples = max(stepsHint, Int(Double(resolvedDuration) / 8.0))
-        let settleRadius = max(self.configuration.settleRadius, min(self.distance * 0.08, 24))
+        let delta = CGVector(dx: self.target.x - self.start.x, dy: self.target.y - self.start.y)
+        let direction = CGVector(dx: delta.dx / self.distance, dy: delta.dy / self.distance)
+        let normal = CGVector(dx: -direction.dy, dy: direction.dx)
+        let curveDirection: CGFloat = rng.nextSignedUnit() < 0 ? -1 : 1
+        let curveMagnitude = min(self.distance * 0.10, 42)
+            * CGFloat(rng.nextDouble(in: 0.55...1.0))
+            * curveDirection
 
-        var overshootTarget: CGPoint?
-        if Self.shouldOvershoot(
+        let control1 = CGPoint(
+            x: self.start.x + (delta.dx * 0.28) + (normal.dx * curveMagnitude),
+            y: self.start.y + (delta.dy * 0.28) + (normal.dy * curveMagnitude))
+
+        let shouldOvershoot = Self.shouldOvershoot(
             distance: self.distance,
             probability: self.configuration.overshootProbability,
             rng: &rng)
-        {
-            overshootTarget = self.makeOvershootTarget(distance: self.distance, rng: &rng)
-        }
-        var currentTarget = overshootTarget ?? self.target
-        var overshootConsumed = overshootTarget == nil
+        let overshootDistance = shouldOvershoot
+            ? self.distance * CGFloat(rng.nextDouble(in: self.configuration.overshootFractionRange))
+            : 0
+        let control2 = CGPoint(
+            x: self.target.x + (direction.dx * overshootDistance) - (normal.dx * curveMagnitude * 0.22),
+            y: self.target.y + (direction.dy * overshootDistance) - (normal.dy * curveMagnitude * 0.22))
 
-        // Wind/gravity integration gives human profile moves small curves while seeded tests stay deterministic.
-        for _ in 0..<max(minimumSamples, 24) {
-            let delta = CGVector(dx: currentTarget.x - current.x, dy: currentTarget.y - current.y)
-            let distanceToTarget = max(0.001, hypot(delta.dx, delta.dy))
-            let gravityMagnitude = Self.gravity(for: distanceToTarget)
-            let gravity = CGVector(
-                dx: (delta.dx / distanceToTarget) * gravityMagnitude,
-                dy: (delta.dy / distanceToTarget) * gravityMagnitude)
-            wind.dx = (wind.dx * 0.8) + (rng.nextSignedUnit() * Self.windMagnitude(for: distanceToTarget))
-            wind.dy = (wind.dy * 0.8) + (rng.nextSignedUnit() * Self.windMagnitude(for: distanceToTarget))
+        var samples: [CGPoint] = []
+        samples.reserveCapacity(sampleCount)
+        for index in 1...sampleCount {
+            let time = CGFloat(index) / CGFloat(sampleCount)
+            let progress = Self.minimumJerkProgress(time)
+            var point = Self.cubicBezier(
+                from: self.start,
+                control1: control1,
+                control2: control2,
+                to: self.target,
+                progress: progress)
 
-            velocity.dx = (velocity.dx + wind.dx + gravity.dx) * 0.88
-            velocity.dy = (velocity.dy + wind.dy + gravity.dy) * 0.88
-
-            current.x += velocity.dx
-            current.y += velocity.dy
-            current = self.applyJitter(point: current, rng: &rng)
-            samples.append(current)
-
-            if distanceToTarget <= settleRadius {
-                if overshootConsumed {
-                    break
-                } else {
-                    currentTarget = self.target
-                    overshootConsumed = true
-                }
+            if index < sampleCount {
+                let distanceRemaining = self.distance * (1 - progress)
+                let settleTaper = min(1, distanceRemaining / max(self.configuration.settleRadius, 0.001))
+                let jitter = CGFloat(rng.nextSignedUnit())
+                    * self.configuration.jitterAmplitude
+                    * CGFloat(sin(Double.pi * Double(progress)))
+                    * settleTaper
+                point.x += normal.dx * jitter
+                point.y += normal.dy * jitter
             }
+            samples.append(point)
         }
 
-        samples.append(self.target)
-        return HumanMousePath(points: samples, duration: resolvedDuration)
-    }
-
-    private func resolvedDuration() -> Int {
-        if self.duration > 0 {
-            return self.duration
-        }
-
-        let distanceFactor = log2(Double(self.distance) + 1) * 90
-        let perPixel = Double(self.distance) * 0.45
-        let estimate = 220 + distanceFactor + perPixel
-        return min(max(Int(estimate), 250), 1600)
-    }
-
-    private func applyJitter(point: CGPoint, rng: inout HumanMouseRandom) -> CGPoint {
-        let amplitude = Double(self.configuration.jitterAmplitude)
-        return CGPoint(
-            x: point.x + (rng.nextSignedUnit() * amplitude),
-            y: point.y + (rng.nextSignedUnit() * amplitude))
-    }
-
-    private func makeOvershootTarget(distance: CGFloat, rng: inout HumanMouseRandom) -> CGPoint {
-        let overshootFraction = rng.nextDouble(in: self.configuration.overshootFractionRange)
-        let extraDistance = distance * CGFloat(overshootFraction)
-        let direction = CGVector(dx: self.target.x - self.start.x, dy: self.target.y - self.start.y)
-        let length = max(0.001, hypot(direction.dx, direction.dy))
-        let normalized = CGVector(dx: direction.dx / length, dy: direction.dy / length)
-        return CGPoint(
-            x: self.target.x + (normalized.dx * extraDistance),
-            y: self.target.y + (normalized.dy * extraDistance))
+        // Preserve exact targeting even with floating-point interpolation and jitter.
+        samples[samples.count - 1] = self.target
+        return HumanMousePath(points: samples, duration: self.duration)
     }
 
     private static func shouldOvershoot(
@@ -154,14 +130,28 @@ struct HumanMousePathGenerator {
         return rng.nextDouble() < probability
     }
 
-    private static func gravity(for distance: CGFloat) -> Double {
-        let clamped = min(max(distance, 1), 800)
-        return log(Double(clamped) + 2) * 1.8
+    private static func minimumJerkProgress(_ value: CGFloat) -> CGFloat {
+        let t = min(max(value, 0), 1)
+        return (10 * pow(t, 3)) - (15 * pow(t, 4)) + (6 * pow(t, 5))
     }
 
-    private static func windMagnitude(for distance: CGFloat) -> Double {
-        let normalized = min(max(distance / 400, 0.1), 1.0)
-        return 0.6 * Double(normalized)
+    private static func cubicBezier(
+        from start: CGPoint,
+        control1: CGPoint,
+        control2: CGPoint,
+        to end: CGPoint,
+        progress: CGFloat) -> CGPoint
+    {
+        let inverse = 1 - progress
+        let startWeight = pow(inverse, 3)
+        let control1Weight = 3 * pow(inverse, 2) * progress
+        let control2Weight = 3 * inverse * pow(progress, 2)
+        let endWeight = pow(progress, 3)
+        return CGPoint(
+            x: (start.x * startWeight) + (control1.x * control1Weight) +
+                (control2.x * control2Weight) + (end.x * endWeight),
+            y: (start.y * startWeight) + (control1.y * control1Weight) +
+                (control2.y * control2Weight) + (end.y * endWeight))
     }
 }
 

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/GestureService.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/GestureService.swift
@@ -142,8 +142,8 @@ public final class GestureService {
     }
 
     private func stepDelay(duration: Int, steps: Int) -> UInt64 {
-        guard duration > 0, steps > 0 else { return 0 }
-        let secondsPerStep = Double(duration) / 1000.0 / Double(steps)
+        guard duration > 0, steps > 1 else { return 0 }
+        let secondsPerStep = Double(duration) / 1000.0 / Double(steps - 1)
         return UInt64(secondsPerStep * 1_000_000_000)
     }
 
@@ -152,20 +152,14 @@ public final class GestureService {
         start: CGPoint,
         button: MouseButton) async throws
     {
-        let endPoint = path.points.last ?? start
-        let steps = max(path.points.count, 2)
-        let interStepDelay = Double(path.duration) / 1000.0 / Double(steps)
-        try InputDriver.drag(from: start, to: endPoint, button: button, steps: steps, interStepDelay: interStepDelay)
+        try await self.playDragPath(path.points, from: start, button: button, duration: path.duration)
     }
 
     private func performDrag(
         path: HumanMousePath,
         start: CGPoint) async throws
     {
-        let endPoint = path.points.last ?? start
-        let steps = max(path.points.count, 2)
-        let delay = Double(path.duration) / 1000.0 / Double(steps)
-        try InputDriver.drag(from: start, to: endPoint, button: .left, steps: steps, interStepDelay: delay)
+        try await self.playDragPath(path.points, from: start, button: .left, duration: path.duration)
     }
 
     private func makeModifierEvents(for keys: [HeldModifierKey]) throws -> (down: [CGEvent], up: [CGEvent]) {
@@ -230,9 +224,59 @@ public final class GestureService {
     private func playPath(_ points: [CGPoint], duration: Int) async throws {
         guard !points.isEmpty else { return }
         let delay = self.stepDelay(duration: duration, steps: points.count)
-        for point in points {
+        for (index, point) in points.enumerated() {
             try InputDriver.move(to: point)
-            if delay > 0 {
+            if delay > 0, index < points.count - 1 {
+                try await Task.sleep(nanoseconds: delay)
+            }
+        }
+    }
+
+    private func playDragPath(
+        _ points: [CGPoint],
+        from start: CGPoint,
+        button: MouseButton,
+        duration: Int) async throws
+    {
+        guard let end = points.last else { return }
+        let mouseButton: CGMouseButton = button == .left ? .left : .right
+        let downType: CGEventType = button == .left ? .leftMouseDown : .rightMouseDown
+        let draggedType: CGEventType = button == .left ? .leftMouseDragged : .rightMouseDragged
+        let upType: CGEventType = button == .left ? .leftMouseUp : .rightMouseUp
+        guard let downEvent = CGEvent(
+            mouseEventSource: nil,
+            mouseType: downType,
+            mouseCursorPosition: start,
+            mouseButton: mouseButton),
+            let upEvent = CGEvent(
+                mouseEventSource: nil,
+                mouseType: upType,
+                mouseCursorPosition: end,
+                mouseButton: mouseButton)
+        else {
+            throw UIAutomationError.failedToCreateEvent
+        }
+
+        var lastPoint = start
+        downEvent.post(tap: .cghidEventTap)
+        defer {
+            upEvent.location = lastPoint
+            upEvent.post(tap: .cghidEventTap)
+        }
+
+        let delay = self.stepDelay(duration: duration, steps: points.count)
+        for (index, point) in points.enumerated() {
+            guard let dragEvent = CGEvent(
+                mouseEventSource: nil,
+                mouseType: draggedType,
+                mouseCursorPosition: point,
+                mouseButton: mouseButton)
+            else {
+                throw UIAutomationError.failedToCreateEvent
+            }
+            dragEvent.post(tap: .cghidEventTap)
+            lastPoint = point
+            if delay > 0, index < points.count - 1 {
                 try await Task.sleep(nanoseconds: delay)
             }
         }

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/UIAutomationService+PointerKeyboardOperations.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/UIAutomationService+PointerKeyboardOperations.swift
@@ -114,12 +114,12 @@ extension UIAutomationService {
         self.logger.debug("Delegating moveMouse to GestureService")
 
         let fromPoint = InputDriver.currentLocation() ?? to
-        try await self.gestureService.moveMouse(to: to, duration: duration, steps: steps, profile: profile)
-
+        // Dispatch before moving so the overlay follows the real pointer instead of replaying it afterward.
         _ = await self.feedbackClient.showMouseMovement(
             from: fromPoint,
             to: to,
             duration: TimeInterval(duration) / 1000.0)
+        try await self.gestureService.moveMouse(to: to, duration: duration, steps: steps, profile: profile)
     }
 
     public func currentMouseLocation() -> CGPoint? {

--- a/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/ActionInputDriverTests.swift
+++ b/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/ActionInputDriverTests.swift
@@ -168,6 +168,26 @@ struct ActionInputDriverTests {
     }
 
     @Test
+    func `only unselected no-op tab presses require synthetic fallback`() {
+        #expect(ActionInputDriver.tabPressDidNotSelectForTesting(
+            subrole: "AXTabButton",
+            valueBefore: 0,
+            valueAfter: 0))
+        #expect(!ActionInputDriver.tabPressDidNotSelectForTesting(
+            subrole: "AXTabButton",
+            valueBefore: 0,
+            valueAfter: 1))
+        #expect(!ActionInputDriver.tabPressDidNotSelectForTesting(
+            subrole: "AXTabButton",
+            valueBefore: 1,
+            valueAfter: 1))
+        #expect(!ActionInputDriver.tabPressDidNotSelectForTesting(
+            subrole: "AXRadioButton",
+            valueBefore: 0,
+            valueAfter: 0))
+    }
+
+    @Test
     func `unsupported action message includes advertised action names`() {
         let message = UIAutomationService.unsupportedActionMessage(
             actionName: "AXIncrement",

--- a/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/GestureServiceTests.swift
+++ b/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/GestureServiceTests.swift
@@ -13,4 +13,69 @@ final class GestureServiceTests: XCTestCase {
             keys.map(\.flag),
             [.maskCommand, .maskShift, .maskAlternate, .maskControl, .maskSecondaryFn])
     }
+
+    func testHumanMousePathUsesBoundedEasedSamplesAndExactEndpoint() throws {
+        let start = CGPoint(x: 40, y: 80)
+        let target = CGPoint(x: 1040, y: 680)
+        let path = HumanMousePathGenerator(
+            start: start,
+            target: target,
+            distance: hypot(target.x - start.x, target.y - start.y),
+            duration: 1200,
+            stepsHint: 500,
+            configuration: HumanMouseProfileConfiguration(
+                jitterAmplitude: 0,
+                overshootProbability: 0,
+                randomSeed: 42))
+            .generate()
+
+        XCTAssertEqual(path.points.count, 96)
+        XCTAssertEqual(try XCTUnwrap(path.points.last), target)
+
+        let firstStep = try Self.distance(start, XCTUnwrap(path.points.first))
+        let middle = path.points.count / 2
+        let middleStep = Self.distance(path.points[middle - 1], path.points[middle])
+        let finalStep = Self.distance(path.points[path.points.count - 2], target)
+        XCTAssertLessThan(firstStep, middleStep)
+        XCTAssertLessThan(finalStep, middleStep)
+    }
+
+    func testHumanMousePathHonorsExplicitSampleCountAndCurves() {
+        let start = CGPoint(x: 0, y: 0)
+        let target = CGPoint(x: 500, y: 0)
+        let path = HumanMousePathGenerator(
+            start: start,
+            target: target,
+            distance: 500,
+            duration: 600,
+            stepsHint: 8,
+            configuration: HumanMouseProfileConfiguration(
+                jitterAmplitude: 0,
+                overshootProbability: 0,
+                randomSeed: 7))
+            .generate()
+
+        XCTAssertEqual(path.points.count, 8)
+        XCTAssertEqual(path.points.last, target)
+        XCTAssertGreaterThan(path.points.map { abs($0.y) }.max() ?? 0, 1)
+        XCTAssertLessThan(path.points.map { abs($0.y) }.max() ?? .infinity, 50)
+    }
+
+    func testHumanMousePathHonorsZeroDuration() {
+        let path = HumanMousePathGenerator(
+            start: .zero,
+            target: CGPoint(x: 100, y: 100),
+            distance: hypot(100, 100),
+            duration: 0,
+            stepsHint: 8,
+            configuration: HumanMouseProfileConfiguration(randomSeed: 7))
+            .generate()
+
+        XCTAssertEqual(path.duration, 0)
+        XCTAssertEqual(path.points.last, CGPoint(x: 100, y: 100))
+    }
+
+    private static func distance(_ lhs: CGPoint, _ rhs: CGPoint) -> CGFloat {
+        hypot(rhs.x - lhs.x, rhs.y - lhs.y)
+    }
 }

--- a/Core/PeekabooVisualizer/Sources/PeekabooVisualizer/Renderer/VisualizerCoordinator+AnimationAPI.swift
+++ b/Core/PeekabooVisualizer/Sources/PeekabooVisualizer/Renderer/VisualizerCoordinator+AnimationAPI.swift
@@ -103,8 +103,9 @@ extension VisualizerCoordinator {
         ].joined(separator: " ")
         self.logger.info("\(message, privacy: .public)")
 
-        // Short hops don't need a cursor trail, and rapid successive moves would
-        // paint overlapping trails.
+        // Instant hops should stay instant. Short hops don't need a cursor trail,
+        // and rapid successive moves are coalesced by the pointer overlay slot.
+        guard duration >= FeedbackThrottle.minimumPointerDuration else { return true }
         let distance = hypot(to.x - from.x, to.y - from.y)
         guard distance >= FeedbackThrottle.minimumTrailDistance else { return true }
         let now = Date()

--- a/Core/PeekabooVisualizer/Sources/PeekabooVisualizer/Renderer/VisualizerCoordinator+InputDisplays.swift
+++ b/Core/PeekabooVisualizer/Sources/PeekabooVisualizer/Renderer/VisualizerCoordinator+InputDisplays.swift
@@ -170,22 +170,29 @@ extension VisualizerCoordinator {
         let windowRect = Self.travelWindowRect(
             from: from,
             to: to,
-            padding: Self.OverlayPadding.mouseTrail + 50)
+            padding: Self.OverlayPadding.mouseTrail + 100)
 
         // Create mouse trail view with window-local coordinates
-        let mouseDuration = self.scaledDuration(for: duration, minimum: AnimationBaseline.mouseTrail)
+        let mouseDuration = self.scaledDuration(
+            for: duration,
+            minimum: AnimationBaseline.mouseTrail,
+            applySlowdown: false)
         let mouseView = MouseTrailView(
             from: Self.windowLocalPoint(from, in: windowRect),
             to: Self.windowLocalPoint(to, in: windowRect),
-            duration: mouseDuration)
+            duration: mouseDuration,
+            windowRect: windowRect,
+            primaryScreenFrame: NSScreen.screens.first?.frame,
+            tracksLivePointer: self.previewDurationOverride == nil)
 
         // Cursor-trail coordinates are window-local; the travel padding is the margin.
         _ = self.overlayManager.showAnimation(
             at: windowRect,
             content: mouseView,
-            duration: mouseDuration + 0.35,
+            duration: mouseDuration + 0.2,
             fadeOut: true,
-            chromeMargin: 0)
+            chromeMargin: 0,
+            replaceKey: OverlaySlot.pointer)
 
         return true
     }

--- a/Core/PeekabooVisualizer/Sources/PeekabooVisualizer/Renderer/VisualizerCoordinator.swift
+++ b/Core/PeekabooVisualizer/Sources/PeekabooVisualizer/Renderer/VisualizerCoordinator.swift
@@ -41,7 +41,7 @@ public final class VisualizerCoordinator {
         static let clickCursor: TimeInterval = 1.15
         static let typingOverlay: TimeInterval = 1.2
         static let scrollIndicator: TimeInterval = 0.6
-        static let mouseTrail: TimeInterval = 0.75
+        static let mouseTrail: TimeInterval = 0.28
         static let swipePath: TimeInterval = 0.9
         static let hotkeyOverlay: TimeInterval = 1.2
         static let windowOperation: TimeInterval = 0.85
@@ -60,8 +60,10 @@ public final class VisualizerCoordinator {
     enum FeedbackThrottle {
         static let screenshotFlash: TimeInterval = 1.2
         static let scroll: TimeInterval = 0.3
-        static let mouseTrail: TimeInterval = 0.4
+        static let mouseTrail: TimeInterval = 0.18
         static let elementDetection: TimeInterval = 1.0
+        /// Instant pointer hops should not be replayed as a delayed animation.
+        static let minimumPointerDuration: TimeInterval = 0.05
         /// Mouse moves shorter than this aren't worth a cursor trail.
         static let minimumTrailDistance: CGFloat = 80
     }
@@ -75,6 +77,7 @@ public final class VisualizerCoordinator {
         static let space = "space"
         static let appLifecycle = "appLifecycle"
         static let watchHUD = "watchHUD"
+        static let pointer = "pointer"
         static let annotatedScreenshot = "annotatedScreenshot"
         static let elementSheetPrefix = "elements-screen-"
 

--- a/Core/PeekabooVisualizer/Sources/PeekabooVisualizer/Views/MouseTrailView.swift
+++ b/Core/PeekabooVisualizer/Sources/PeekabooVisualizer/Views/MouseTrailView.swift
@@ -2,46 +2,59 @@
 //  MouseTrailView.swift
 //  Peekaboo
 //
-//  A macOS-style cursor tracing its travel with a subtle tapered trail.
+//  A macOS-style cursor that follows the real pointer with a short fading tail.
 //
 
+import AppKit
+import CoreGraphics
 import SwiftUI
 
-/// Mouse-movement feedback: a cursor glides from start to destination,
-/// stretching a soft gradient tail behind it. Points are window-local
-/// SwiftUI coordinates (top-left origin).
+/// Mouse-movement feedback sampled from the live system cursor. Following the
+/// real pointer keeps linear, human, and custom gesture paths visually honest.
 struct MouseTrailView: View {
     let fromPoint: CGPoint
     let toPoint: CGPoint
     let duration: TimeInterval
+    let windowRect: CGRect
+    let primaryScreenFrame: CGRect?
+    let tracksLivePointer: Bool
 
-    @State private var progress: CGFloat = 0
+    @State private var trailPoints: [CGPoint]
+    @State private var cursorPosition: CGPoint
     @State private var trailOpacity: Double = 1
     @State private var cursorOpacity: Double = 0
 
-    init(from: CGPoint, to: CGPoint, duration: TimeInterval = 1.0) {
+    init(
+        from: CGPoint,
+        to: CGPoint,
+        duration: TimeInterval = 1.0,
+        windowRect: CGRect,
+        primaryScreenFrame: CGRect?,
+        tracksLivePointer: Bool = true)
+    {
         self.fromPoint = from
         self.toPoint = to
         self.duration = duration
+        self.windowRect = windowRect
+        self.primaryScreenFrame = primaryScreenFrame
+        self.tracksLivePointer = tracksLivePointer
+        self._trailPoints = State(initialValue: [from])
+        self._cursorPosition = State(initialValue: from)
     }
 
     var body: some View {
         ZStack(alignment: .topLeading) {
-            // Soft afterglow beneath the trail
             self.trailPath
-                .trim(from: max(0, self.progress - 0.35), to: self.progress)
                 .stroke(
-                    VisualizerTheme.accent.opacity(0.22),
-                    style: StrokeStyle(lineWidth: 8, lineCap: .round))
-                .blur(radius: 5)
+                    VisualizerTheme.accent.opacity(0.14),
+                    style: StrokeStyle(lineWidth: 4, lineCap: .round, lineJoin: .round))
+                .blur(radius: 2)
                 .opacity(self.trailOpacity)
 
-            // Tapered cursor trail
             self.trailPath
-                .trim(from: max(0, self.progress - 0.35), to: self.progress)
                 .stroke(
                     self.travelGradient,
-                    style: StrokeStyle(lineWidth: 2.5, lineCap: .round))
+                    style: StrokeStyle(lineWidth: 1.4, lineCap: .round, lineJoin: .round))
                 .opacity(self.trailOpacity)
 
             CursorGlyphView()
@@ -49,29 +62,26 @@ struct MouseTrailView: View {
                 .offset(x: self.cursorPosition.x, y: self.cursorPosition.y)
         }
         .task {
-            await self.animateTrail()
+            await self.followPointer()
         }
     }
 
     private var trailPath: Path {
         Path { path in
-            path.move(to: self.fromPoint)
-            path.addLine(to: self.toPoint)
+            guard let first = self.trailPoints.first else { return }
+            path.move(to: first)
+            for point in self.trailPoints.dropFirst() {
+                path.addLine(to: point)
+            }
         }
     }
 
-    private var cursorPosition: CGPoint {
-        CGPoint(
-            x: self.fromPoint.x + (self.toPoint.x - self.fromPoint.x) * self.progress,
-            y: self.fromPoint.y + (self.toPoint.y - self.fromPoint.y) * self.progress)
-    }
-
-    /// Gradient oriented along the travel direction so the tail fades out behind the cursor.
+    /// Gradient oriented along the sampled tail so it fades behind the cursor.
     private var travelGradient: LinearGradient {
         LinearGradient(
             colors: [VisualizerTheme.accent.opacity(0.05), VisualizerTheme.accentSecondary, .white],
-            startPoint: self.unitPoint(for: self.fromPoint),
-            endPoint: self.unitPoint(for: self.toPoint))
+            startPoint: self.unitPoint(for: self.trailPoints.first ?? self.fromPoint),
+            endPoint: self.unitPoint(for: self.trailPoints.last ?? self.cursorPosition))
     }
 
     private func unitPoint(for point: CGPoint) -> UnitPoint {
@@ -81,26 +91,137 @@ struct MouseTrailView: View {
             y: (point.y - bounds.minY) / max(bounds.height, 1))
     }
 
-    private func animateTrail() async {
-        let travel = max(self.duration * 0.75, 0.15)
+    private func followPointer() async {
+        let travel = max(self.duration, 0.12)
+        let start = Date()
+        let previewPath = PointerPreviewPath(from: self.fromPoint, to: self.toPoint)
 
         withAnimation(VisualizerMotion.enter(0.1)) {
             self.cursorOpacity = 1
         }
-        withAnimation(VisualizerMotion.glide(travel)) {
-            self.progress = 1
+
+        while !Task.isCancelled {
+            let elapsed = Date().timeIntervalSince(start)
+            guard elapsed < travel else { break }
+            if self.tracksLivePointer {
+                self.sampleCursor()
+            } else {
+                self.samplePreview(previewPath.point(at: elapsed / travel))
+            }
+            try? await Task.sleep(for: .milliseconds(16))
+        }
+        guard !Task.isCancelled else { return }
+        if self.tracksLivePointer {
+            self.sampleCursor()
+        } else {
+            self.samplePreview(previewPath.point(at: 1))
         }
 
-        await self.sleep(travel)
-        guard !Task.isCancelled else { return }
         withAnimation(VisualizerMotion.exit(0.25)) {
             self.trailOpacity = 0
             self.cursorOpacity = 0
         }
     }
 
-    private func sleep(_ seconds: Double) async {
-        try? await Task.sleep(nanoseconds: UInt64(seconds * 1_000_000_000))
+    private func sampleCursor() {
+        guard let globalPoint = CGEvent(source: nil)?.location else { return }
+        let appKitPoint = VisualizerScreenGeometry.appKitPoint(
+            fromGlobalDisplay: globalPoint,
+            primaryScreenFrame: self.primaryScreenFrame)
+        let localPoint = CGPoint(
+            x: appKitPoint.x - self.windowRect.minX,
+            y: self.windowRect.maxY - appKitPoint.y)
+        self.cursorPosition = localPoint
+        self.trailPoints = PointerTrailSamples.appending(localPoint, to: self.trailPoints)
+    }
+
+    private func samplePreview(_ point: CGPoint) {
+        self.cursorPosition = point
+        self.trailPoints = PointerTrailSamples.appending(point, to: self.trailPoints)
+    }
+}
+
+/// Bounds live pointer history by both visible length and sample count.
+struct PointerTrailSamples {
+    static let maximumLength: CGFloat = 84
+    static let maximumCount = 32
+
+    static func appending(_ point: CGPoint, to points: [CGPoint]) -> [CGPoint] {
+        var result = points
+        if let last = result.last, self.distance(last, point) < 0.25 {
+            result[result.count - 1] = point
+            return result
+        }
+        result.append(point)
+
+        if result.count > self.maximumCount {
+            result.removeFirst(result.count - self.maximumCount)
+        }
+        while result.count > 2, self.pathLength(result) > self.maximumLength {
+            result.removeFirst()
+        }
+
+        let excess = self.pathLength(result) - self.maximumLength
+        if excess > 0, result.count >= 2 {
+            let segmentLength = self.distance(result[0], result[1])
+            if segmentLength > 0 {
+                let fraction = min(excess / segmentLength, 1)
+                result[0] = CGPoint(
+                    x: result[0].x + ((result[1].x - result[0].x) * fraction),
+                    y: result[0].y + ((result[1].y - result[0].y) * fraction))
+            }
+        }
+        return result
+    }
+
+    static func pathLength(_ points: [CGPoint]) -> CGFloat {
+        zip(points, points.dropFirst()).reduce(0) { total, pair in
+            total + self.distance(pair.0, pair.1)
+        }
+    }
+
+    private static func distance(_ lhs: CGPoint, _ rhs: CGPoint) -> CGFloat {
+        hypot(rhs.x - lhs.x, rhs.y - lhs.y)
+    }
+}
+
+/// Deterministic natural motion used only by the Settings preview, where no
+/// real automation command exists for the overlay to follow.
+struct PointerPreviewPath {
+    let fromPoint: CGPoint
+    let toPoint: CGPoint
+    let control1: CGPoint
+    let control2: CGPoint
+
+    init(from: CGPoint, to: CGPoint) {
+        self.fromPoint = from
+        self.toPoint = to
+        let delta = CGVector(dx: to.x - from.x, dy: to.y - from.y)
+        let distance = max(hypot(delta.dx, delta.dy), 0.001)
+        let normal = CGVector(dx: -delta.dy / distance, dy: delta.dx / distance)
+        let curveDirection: CGFloat = (delta.dx * delta.dy) >= 0 ? -1 : 1
+        let curvature = min(distance * 0.08, 28) * curveDirection
+        self.control1 = CGPoint(
+            x: from.x + (delta.dx * 0.30) + (normal.dx * curvature),
+            y: from.y + (delta.dy * 0.30) + (normal.dy * curvature))
+        self.control2 = CGPoint(
+            x: from.x + (delta.dx * 0.72) - (normal.dx * curvature * 0.20),
+            y: from.y + (delta.dy * 0.72) - (normal.dy * curvature * 0.20))
+    }
+
+    func point(at time: Double) -> CGPoint {
+        let t = min(max(CGFloat(time), 0), 1)
+        let progress = (10 * pow(t, 3)) - (15 * pow(t, 4)) + (6 * pow(t, 5))
+        let inverse = 1 - progress
+        return CGPoint(
+            x: (self.fromPoint.x * pow(inverse, 3))
+                + (self.control1.x * 3 * pow(inverse, 2) * progress)
+                + (self.control2.x * 3 * inverse * pow(progress, 2))
+                + (self.toPoint.x * pow(progress, 3)),
+            y: (self.fromPoint.y * pow(inverse, 3))
+                + (self.control1.y * 3 * pow(inverse, 2) * progress)
+                + (self.control2.y * 3 * inverse * pow(progress, 2))
+                + (self.toPoint.y * pow(progress, 3)))
     }
 }
 
@@ -109,7 +230,10 @@ struct MouseTrailView: View {
     MouseTrailView(
         from: CGPoint(x: 60, y: 80),
         to: CGPoint(x: 340, y: 320),
-        duration: 1.2)
+        duration: 1.2,
+        windowRect: CGRect(x: 0, y: 0, width: 400, height: 400),
+        primaryScreenFrame: NSScreen.screens.first?.frame,
+        tracksLivePointer: false)
         .frame(width: 400, height: 400)
         .background(Color.gray.opacity(0.3))
 }

--- a/Core/PeekabooVisualizer/Sources/PeekabooVisualizer/Views/VisualizerDesign.swift
+++ b/Core/PeekabooVisualizer/Sources/PeekabooVisualizer/Views/VisualizerDesign.swift
@@ -76,6 +76,11 @@ enum VisualizerMotion {
     static func glide(_ duration: Double) -> Animation {
         .easeInOut(duration: duration)
     }
+
+    /// Fast acceleration with a longer, precise settle for pointer travel.
+    static func pointerTravel(_ duration: Double) -> Animation {
+        .timingCurve(0.22, 0.05, 0.18, 1.0, duration: duration)
+    }
 }
 
 // MARK: - HUD Chip

--- a/Core/PeekabooVisualizer/Tests/PeekabooVisualizerTests/VisualizerOverlaySizingTests.swift
+++ b/Core/PeekabooVisualizer/Tests/PeekabooVisualizerTests/VisualizerOverlaySizingTests.swift
@@ -172,6 +172,48 @@ struct VisualizerOverlaySizingTests {
     }
 
     @Test
+    func `Pointer tail preserves the live sampled path`() {
+        var samples = [CGPoint(x: 20, y: 40)]
+        samples = PointerTrailSamples.appending(CGPoint(x: 60, y: 40), to: samples)
+        samples = PointerTrailSamples.appending(CGPoint(x: 90, y: 60), to: samples)
+
+        #expect(samples.last == CGPoint(x: 90, y: 60))
+        #expect(samples.contains(CGPoint(x: 60, y: 40)))
+    }
+
+    @Test
+    func `Pointer tail stays short on long moves`() {
+        var samples = [CGPoint.zero]
+        for x in stride(from: 10, through: 2400, by: 10) {
+            samples = PointerTrailSamples.appending(CGPoint(x: x, y: x / 2), to: samples)
+        }
+
+        #expect(PointerTrailSamples.pathLength(samples) <= PointerTrailSamples.maximumLength + 0.001)
+        #expect(samples.count <= PointerTrailSamples.maximumCount)
+        #expect(samples.last == CGPoint(x: 2400, y: 1200))
+    }
+
+    @Test
+    func `Pointer settings preview is natural and lands exactly`() {
+        let path = PointerPreviewPath(
+            from: CGPoint(x: 20, y: 40),
+            to: CGPoint(x: 1020, y: 640))
+
+        #expect(path.point(at: 0) == CGPoint(x: 20, y: 40))
+        #expect(path.point(at: 1) == CGPoint(x: 1020, y: 640))
+        let midpoint = path.point(at: 0.5)
+        #expect(hypot(midpoint.x - 520, midpoint.y - 340) > 1)
+    }
+
+    @Test
+    func `Pointer duration is not multiplied by visualizer slowdown`() {
+        let coordinator = VisualizerCoordinator()
+        let duration = coordinator.scaledDuration(for: 0.6, minimum: 0.28, applySlowdown: false)
+
+        #expect(abs(duration - 0.6) < 0.001)
+    }
+
+    @Test
     func `Hotkey overlay grows with more keys`() {
         let compact = VisualizerCoordinator.estimatedHotkeyOverlaySize(for: ["cmd", "k"])
         let wide = VisualizerCoordinator.estimatedHotkeyOverlaySize(for: ["cmd", "shift", "option", "ctrl", "space"])

--- a/docs/commands/drag.md
+++ b/docs/commands/drag.md
@@ -27,7 +27,7 @@ read_when:
 - When you pass `--to-app`, the command resolves the app’s focused window via AX and drags to its midpoint; `Trash` is handled specially by scraping the Dock’s accessibility hierarchy.
 - Element IDs are resolved through `AutomationServiceBridge.waitForElement` (5 s timeout) and use the element’s bounds midpoint as the drag point.
 - Modifier strings are forwarded verbatim to `DragRequest`, so `--modifiers cmd,shift` behaves like holding Cmd+Shift while dragging.
-- `--profile human` automatically chooses adaptive durations/steps and feeds the motion through the same humanized generator described in `docs/human-mouse-move.md`.
+- `--profile human` chooses adaptive duration/samples and posts drag events along the generated curve; `--steps` is honored up to the 96-sample safety cap.
 - Results are logged in both human-readable form and JSON (`DragResult`) with start/end coordinates, duration, steps, modifiers, execution time, and `fromTargetPoint`/`toTargetPoint` diagnostics when either endpoint resolves from a snapshot element.
 
 ## Examples

--- a/docs/commands/move.md
+++ b/docs/commands/move.md
@@ -21,15 +21,15 @@ read_when:
 | `--snapshot <id>` | Required when using `--on`/`--id`/`--to`; defaults to the most recent snapshot. |
 | Target flags | `--app <name>`, `--pid <pid>`, `--window-id <id>`, `--window-title <title>`, `--window-index <n>` — focus a specific app/window before moving. (`--window-title`/`--window-index` require `--app` or `--pid`; `--window-id` does not.) |
 | Focus flags | `FocusCommandOptions` control Space switching + retries. |
-| `--smooth` | Animate the move over multiple steps (defaults to 500 ms, 20 steps). |
-| `--duration <ms>` / `--steps <n>` | Override the smooth-move timing/step count; instant moves use duration `0` unless overridden. |
-| `--profile <linear\|human>` | Select a movement profile. `human` enables eased arcs and micro-jitter with no extra tuning required. |
+| `--smooth` | Use natural eased movement with distance-aware timing. |
+| `--duration <ms>` / `--steps <n>` | Override movement timing/sample count; a positive duration opts into natural movement unless `--profile linear` is explicit. |
+| `--profile <linear\|human>` | Select a movement profile. Animated moves default to `human`; instant moves default to `linear`. |
 
 ## Implementation notes
 - Validation enforces exactly one target: coordinates (`[x,y]` or `--coords`), `--on`/`--id`, `--to`, or `--center`.
 - Element-based moves reuse snapshot data via `services.snapshots.getDetectionResult`; query-based moves run `AutomationServiceBridge.waitForElement`, so they automatically wait up to 5 s for dynamic UIs.
-- Smooth moves compute intermediate steps client-side and track the previous cursor location so the result payload can include the travel distance.
-- `--profile human` automatically enables smooth movement, adapts duration/steps to travel distance, and adds natural jitter/overshoot. See `docs/human-mouse-move.md` for deeper guidance.
+- Smooth moves compute a bounded minimum-jerk Bézier path and track the previous cursor location so the result payload can include the travel distance.
+- `--smooth`, a positive `--duration`, or `--profile human` enables natural movement with distance-aware duration and sample defaults. Use `--profile linear` for a straight path. See `docs/human-mouse-move.md` for deeper guidance.
 - JSON output reports `fromLocation`, `targetLocation`, `targetDescription`, total distance, and run time. Element/query targets also include `targetPoint` diagnostics with the original snapshot midpoint, final resolved point, snapshot ID, and moved-window adjustment status.
 
 ## Examples
@@ -38,8 +38,8 @@ read_when:
 peekaboo move 1024,88
 peekaboo move --coords 1024,88
 
-# Human-style movement with one flag
-peekaboo move 520,360 --profile human
+# Natural movement with one flag
+peekaboo move 520,360 --smooth
 
 # Hover the element with ID `menu_gear` using the latest snapshot
 peekaboo move --on menu_gear --smooth

--- a/docs/commands/swipe.md
+++ b/docs/commands/swipe.md
@@ -28,7 +28,7 @@ read_when:
 - Coordinate parsing accepts `"x,y"` with optional whitespace; invalid strings result in immediate validation errors.
 - After issuing the swipe it waits ~0.1 s before reporting success to give AppKit time to settle (matching what integration tests expect).
 - JSON output surfaces both endpoints and the computed Euclidean distance. Element endpoints also include `fromTargetPoint`/`toTargetPoint` diagnostics with the original snapshot midpoint, final resolved point, snapshot ID, and moved-window adjustment status.
-- `--profile human` enables adaptive durations/steps plus jittery arcs; see `docs/human-mouse-move.md` for the generator’s behavior.
+- `--profile human` enables adaptive duration/samples and posts the swipe along a bounded eased arc; see `docs/human-mouse-move.md` for details.
 
 ## Examples
 ```bash

--- a/docs/human-mouse-move.md
+++ b/docs/human-mouse-move.md
@@ -10,12 +10,12 @@ read_when:
 Peekaboo's `human` profile makes cursor motion look hand-driven without forcing users to juggle dozens of tuning flags. It builds on three ideas:
 
 1. **Distance-aware pacing** - Short hops complete in ~300 ms while multi-display traversals stretch toward 1.5 s, following a loose Fitts-style curve.
-2. **Organic paths** - Each move is simulated with gently changing wind forces, gravity toward the destination, and a single optional overshoot before settling.
-3. **Micro-jitter** - Low-amplitude noise keeps the trace from looking perfectly straight, but it is clamped so the pointer never drifts outside the target bounds.
+2. **Organic paths** - A shallow Bézier arc uses minimum-jerk timing for quick acceleration and a precise settle, with one optional subtle overshoot.
+3. **Micro-jitter** - Low-amplitude perpendicular noise tapers to zero near the destination, and the final event is always the exact requested point.
 
 ## Using the profile
 
-- **CLI**: add `--profile human` to `peekaboo move`, `peekaboo drag`, or `peekaboo swipe`. Smooth animation toggles on automatically, and duration/step counts pick sensible defaults per distance. You can still override `--duration` or `--steps` when you need deterministic timings; the profile treats those as hard caps.
+- **CLI**: use `--smooth` for a natural `peekaboo move`, or add `--profile human` to `move`, `drag`, or `swipe`. Duration/sample counts pick sensible defaults per distance. Explicit `--duration` and `--steps` values are honored; human paths never emit more than 96 samples.
 - **Agents / MCP**: include `"profile": "human"` in the move/drag/swipe tool arguments. Optional `duration` and `steps` fields work the same way as in the CLI-you only need them when you want to clamp the adaptive heuristics.
 
 ## Defaults at a glance
@@ -24,7 +24,7 @@ Peekaboo's `human` profile makes cursor motion look hand-driven without forcing 
 | --- | --- | --- | --- |
 | < 200 px | 280-350 ms | 30-40 | Minimal overshoot; jitter keeps subtle motion. |
 | 200-800 px | 400-900 ms | 40-80 | Overshoot only triggers when the hop is long enough to look intentional. |
-| > 800 px | 900-1700 ms | 80-120 | Velocity eases into and out of the target to avoid "teleport" endings. |
+| > 800 px | 900-1700 ms | 80-96 | Velocity eases into and out of the target without redundant events. |
 
 Additional details:
 - Overshoot probability starts near 0 for short hops and tops out around 20 % for long moves. When it fires, the cursor glides slightly past the destination before recentering.
@@ -33,7 +33,7 @@ Additional details:
 
 ## When to prefer other profiles
 
-- Use **`--profile linear`** (or omit `--profile`) for pixel-perfect hops, screenshots that need straight edges, or performance-critical test loops.
-- Pair **`--profile human`** with screenshots, menu explorations, or demos where observers expect a believable pointer trace.
+- Omit movement flags for an instant pixel-perfect hop. Use **`--profile linear`** with `--smooth` or `--duration` when an animated path must stay straight.
+- Use **`--smooth`** or **`--profile human`** for menu exploration and demos where observers expect believable pointer motion.
 
 For implementation details or to tweak the heuristics, see `GestureService.moveMouse` in `PeekabooAutomation`. Most adjustments boil down to the duration curve, overshoot probability, or jitter amplitude constants described above.


### PR DESCRIPTION
## Summary

- make animated pointer movement natural by default, with bounded minimum-jerk paths, exact endpoints, and explicit linear/zero-duration behavior preserved
- drive move, drag, and swipe through the generated path while capping human motion at 96 events
- replace the large replayed mouse line with a coalesced 84-point fading tail that follows the live cursor; retain a preview-only natural simulation in Settings
- clarify move/inspect-ui CLI options and fix action-first SwiftUI tab clicks plus local snapshot publication ordering found during cross-app validation

## Proof

- `pnpm run format`
- `pnpm run lint` (13 existing warnings, 0 serious)
- `pnpm run test:safe` (744 tests, 85 suites)
- `pnpm run test:automation` (1,338 tests, 181 suites)
- focused GestureService (4), MoveCommand (13), and Visualizer (17) tests
- `./scripts/build-mac-debug.sh`
- black-box pointer probe: 96 movement events, eased start/settle, shallow curve, exact endpoint
- Playground element targeting landed exactly at the resolved button center
- signed Peekaboo bridge reported Screen Recording, Accessibility, and event posting available
- final structured autoreview: no accepted/actionable findings
