### PR TITLE
fix: update AXorcist concurrency isolation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [3.9.3] - Unreleased
 
+### Fixed
+- Keep swift-log calls usable from nonisolated code when importing AXorcist under current Swift 6 toolchains.
+
 ## [3.9.2] - 2026-07-14
 
 ### Added

--- a/Package.swift
+++ b/Package.swift
@@ -49,7 +49,7 @@ let package = Package(
             targets: ["PeekabooBridge"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/steipete/AXorcist.git", exact: "0.1.3"),
+        .package(url: "https://github.com/steipete/AXorcist.git", exact: "0.1.4"),
         .package(url: "https://github.com/apple/swift-algorithms", from: "1.2.1"),
     ],
     targets: [


### PR DESCRIPTION
## Summary

- update AXorcist from 0.1.3 to 0.1.4
- bump the vendored submodule to the matching release commit
- document the downstream Swift 6 isolation fix for Peekaboo 3.9.3

## Proof

- `pnpm run format`: clean
- `pnpm run lint`: zero serious violations; 13 existing warnings
- `pnpm run test:safe`: 747 tests in 85 suites passed
- AXorcist 0.1.4: 38 tests in 15 suites passed on Swift 6.3.3 and ClawMac Swift 6.4 beta
- full OpenClaw macOS `swift build` passed on ClawMac against AXorcist 0.1.4 contents
- autoreview: clean; dependency commit reviewed independently because gitlinks are intentionally opaque to the bundle helper
