### PR TITLE
fix(release): resolve SwiftPM binary output paths

### DIFF
--- a/scripts/build-swift-arm.sh
+++ b/scripts/build-swift-arm.sh
@@ -129,7 +129,9 @@ echo "🏗️ Building for arm64 (Apple Silicon) only..."
     cd "$SWIFT_PROJECT_PATH"
     swift build --arch arm64 -c release $SWIFT_OPTIMIZATION_FLAGS 2>&1 | pipe_build_output
 )
-cp "$SWIFT_PROJECT_PATH/.build/arm64-apple-macosx/release/$FINAL_BINARY_NAME" "$FINAL_BINARY_PATH.tmp"
+ARM64_BUILD_BINARY=$(bash "$PROJECT_ROOT/scripts/resolve-swift-binary-path.sh" \
+    "$SWIFT_PROJECT_PATH" arm64 release "$FINAL_BINARY_NAME")
+cp "$ARM64_BUILD_BINARY" "$FINAL_BINARY_PATH.tmp"
 echo "✅ arm64 build complete"
 
 echo "🤏 Stripping symbols for further size reduction..."

--- a/scripts/build-swift-universal.sh
+++ b/scripts/build-swift-universal.sh
@@ -132,7 +132,9 @@ echo "🏗️ Building for arm64 (Apple Silicon)..."
     cd "$SWIFT_PROJECT_PATH"
     swift build --arch arm64 -c release $SWIFT_OPTIMIZATION_FLAGS 2>&1 | pipe_build_output
 )
-cp "$SWIFT_PROJECT_PATH/.build/arm64-apple-macosx/release/$FINAL_BINARY_NAME" "$ARM64_BINARY_TEMP"
+ARM64_BUILD_BINARY=$(bash "$PROJECT_ROOT/scripts/resolve-swift-binary-path.sh" \
+    "$SWIFT_PROJECT_PATH" arm64 release "$FINAL_BINARY_NAME")
+cp "$ARM64_BUILD_BINARY" "$ARM64_BINARY_TEMP"
 echo "✅ arm64 build complete: $ARM64_BINARY_TEMP"
 
 echo "🏗️ Building for x86_64 (Intel)..."
@@ -140,7 +142,9 @@ echo "🏗️ Building for x86_64 (Intel)..."
     cd "$SWIFT_PROJECT_PATH"
     swift build --arch x86_64 -c release $SWIFT_OPTIMIZATION_FLAGS 2>&1 | pipe_build_output
 )
-cp "$SWIFT_PROJECT_PATH/.build/x86_64-apple-macosx/release/$FINAL_BINARY_NAME" "$X86_64_BINARY_TEMP"
+X86_64_BUILD_BINARY=$(bash "$PROJECT_ROOT/scripts/resolve-swift-binary-path.sh" \
+    "$SWIFT_PROJECT_PATH" x86_64 release "$FINAL_BINARY_NAME")
+cp "$X86_64_BUILD_BINARY" "$X86_64_BINARY_TEMP"
 echo "✅ x86_64 build complete: $X86_64_BINARY_TEMP"
 
 echo "🔗 Creating universal binary..."

--- a/scripts/resolve-swift-binary-path.sh
+++ b/scripts/resolve-swift-binary-path.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+set -euo pipefail
+
+if [ "$#" -ne 4 ]; then
+    echo "Usage: $0 <package-path> <architecture> <configuration> <binary-name>" >&2
+    exit 2
+fi
+
+PACKAGE_PATH="$1"
+ARCHITECTURE="$2"
+CONFIGURATION="$3"
+BINARY_NAME="$4"
+
+BIN_DIRECTORY=$(
+    cd "$PACKAGE_PATH"
+    swift build --arch "$ARCHITECTURE" -c "$CONFIGURATION" --show-bin-path
+)
+BINARY_PATH="$BIN_DIRECTORY/$BINARY_NAME"
+
+if [ ! -f "$BINARY_PATH" ]; then
+    echo "ERROR: Swift build completed but $BINARY_NAME was not found at $BINARY_PATH" >&2
+    exit 1
+fi
+
+printf '%s\n' "$BINARY_PATH"


### PR DESCRIPTION
## Summary

- resolve release binaries through SwiftPM's supported `--show-bin-path` output
- use the resolved path for both arm64-only and universal CLI builds
- fail with an explicit product path when SwiftPM reports a bin directory without the expected executable

## Why

The 3.9.5 release build completed its arm64 compile under Xcode 27, then failed because the packaging script assumed the legacy `.build/arm64-apple-macosx/release` layout. SwiftPM placed the product in `.build/out/Products/Release` on this toolchain.

## Proof

- `bash -n scripts/resolve-swift-binary-path.sh scripts/build-swift-universal.sh scripts/build-swift-arm.sh`
- `bash scripts/resolve-swift-binary-path.sh Apps/CLI arm64 release peekaboo` resolved the existing product at `.build/out/Products/Release/peekaboo`
- autoreview: clean after accepting the executable-mode finding and making callers invoke the helper through `bash`
