### PR TITLE
fix: update AXorcist for Swift 6.2 isolation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 ### Added
 - GitHub releases now include a signed, notarized Peekaboo DMG with a branded drag-to-Applications layout; release automation builds, verifies, checksums, and uploads it alongside the app zip.
 
+### Fixed
+- AX error descriptions remain available to nonisolated automation classifiers under Swift 6.2 strict concurrency.
+
 ## [3.9.1] - 2026-07-14
 
 ### Changed

--- a/Package.swift
+++ b/Package.swift
@@ -49,7 +49,7 @@ let package = Package(
             targets: ["PeekabooBridge"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/steipete/AXorcist.git", exact: "0.1.2"),
+        .package(url: "https://github.com/steipete/AXorcist.git", exact: "0.1.3"),
         .package(url: "https://github.com/apple/swift-algorithms", from: "1.2.1"),
     ],
     targets: [


### PR DESCRIPTION
## Summary

- update the root Swift package and vendored submodule to AXorcist 0.1.3
- restore nonisolated AX error classification under Swift 6.2 strict concurrency
- document the fix for Peekaboo 3.9.2

Upstream fix: openclaw/AXorcist#14.

## Validation

- `swift build` — passed; compiled `ActionInputDriver.swift` against AXorcist 0.1.3
- `pnpm run format` — clean
- `pnpm run lint` — 0 serious violations; 13 existing warnings
- `swift test` — build passed, then root package reported no test targets
- autoreview — clean, no accepted/actionable findings
