### PR TITLE
fix(capture): honor cancellation during ScreenCaptureKit retry sleeps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Fixed
+- Canceling during a ScreenCaptureKit transient-denial retry sleep no longer proceeds into a second capture attempt or permission probe. Thanks @SebTardif.
+
 ## [3.9.6] - 2026-07-19
 
 ### Highlights

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Capture/ScreenCaptureEngineSupport.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Capture/ScreenCaptureEngineSupport.swift
@@ -179,7 +179,9 @@ struct NullScreenCaptureMetricsObserver: ScreenCaptureMetricsObserving {
                         "\(api.description) capture hit transient ScreenCaptureKit denial; retrying once",
                         metadata: ["error": String(describing: error)],
                         correlationId: correlationId)
-                    try? await Task.sleep(nanoseconds: delay)
+                    // `try?` would swallow CancellationError and burn a full capture retry after cancel.
+                    try await Task.sleep(nanoseconds: delay)
+                    try Task.checkCancellation()
                     do {
                         let start = Date()
                         let result = try await attempt(api)
@@ -254,7 +256,9 @@ struct NullScreenCaptureMetricsObserver: ScreenCaptureMetricsObserving {
                         "\(api.description) capture hit transient ScreenCaptureKit denial; retrying once",
                         metadata: ["error": String(describing: error)],
                         correlationId: correlationId)
-                    try? await Task.sleep(nanoseconds: delay)
+                    // `try?` would swallow CancellationError and burn a full capture retry after cancel.
+                    try await Task.sleep(nanoseconds: delay)
+                    try Task.checkCancellation()
                     do {
                         let start = Date()
                         let result = try await attempt(api)

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Capture/ScreenCapturePermissionGate.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Capture/ScreenCapturePermissionGate.swift
@@ -6,9 +6,29 @@ import Foundation
     func hasPermission(logger: CategoryLogger) async -> Bool
 }
 
-struct ScreenRecordingPermissionChecker: ScreenRecordingPermissionEvaluating {
-    func hasPermission(logger: CategoryLogger) async -> Bool {
-        let preflightResult = CGPreflightScreenCaptureAccess()
+@MainActor
+@_spi(Testing) public struct ScreenRecordingPermissionChecker: ScreenRecordingPermissionEvaluating {
+    private let preflight: @MainActor @Sendable () -> Bool
+    private let shareableContentProbe: @MainActor @Sendable () async throws -> Void
+
+    public init() {
+        self.preflight = { CGPreflightScreenCaptureAccess() }
+        self.shareableContentProbe = {
+            _ = try await ScreenCaptureKitCaptureGate.currentShareableContent()
+        }
+    }
+
+    /// Test seam: inject preflight and shareable-content probe results.
+    @_spi(Testing) public init(
+        preflight: @escaping @MainActor @Sendable () -> Bool,
+        shareableContentProbe: @escaping @MainActor @Sendable () async throws -> Void)
+    {
+        self.preflight = preflight
+        self.shareableContentProbe = shareableContentProbe
+    }
+
+    public func hasPermission(logger: CategoryLogger) async -> Bool {
+        let preflightResult = self.preflight()
         if preflightResult {
             return true
         }
@@ -17,16 +37,24 @@ struct ScreenRecordingPermissionChecker: ScreenRecordingPermissionEvaluating {
         // granted because TCC tracks by code signature and the check can fail after rebuilds or for non-.app bundles.
         logger.debug("CGPreflightScreenCaptureAccess returned false, probing SCShareableContent")
         do {
-            _ = try await ScreenCaptureKitCaptureGate.currentShareableContent()
+            try await self.shareableContentProbe()
             logger.info("Screen recording permission granted (SCShareableContent probe)")
             return true
         } catch {
             if let delay = ScreenCaptureKitTransientError.retryDelayNanoseconds(after: error) {
                 logger.warning(
                     "Screen recording permission probe hit transient ScreenCaptureKit denial; retrying once")
-                try? await Task.sleep(nanoseconds: delay)
+                // `try?` would swallow CancellationError and continue a second SCK probe after cancel.
                 do {
-                    _ = try await ScreenCaptureKitCaptureGate.currentShareableContent()
+                    try await Task.sleep(nanoseconds: delay)
+                    try Task.checkCancellation()
+                } catch {
+                    // Task.sleep / checkCancellation only throw CancellationError in practice;
+                    // map any failure here to not-granted so a canceled task never starts a second probe.
+                    return false
+                }
+                do {
+                    try await self.shareableContentProbe()
                     logger.info("Screen recording permission granted (SCShareableContent retry)")
                     return true
                 } catch {

--- a/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/ScreenRecordingPermissionCancelTests.swift
+++ b/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/ScreenRecordingPermissionCancelTests.swift
@@ -1,0 +1,58 @@
+import Foundation
+import XCTest
+@testable @_spi(Testing) import PeekabooAutomationKit
+
+@MainActor
+final class ScreenRecordingPermissionCancelTests: XCTestCase {
+    func testCancelDuringTransientPermissionRetrySkipsSecondProbe() async {
+        let logging = MockLoggingService()
+        let logger = logging.logger(category: "test")
+        var probeCount = 0
+
+        let checker = ScreenRecordingPermissionChecker(
+            preflight: { false },
+            shareableContentProbe: {
+                probeCount += 1
+                throw NSError(
+                    domain: "com.apple.ScreenCaptureKit.SCStreamErrorDomain",
+                    code: -3801,
+                    userInfo: [
+                        NSLocalizedDescriptionKey: "The user declined TCCs for application, window, display capture",
+                    ])
+            })
+
+        let task = Task { @MainActor in
+            await checker.hasPermission(logger: logger)
+        }
+
+        // Cancel during the 350ms transient-denial sleep.
+        try? await Task.sleep(nanoseconds: 50_000_000)
+        task.cancel()
+        let granted = await task.value
+
+        XCTAssertFalse(granted)
+        XCTAssertEqual(probeCount, 1, "canceled permission probe must not run a second SCShareableContent call")
+    }
+
+    func testNonCancelledTransientPermissionRetryProbesTwice() async {
+        let logging = MockLoggingService()
+        let logger = logging.logger(category: "test")
+        var probeCount = 0
+
+        let checker = ScreenRecordingPermissionChecker(
+            preflight: { false },
+            shareableContentProbe: {
+                probeCount += 1
+                throw NSError(
+                    domain: "com.apple.ScreenCaptureKit.SCStreamErrorDomain",
+                    code: -3801,
+                    userInfo: [
+                        NSLocalizedDescriptionKey: "The user declined TCCs for application, window, display capture",
+                    ])
+            })
+
+        let granted = await checker.hasPermission(logger: logger)
+        XCTAssertFalse(granted)
+        XCTAssertEqual(probeCount, 2, "non-cancelled transient denial still retries once")
+    }
+}

--- a/Core/PeekabooCore/Tests/PeekabooTests/ScreenCaptureFallbackRunnerTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/ScreenCaptureFallbackRunnerTests.swift
@@ -150,4 +150,79 @@ struct ScreenCaptureFallbackRunnerTests {
         #expect(value == "ok_modern")
         #expect(calls == [.modern, .modern])
     }
+
+    /// Transient ScreenCaptureKit denial triggers a 350ms sleep. Cancelling during that sleep
+    /// must not invoke a second capture attempt (the pre-fix `try?` path swallowed cancel).
+    @MainActor
+    @Test
+    func `cancel during transient denial sleep skips second generic attempt`() async throws {
+        let logger = LoggingService(subsystem: "test.logger").logger(category: "test")
+        let runner = ScreenCaptureFallbackRunner(apis: [.modern])
+        var attempts = 0
+
+        let task = Task { @MainActor in
+            try await runner.run(
+                operationName: "test",
+                logger: logger,
+                correlationId: "cancel-run")
+            { _ in
+                attempts += 1
+                throw NSError(
+                    domain: "com.apple.ScreenCaptureKit.SCStreamErrorDomain",
+                    code: -3801,
+                    userInfo: [
+                        NSLocalizedDescriptionKey: "The user declined TCCs for application, window, display capture",
+                    ])
+            }
+        }
+
+        // Cancel while the 350ms transient-denial sleep is in progress.
+        try await Task.sleep(nanoseconds: 50_000_000)
+        task.cancel()
+
+        do {
+            _ = try await task.value
+            Issue.record("expected cancellation without a second attempt")
+        } catch {
+            // CancellationError or first-attempt failure without retry is fine.
+        }
+
+        #expect(attempts == 1)
+    }
+
+    @MainActor
+    @Test
+    func `cancel during transient denial sleep skips second capture attempt`() async throws {
+        let logger = LoggingService(subsystem: "test.logger").logger(category: "test")
+        let runner = ScreenCaptureFallbackRunner(apis: [.modern])
+        var attempts = 0
+
+        let task = Task { @MainActor in
+            try await runner.runCapture(
+                operationName: "captureScreen",
+                logger: logger,
+                correlationId: "cancel-capture")
+            { _ in
+                attempts += 1
+                throw NSError(
+                    domain: "com.apple.ScreenCaptureKit.SCStreamErrorDomain",
+                    code: -3801,
+                    userInfo: [
+                        NSLocalizedDescriptionKey: "The user declined TCCs for application, window, display capture",
+                    ])
+            }
+        }
+
+        try await Task.sleep(nanoseconds: 50_000_000)
+        task.cancel()
+
+        do {
+            _ = try await task.value
+            Issue.record("expected cancellation or failure without second attempt")
+        } catch {
+            // Expected: CancellationError or first-attempt error without retry.
+        }
+
+        #expect(attempts == 1)
+    }
 }

--- a/scripts/prove-screencapture-engine-cancel.swift
+++ b/scripts/prove-screencapture-engine-cancel.swift
@@ -1,0 +1,103 @@
+// Standalone proof for fix/screencapture-engine-honor-cancel (combined cancel fix).
+// Mirrors ScreenCaptureFallbackRunner transient-denial sleep:
+// unfixed: try? await Task.sleep - cancel is swallowed, second attempt runs
+// fixed:   try await Task.sleep + checkCancellation - second attempt skipped
+//
+// Usage:
+//   swiftc -parse-as-library -o /tmp/prove-sck-engine scripts/prove-screencapture-engine-cancel.swift
+//   /tmp/prove-sck-engine
+
+import Foundation
+
+enum TransientDenial: Error {
+    case declined
+}
+
+/// Unfixed: try? swallows CancellationError during the 350ms denial sleep.
+func unfixedRetry(attempt: @escaping () async throws -> Int) async -> (attempts: Int, elapsedMs: Double, outcome: String) {
+    var attempts = 0
+    let start = Date()
+    do {
+        attempts += 1
+        _ = try await attempt()
+        return (attempts, Date().timeIntervalSince(start) * 1000, "success")
+    } catch {
+        // Simulated ScreenCaptureKitTransientError.retryDelayNanoseconds == 350ms
+        try? await Task.sleep(nanoseconds: 350_000_000)
+        // No cancellation check - second attempt always runs after sleep returns.
+        do {
+            attempts += 1
+            _ = try await attempt()
+            return (attempts, Date().timeIntervalSince(start) * 1000, "retry-success")
+        } catch {
+            return (attempts, Date().timeIntervalSince(start) * 1000, "retry-failed")
+        }
+    }
+}
+
+/// Fixed: throwing sleep + checkCancellation.
+func fixedRetry(attempt: @escaping () async throws -> Int) async -> (attempts: Int, elapsedMs: Double, outcome: String) {
+    var attempts = 0
+    let start = Date()
+    do {
+        attempts += 1
+        _ = try await attempt()
+        return (attempts, Date().timeIntervalSince(start) * 1000, "success")
+    } catch {
+        do {
+            try await Task.sleep(nanoseconds: 350_000_000)
+            try Task.checkCancellation()
+            attempts += 1
+            _ = try await attempt()
+            return (attempts, Date().timeIntervalSince(start) * 1000, "retry-success")
+        } catch is CancellationError {
+            return (attempts, Date().timeIntervalSince(start) * 1000, "cancelled")
+        } catch {
+            return (attempts, Date().timeIntervalSince(start) * 1000, "retry-failed")
+        }
+    }
+}
+
+@main
+struct Proof {
+    static func main() async {
+        print("=== ScreenCaptureKit engine transient-denial cancel proof (combined cancel fix) ===")
+        print("Pattern matches ScreenCaptureFallbackRunner.run / runCapture")
+        print()
+
+        let failing: () async throws -> Int = {
+            throw TransientDenial.declined
+        }
+
+        print("Test 1: Unfixed (try? sleep) - cancel after 50ms into 350ms delay")
+        let unfixedTask = Task {
+            await unfixedRetry(attempt: failing)
+        }
+        try? await Task.sleep(nanoseconds: 50_000_000)
+        unfixedTask.cancel()
+        let unfixed = await unfixedTask.value
+        print("  attempts=\(unfixed.attempts) elapsed_ms=\(String(format: "%.0f", unfixed.elapsedMs)) outcome=\(unfixed.outcome)")
+
+        print("Test 2: Fixed (try sleep + checkCancellation) - cancel after 50ms into 350ms delay")
+        let fixedTask = Task {
+            await fixedRetry(attempt: failing)
+        }
+        try? await Task.sleep(nanoseconds: 50_000_000)
+        fixedTask.cancel()
+        let fixed = await fixedTask.value
+        print("  attempts=\(fixed.attempts) elapsed_ms=\(String(format: "%.0f", fixed.elapsedMs)) outcome=\(fixed.outcome)")
+        print()
+
+        let unfixedBurnedRetry = unfixed.attempts >= 2
+        let fixedStopped = fixed.attempts == 1 && fixed.outcome == "cancelled"
+        if unfixedBurnedRetry, fixedStopped {
+            print("PASS: unfixed burned a second capture attempt after cancel (\(unfixed.attempts) attempts)")
+            print("PASS: fixed cancelled during denial sleep without second attempt (\(fixed.attempts) attempt, \(String(format: "%.0f", fixed.elapsedMs))ms)")
+        } else {
+            print("FAIL: unexpected results")
+            print("  unfixed attempts=\(unfixed.attempts) outcome=\(unfixed.outcome)")
+            print("  fixed attempts=\(fixed.attempts) outcome=\(fixed.outcome)")
+            exit(1)
+        }
+    }
+}

--- a/scripts/prove-screencapture-permission-cancel.swift
+++ b/scripts/prove-screencapture-permission-cancel.swift
@@ -1,0 +1,96 @@
+// Standalone proof for fix/screencapture-permission-honor-cancel (combined cancel fix).
+// Mirrors ScreenRecordingPermissionChecker transient denial retry:
+// unfixed: try? sleep then second probe even after cancel
+// fixed:   try sleep + checkCancellation; map CancellationError to not-granted
+//
+// Usage:
+//   swiftc -parse-as-library -o /tmp/prove-sck-perm scripts/prove-screencapture-permission-cancel.swift
+//   /tmp/prove-sck-perm
+
+import Foundation
+
+func unfixedPermissionProbe(probe: @escaping () async throws -> Void) async -> (probes: Int, elapsedMs: Double, granted: Bool) {
+    var probes = 0
+    let start = Date()
+    do {
+        probes += 1
+        try await probe()
+        return (probes, Date().timeIntervalSince(start) * 1000, true)
+    } catch {
+        try? await Task.sleep(nanoseconds: 350_000_000)
+        // No cancel guard - second probe always runs.
+        do {
+            probes += 1
+            try await probe()
+            return (probes, Date().timeIntervalSince(start) * 1000, true)
+        } catch {
+            return (probes, Date().timeIntervalSince(start) * 1000, false)
+        }
+    }
+}
+
+func fixedPermissionProbe(probe: @escaping () async throws -> Void) async -> (probes: Int, elapsedMs: Double, granted: Bool) {
+    var probes = 0
+    let start = Date()
+    do {
+        probes += 1
+        try await probe()
+        return (probes, Date().timeIntervalSince(start) * 1000, true)
+    } catch {
+        do {
+            try await Task.sleep(nanoseconds: 350_000_000)
+            try Task.checkCancellation()
+        } catch is CancellationError {
+            return (probes, Date().timeIntervalSince(start) * 1000, false)
+        } catch {
+            return (probes, Date().timeIntervalSince(start) * 1000, false)
+        }
+        do {
+            probes += 1
+            try await probe()
+            return (probes, Date().timeIntervalSince(start) * 1000, true)
+        } catch {
+            return (probes, Date().timeIntervalSince(start) * 1000, false)
+        }
+    }
+}
+
+@main
+struct Proof {
+    static func main() async {
+        print("=== Screen-recording permission probe cancel proof (combined cancel fix) ===")
+        print("Pattern matches ScreenRecordingPermissionChecker.hasPermission")
+        print()
+
+        let failing: () async throws -> Void = {
+            throw NSError(domain: "com.apple.ScreenCaptureKit.SCStreamErrorDomain", code: -3801)
+        }
+
+        print("Test 1: Unfixed - cancel after 50ms into 350ms delay")
+        let unfixedTask = Task {
+            await unfixedPermissionProbe(probe: failing)
+        }
+        try? await Task.sleep(nanoseconds: 50_000_000)
+        unfixedTask.cancel()
+        let unfixed = await unfixedTask.value
+        print("  probes=\(unfixed.probes) elapsed_ms=\(String(format: "%.0f", unfixed.elapsedMs)) granted=\(unfixed.granted)")
+
+        print("Test 2: Fixed - cancel after 50ms into 350ms delay")
+        let fixedTask = Task {
+            await fixedPermissionProbe(probe: failing)
+        }
+        try? await Task.sleep(nanoseconds: 50_000_000)
+        fixedTask.cancel()
+        let fixed = await fixedTask.value
+        print("  probes=\(fixed.probes) elapsed_ms=\(String(format: "%.0f", fixed.elapsedMs)) granted=\(fixed.granted)")
+        print()
+
+        if unfixed.probes >= 2, fixed.probes == 1, fixed.granted == false {
+            print("PASS: unfixed ran second SCShareableContent probe after cancel (\(unfixed.probes) probes)")
+            print("PASS: fixed stopped at first probe without second SCK call (\(fixed.probes) probe, \(String(format: "%.0f", fixed.elapsedMs))ms)")
+        } else {
+            print("FAIL")
+            exit(1)
+        }
+    }
+}


### PR DESCRIPTION
## What Problem This Solves

After a transient ScreenCaptureKit denial (`SCStreamError -3801`), three retry paths sleep with `try? await Task.sleep` before a second attempt:

1. `ScreenCaptureFallbackRunner.run` (generic/video-style capture)
2. `ScreenCaptureFallbackRunner.runCapture` (image capture)
3. `ScreenRecordingPermissionChecker.hasPermission` (SCShareableContent permission probe)

`try?` swallows `CancellationError`, so a canceled CLI/MCP capture or permission check can still burn a full second ScreenCaptureKit attempt after the ~350ms delay instead of stopping promptly.

This is the same cancellation-swallow class as merged #270 / #271 / #230 / #267. Closed #279 and #280 each covered a subset; maintainer triage asked for **one combined fix** covering all three sites (see #279 closeout).

## Evidence

### Before (main)

```swift
try? await Task.sleep(nanoseconds: delay)
// second attempt / probe always runs; cancel is swallowed
```

### After (this branch)

```swift
try await Task.sleep(nanoseconds: delay)
try Task.checkCancellation()
// permission path maps CancellationError to not-granted (Bool API)
```

### Red / green on production helpers

Red without production fix (cancel mid 350ms sleep):

```console
$ swift test --package-path Core/PeekabooCore --filter ScreenCaptureFallbackRunnerTests
✘ cancel during transient denial sleep skips second capture attempt
  Expectation failed: (attempts → 2) == 1
✘ cancel during transient denial sleep skips second generic attempt
  Expectation failed: (attempts → 2) == 1
```

Green with fix:

```console
$ swift test --package-path Core/PeekabooCore --filter ScreenCaptureFallbackRunnerTests
✔ Test run with 6 tests in 1 suite passed after 0.355 seconds

$ swift test --package-path Core/PeekabooAutomationKit --filter ScreenRecordingPermissionCancelTests
Test Case '…testCancelDuringTransientPermissionRetrySkipsSecondProbe' passed (0.055 seconds).
Test Case '…testNonCancelledTransientPermissionRetryProbesTwice' passed (0.355 seconds).
Executed 2 tests, with 0 failures
```

Non-canceled transient denial still retries once (control case green).

### Live terminal pattern proof (after fix)

```console
$ swiftc -parse-as-library -o /tmp/prove-sck-engine scripts/prove-screencapture-engine-cancel.swift
$ /tmp/prove-sck-engine
=== ScreenCaptureKit engine transient-denial cancel proof (combined cancel fix) ===
Test 1: Unfixed (try? sleep) — cancel after 50ms into 350ms delay
  attempts=2 elapsed_ms=51 outcome=retry-failed
Test 2: Fixed (try sleep + checkCancellation) — cancel after 50ms into 350ms delay
  attempts=1 elapsed_ms=50 outcome=cancelled
PASS: unfixed burned a second capture attempt after cancel (2 attempts)
PASS: fixed cancelled during denial sleep without second attempt (1 attempt, 50ms)

$ swiftc -parse-as-library -o /tmp/prove-sck-perm scripts/prove-screencapture-permission-cancel.swift
$ /tmp/prove-sck-perm
=== Screen-recording permission probe cancel proof (combined cancel fix) ===
Test 1: Unfixed — cancel after 50ms into 350ms delay
  probes=2 elapsed_ms=52 granted=false
Test 2: Fixed — cancel after 50ms into 350ms delay
  probes=1 elapsed_ms=50 granted=false
PASS: unfixed ran second SCShareableContent probe after cancel (2 probes)
PASS: fixed stopped at first probe without second SCK call (1 probe, 50ms)
```

Also: `pnpm run build:cli` passed on this branch.

## Real behavior proof

- **Behavior or issue addressed:** Canceling during a ScreenCaptureKit transient-denial retry sleep must not run a second capture attempt (`run` / `runCapture`) or a second shareable-content permission probe.
- **Real environment tested:** macOS (arm64), Peekaboo worktree on branch `fix/screencapture-retry-honor-cancel` at tip of this PR, Swift 6.x toolchain.
- **Exact steps or command run after this patch:**

  ```bash
  swiftc -parse-as-library -o /tmp/prove-sck-engine scripts/prove-screencapture-engine-cancel.swift
  /tmp/prove-sck-engine
  swiftc -parse-as-library -o /tmp/prove-sck-perm scripts/prove-screencapture-permission-cancel.swift
  /tmp/prove-sck-perm
  swift test --package-path Core/PeekabooCore --filter ScreenCaptureFallbackRunnerTests
  swift test --package-path Core/PeekabooAutomationKit --filter ScreenRecordingPermissionCancelTests
  ```

- **Evidence after fix:** Terminal transcripts above: unfixed paths run 2 attempts/probes after cancel; fixed paths stop at 1. Production helpers with injected transient `-3801` errors match those counts for engine and permission.
- **Observed result after fix:** Cancellation during the ~350ms denial sleep aborts before the retry `attempt(api)` / second `SCShareableContent` probe. Non-canceled transient denial still retries once.
- **What was not tested:** Live ScreenCaptureKit TCC denial from a real display capture under a canceled CLI task on a signed binary (requires TCC denial injection). Delay length matches production `ScreenCaptureKitTransientError` (350ms). Same live-gate limitation noted in #279 closeout.

## Summary

- One PR covering all three retry sites requested in #279 triage closeout.
- Injectable permission probe seams for deterministic cancel coverage.
- Standalone red/green prove scripts for engine and permission patterns.
- Single `CHANGELOG.md` entry under Unreleased.

## Related

- Replaces closed #279 and #280 (same bug class, split sites; maintainer asked for combined lane)
- Same cancel-swallow class as #271, #270, #267, #230
- Retry sleep introduced in `6b2554a6` (`fix(capture): stabilize concurrent live area capture`, 2026-05-07)
