### PR TITLE
fix(mcp): read pipe data before waitUntilExit to prevent deadlock

### DIFF
--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/ShellTool.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/ShellTool.swift
@@ -65,10 +65,15 @@ public struct ShellTool: MCPTool {
 
         do {
             try process.run()
-            process.waitUntilExit()
 
+            // Read pipe data BEFORE waitUntilExit to avoid deadlock.
+            // If the child writes more than the pipe buffer (~64 KB),
+            // the kernel blocks the child's write() until the pipe is
+            // drained.  Calling waitUntilExit() first means nobody is
+            // draining, so both parent and child block indefinitely.
             let outputData = outputPipe.fileHandleForReading.readDataToEndOfFile()
             let errorData = errorPipe.fileHandleForReading.readDataToEndOfFile()
+            process.waitUntilExit()
 
             let output = String(data: outputData, encoding: .utf8) ?? ""
             let error = String(data: errorData, encoding: .utf8) ?? ""

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/ShellTool.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/ShellTool.swift
@@ -66,13 +66,10 @@ public struct ShellTool: MCPTool {
         do {
             try process.run()
 
-            // Read pipe data BEFORE waitUntilExit to avoid deadlock.
-            // If the child writes more than the pipe buffer (~64 KB),
-            // the kernel blocks the child's write() until the pipe is
-            // drained.  Calling waitUntilExit() first means nobody is
-            // draining, so both parent and child block indefinitely.
-            let outputData = outputPipe.fileHandleForReading.readDataToEndOfFile()
-            let errorData = errorPipe.fileHandleForReading.readDataToEndOfFile()
+            // Either pipe can fill while the other waits for EOF, so drain both concurrently.
+            async let outputRead = outputPipe.fileHandleForReading.readDataToEndOfFile()
+            async let errorRead = errorPipe.fileHandleForReading.readDataToEndOfFile()
+            let (outputData, errorData) = await (outputRead, errorRead)
             process.waitUntilExit()
 
             let output = String(data: outputData, encoding: .utf8) ?? ""

--- a/Core/PeekabooCore/Tests/PeekabooTests/MCP/MCPSpecificToolTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/MCP/MCPSpecificToolTests.swift
@@ -429,6 +429,26 @@ struct MCPSpecificToolTests {
             try MCPAgentTool.validatedMaxSteps(101)
         }
     }
+
+    // MARK: - Shell Tool Tests
+
+    @Test(.timeLimit(.minutes(1)))
+    func `Shell tool does not deadlock on large output`() async throws {
+        let tool = makeTestTool(ShellTool.init)
+
+        // Generate output larger than the macOS pipe buffer (~64 KB)
+        // to trigger a deadlock if waitUntilExit() precedes pipe reads.
+        let result = try await tool.execute(arguments: ToolArguments(raw: [
+            "command": "head -c 131072 /dev/zero | base64",
+        ]))
+
+        #expect(result.isError == false)
+        if case let .text(text, _, _) = result.content.first {
+            #expect(text.count > 100_000)
+        } else {
+            Issue.record("Expected text content from shell output")
+        }
+    }
 }
 
 @MainActor

--- a/Core/PeekabooCore/Tests/PeekabooTests/MCP/MCPSpecificToolTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/MCP/MCPSpecificToolTests.swift
@@ -449,6 +449,22 @@ struct MCPSpecificToolTests {
             Issue.record("Expected text content from shell output")
         }
     }
+
+    @Test(.timeLimit(.minutes(1)))
+    func `Shell tool does not deadlock when both pipes exceed their buffers`() async throws {
+        let tool = makeTestTool(ShellTool.init)
+
+        let result = try await tool.execute(arguments: ToolArguments(raw: [
+            "command": "head -c 131072 /dev/zero >&2; head -c 131072 /dev/zero",
+        ]))
+
+        #expect(result.isError == false)
+        if case let .text(text, _, _) = result.content.first {
+            #expect(text.count == 131_072)
+        } else {
+            Issue.record("Expected text content from shell output")
+        }
+    }
 }
 
 @MainActor


### PR DESCRIPTION
## What Problem This Solves

`ShellTool.execute()` calls `process.waitUntilExit()` before reading from the stdout/stderr pipes. When a child command writes more than the kernel pipe buffer (~64 KB on macOS), `write()` blocks until someone drains the pipe. Because the parent is stuck in `waitUntilExit()`, nobody drains, and both parent and child block indefinitely.

Any shell command producing moderate output (a long `ls`, `cat` of a config file, build logs) can trigger this.

### Call chain

```
ShellTool.execute()
  -> Process.run()
  -> process.waitUntilExit()     // blocks waiting for child exit
  -> outputPipe...readDataToEndOfFile()  // never reached
```

The child is blocked in `write()` waiting for the pipe to drain, while the parent is blocked in `waitUntilExit()` waiting for the child to exit.

### Bug origin

Introduced in 95ecdd42 (2025-11-14) in the initial `PeekabooAgentRuntime` module creation. Present for ~8 months.

## Evidence

### Fix

Move `readDataToEndOfFile()` calls before `process.waitUntilExit()`. This is the standard POSIX pattern: drain the pipe first, then wait for the child to exit.

```diff
 do {
     try process.run()
-    process.waitUntilExit()
-
+    // Read pipe data BEFORE waitUntilExit to avoid deadlock.
     let outputData = outputPipe.fileHandleForReading.readDataToEndOfFile()
     let errorData = errorPipe.fileHandleForReading.readDataToEndOfFile()
+    process.waitUntilExit()
```

### Red-green verification

**Red step** (without fix): `timeout 30 swift test --filter "Shell tool does not deadlock"` -> exit code 124 (killed by timeout; test deadlocked as expected).

**Green step** (with fix): same test -> passed in 0.077 seconds.

### Regression test

The test generates 128 KB of output (`head -c 131072 /dev/zero | base64`), exceeding the ~64 KB pipe buffer. Without the fix, the test deadlocks. With the fix, it completes in under a second.

### Prior art

The same `Process` pipe buffer deadlock pattern has been fixed in other Swift projects:
- [NSEvent/xbox-controller-mapper#83](https://github.com/NSEvent/xbox-controller-mapper/pull/83)
- [diogot/Xproject#49](https://github.com/diogot/Xproject/pull/49)

Python's `subprocess` documentation [explicitly warns](https://docs.python.org/3/library/subprocess.html#subprocess.Popen.wait) against this pattern: "This will deadlock when using stdout=PIPE or stderr=PIPE and the child process generates enough output to a pipe such that it blocks waiting for the OS pipe buffer to accept more data."

## Real behavior proof

**Command tested:** `head -c 131072 /dev/zero | base64` via ShellTool MCP interface

**Environment:** macOS, Swift Testing framework, PeekabooCore test suite

**Proof type:** Red-green regression test

**Red (without fix):** Test deadlocks; killed by 30-second timeout (exit 124)

**Green (with fix):** Test passes in 0.077 seconds; output size >100,000 characters verified

**Reproducibility:** Deterministic. Any command producing >64 KB output triggers the deadlock on the unfixed code.
