### PR TITLE
fix: refresh AXorcist and bridge invalidation

### DIFF
--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Shared/InteractionObservationInvalidator.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Shared/InteractionObservationInvalidator.swift
@@ -330,7 +330,8 @@ enum InteractionObservationInvalidator {
                     )
                 } else {
                     logger.debug(
-                        "Skipping unavailable alternate snapshot endpoint at \(path) after \(reason)"
+                        "Skipping unavailable alternate snapshot endpoint at \(path) after \(reason): " +
+                            error.localizedDescription
                     )
                 }
             }
@@ -377,14 +378,18 @@ enum InteractionObservationInvalidator {
     private static func makeRemoteSnapshotManager(
         socketPath: String
     ) async throws -> (any SnapshotManagerProtocol)? {
-        let client = PeekabooBridgeClient(socketPath: socketPath, requestTimeoutSec: 1)
         let identity = PeekabooBridgeClientIdentity(
             bundleIdentifier: Bundle.main.bundleIdentifier,
             teamIdentifier: nil,
             processIdentifier: getpid(),
             hostname: Host.current().name
         )
-        let handshake = try await client.handshake(client: identity, requestedHost: nil)
+        let (client, handshake): (PeekabooBridgeClient, PeekabooBridgeHandshakeResponse) =
+            try await self.retryBridgeTimeout { timeoutSec in
+                let client = PeekabooBridgeClient(socketPath: socketPath, requestTimeoutSec: timeoutSec)
+                let handshake = try await client.handshake(client: identity, requestedHost: nil)
+                return (client, handshake)
+            }
         guard BridgeCapabilityPolicy.supportsImplicitSnapshotInvalidation(for: handshake) else {
             return nil
         }
@@ -393,6 +398,21 @@ enum InteractionObservationInvalidator {
             supportsImplicitLatestSnapshotInvalidation: true,
             desktopMutationWatermarkStore: DesktopMutationWatermarkStore()
         )
+    }
+
+    static func retryBridgeTimeout<T>(
+        operation: (TimeInterval) async throws -> T
+    ) async throws -> T {
+        do {
+            return try await operation(1)
+        } catch {
+            let isTimeout = (error as? POSIXError)?.code == .ETIMEDOUT ||
+                (error as? PeekabooBridgeErrorEnvelope)?.code == .timeout
+            guard isTimeout else { throw error }
+
+            // A busy local host can accept the connection before its handler is scheduled.
+            return try await operation(2)
+        }
     }
 
     @discardableResult

--- a/Apps/CLI/Tests/CoreCLITests/InteractionMutationInvalidatorTests.swift
+++ b/Apps/CLI/Tests/CoreCLITests/InteractionMutationInvalidatorTests.swift
@@ -7,6 +7,22 @@ import Testing
 @MainActor
 struct InteractionMutationInvalidatorTests {
     @Test
+    func `Bridge timeout retries once with a longer budget`() async throws {
+        var attemptedTimeouts: [TimeInterval] = []
+
+        let result: String = try await InteractionObservationInvalidator.retryBridgeTimeout { timeoutSec in
+            attemptedTimeouts.append(timeoutSec)
+            if attemptedTimeouts.count == 1 {
+                throw POSIXError(.ETIMEDOUT)
+            }
+            return "connected"
+        }
+
+        #expect(result == "connected")
+        #expect(attemptedTimeouts == [1, 2])
+    }
+
+    @Test
     func `Mutation invalidates all hosts while preserving explicit snapshots`() async throws {
         let selectedSnapshots = InMemorySnapshotManager()
         let alternateSnapshots = InMemorySnapshotManager()

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,10 @@
 ## [3.9.4] - Unreleased
 
 ### Changed
-- Refresh AXorcist, Commander, Swiftdansi, Tachikoma, and TauTUI to their latest patch releases, including stricter SwiftPM checkout handling for Tachikoma's Commander dependency.
+- Refresh AXorcist, Commander, Swiftdansi, Tachikoma, and TauTUI, including stricter SwiftPM checkout handling for Tachikoma's Commander dependency plus corrected AXorcist app resolution, attribute serialization, and descendant filtering.
+
+### Fixed
+- Keep bridge acceptance and request handling responsive, and retry timed-out snapshot invalidation handshakes once so busy local endpoints are not mistaken for stale sockets.
 
 ## [3.9.3] - 2026-07-14
 

--- a/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeHost.swift
+++ b/Core/PeekabooCore/Sources/PeekabooBridge/PeekabooBridgeHost.swift
@@ -169,7 +169,7 @@ public final actor PeekabooBridgeHost {
         let requestTimeoutSec = self.requestTimeoutSec
         let connectionTracker = self.connectionTracker
 
-        self.acceptTask = Task.detached(priority: .utility) {
+        self.acceptTask = Task.detached(priority: .userInitiated) {
             await Self.acceptLoop(
                 listenFD: fd,
                 server: server,
@@ -1114,7 +1114,7 @@ public final actor PeekabooBridgeHost {
                 continue
             }
             await connectionTracker.begin()
-            Task.detached(priority: .utility) {
+            Task.detached(priority: .userInitiated) {
                 defer { close(client) }
                 await Self.handleClient(
                     fd: client,

--- a/Package.swift
+++ b/Package.swift
@@ -49,7 +49,7 @@ let package = Package(
             targets: ["PeekabooBridge"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/openclaw/AXorcist.git", exact: "0.1.5"),
+        .package(url: "https://github.com/openclaw/AXorcist.git", exact: "0.1.6"),
         .package(url: "https://github.com/apple/swift-algorithms", from: "1.2.1"),
     ],
     targets: [


### PR DESCRIPTION
## Summary

- update AXorcist from `46c5adb` to the released-and-documented `8f56bb2` head after AXorcist 0.1.6
- keep bridge accept and request-handler work latency-sensitive
- retry timeout-only alternate snapshot handshakes once with a bounded longer budget
- include endpoint errors in debug logs and add deterministic retry coverage

## Why

The final integration run exposed an existing bridge test failure: healthy local alternate endpoints were intermittently treated as stale because their `.utility` request handler could miss the one-second client deadline under load. Before the fix, the focused test failed 8/10 runs with the original timeout, and a simple two-second timeout still failed 1/10. Raising both socket tasks to `.userInitiated` plus a timeout-only retry passed 50/50 exact-test runs and 20/20 full launch-suite runs.

## Verification

- `pnpm run lint` — completes with the existing 13 non-serious baseline warnings
- `pnpm run format` — zero files changed
- `pnpm run build:cli`
- `pnpm run test:safe` — 748 tests passed
- focused snapshot invalidation test — 50/50 passes
- `AppCommandLaunchFlowTests` — 20/20 passes
- autoreview — no accepted/actionable findings

AXorcist upstream proof:

- implementation: https://github.com/openclaw/AXorcist/pull/17
- release: https://github.com/openclaw/AXorcist/releases/tag/v0.1.6
- Homebrew formula: https://github.com/openclaw/homebrew-tap/pull/9
