### PR TITLE
fix(resolve): match applications by executable name

### DIFF
--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Capture/ScreenCaptureApplicationResolver.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Capture/ScreenCaptureApplicationResolver.swift
@@ -39,18 +39,35 @@ struct PeekabooApplicationResolver: ApplicationResolving {
             return Self.applicationInfo(from: exactName)
         }
 
+        // Exact executable-name match: the process/binary name shown by ps, pgrep, and
+        // Activity Monitor often differs from the localized app name (e.g. an app whose
+        // CFBundleName is "OpenClaw Desktop Test" ships an "openclaw-desktop" binary).
+        if let exactExecutable = runningApps.first(where: {
+            guard let executable = $0.executableURL?.lastPathComponent else { return false }
+            return executable.compare(trimmedIdentifier, options: .caseInsensitive) == .orderedSame
+        }) {
+            return Self.applicationInfo(from: exactExecutable)
+        }
+
         let fuzzyMatches = runningApps.compactMap { app -> (app: NSRunningApplication, score: Int)? in
-            guard app.activationPolicy != .prohibited,
-                  let name = app.localizedName,
-                  name.localizedCaseInsensitiveContains(trimmedIdentifier)
-            else { return nil }
+            guard app.activationPolicy != .prohibited, let name = app.localizedName else { return nil }
+            let executable = app.executableURL?.lastPathComponent
+            let nameMatches = name.localizedCaseInsensitiveContains(trimmedIdentifier)
+            let executableMatches = executable?.localizedCaseInsensitiveContains(trimmedIdentifier) ?? false
+            guard nameMatches || executableMatches else { return nil }
 
             var score = 0
             if name.compare(trimmedIdentifier, options: .caseInsensitive) == .orderedSame {
                 score += 1000
             }
+            if let executable, executable.compare(trimmedIdentifier, options: .caseInsensitive) == .orderedSame {
+                score += 800
+            }
             if name.lowercased().hasPrefix(trimmedIdentifier.lowercased()) {
                 score += 100
+            }
+            if let executable, executable.lowercased().hasPrefix(trimmedIdentifier.lowercased()) {
+                score += 80
             }
             if app.activationPolicy == .regular {
                 score += 50

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/System/ApplicationService+Discovery.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/System/ApplicationService+Discovery.swift
@@ -135,27 +135,46 @@ extension ApplicationService {
             return self.createApplicationInfo(from: exactName)
         }
 
-        // 4. Fuzzy matching with prioritization
-        // Collect all fuzzy matches and sort by relevance
+        // 4. Try exact executable-name match (case-insensitive)
+        // The process/binary name shown by ps, pgrep, and Activity Monitor often differs
+        // from the localized app name (e.g. an app whose CFBundleName is
+        // "OpenClaw Desktop Test" ships an "openclaw-desktop" binary).
+        if let exactExecutable = runningApps.first(where: {
+            guard let executable = $0.executableURL?.lastPathComponent else { return false }
+            return executable.compare(trimmedIdentifier, options: .caseInsensitive) == .orderedSame
+        }) {
+            return self.createApplicationInfo(from: exactExecutable)
+        }
+
+        // 5. Fuzzy matching with prioritization
+        // Collect all fuzzy matches (localized name or executable name) and sort by relevance
         let fuzzyMatches = runningApps.compactMap { app -> (app: NSRunningApplication, score: Int)? in
-            guard app.activationPolicy != .prohibited,
-                  let name = app.localizedName,
-                  name.localizedCaseInsensitiveContains(trimmedIdentifier)
-            else { return nil }
+            guard app.activationPolicy != .prohibited, let name = app.localizedName else { return nil }
+            let executable = app.executableURL?.lastPathComponent
+            let nameMatches = name.localizedCaseInsensitiveContains(trimmedIdentifier)
+            let executableMatches = executable?.localizedCaseInsensitiveContains(trimmedIdentifier) ?? false
+            guard nameMatches || executableMatches else { return nil }
 
             // Calculate match score (higher is better)
             var score = 0
 
-            // Exact match gets highest score
+            let lowercaseIdentifier = trimmedIdentifier.lowercased()
+
+            // Exact match gets highest score; an exact executable match ranks just below
+            // an exact localized-name match.
             if name.compare(trimmedIdentifier, options: .caseInsensitive) == .orderedSame {
                 score += 1000
             }
+            if let executable, executable.compare(trimmedIdentifier, options: .caseInsensitive) == .orderedSame {
+                score += 800
+            }
 
-            // Name starts with identifier gets high score
-            let lowercaseName = name.lowercased()
-            let lowercaseIdentifier = trimmedIdentifier.lowercased()
-            if lowercaseName.hasPrefix(lowercaseIdentifier) {
+            // Name / executable starts with identifier gets high score
+            if name.lowercased().hasPrefix(lowercaseIdentifier) {
                 score += 100
+            }
+            if let executable, executable.lowercased().hasPrefix(lowercaseIdentifier) {
+                score += 80
             }
 
             // Prefer regular apps over accessories/helpers


### PR DESCRIPTION
## Problem

`--app <name>` resolved an application only by **bundle identifier** and **localized app name** (`NSRunningApplication.localizedName`), never by the **executable/process name**. So an app whose `CFBundleName` differs from its binary name could not be targeted by the name you see in `ps`, `pgrep`, or Activity Monitor.

Concrete repro: a Tauri app whose `CFBundleName` is `OpenClaw Desktop Test` ships an `openclaw-desktop` binary. `peekaboo image --app openclaw-desktop` failed with `APP_NOT_FOUND` even though the process was obviously running.

## Fix

Both resolvers — `ScreenCaptureApplicationResolver` (used by capture) and `ApplicationService.findApplication` (general) — now:
- add an **exact executable-name match** (after exact bundle-id and exact localized-name, before fuzzy), and
- include the executable name in **fuzzy** matching, ranked just below the localized-name signals (exact-name 1000 > exact-exe 800; name-prefix 100 > exe-prefix 80).

## Verification

Live, against the running app (standalone snippet replicating the resolver against `NSWorkspace`):

```
OLD logic → NOT FOUND   (reproduces the bug)
NEW logic → OpenClaw Desktop Test (pid 44303) exe=openclaw-desktop
```

`PeekabooAutomationKit` builds clean with the change. (The full CLI `swift build` currently fails on an unrelated pre-existing `LanguageModel.OpenAI.gpt56Model` error in the AI module on `main`, not touched here.)
