### PR TITLE
fix(auth): support OpenAI OAuth vision in Peekaboo

### DIFF
--- a/Apps/Mac/Peekaboo/Core/PeekabooAgent.swift
+++ b/Apps/Mac/Peekaboo/Core/PeekabooAgent.swift
@@ -265,6 +265,8 @@ extension PeekabooAgent {
             "[Tool call: \(toolCall.name)]"
         case let .toolResult(toolResult):
             "[Tool result: \(toolResult.toolCallId)]"
+        case .reasoning:
+            "[Reasoning]"
         }
     }
 
@@ -344,7 +346,7 @@ extension PeekabooAgent {
                 sessionId: self.currentSessionId,
                 model: nil,
                 eventDelegate: eventDelegate)
-        case .image, .toolCall, .toolResult:
+        case .image, .toolCall, .toolResult, .reasoning:
             try await agent.executeTask(
                 description,
                 sessionId: self.currentSessionId,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Refresh Swift package locks, AXorcist, Tachikoma, and the pnpm toolchain to their latest compatible releases.
 
 ### Fixed
+- OpenAI OAuth (ChatGPT login) sessions with an expired access token but valid refresh token are no longer reported unavailable; vision/`--analyze` now routes through the Codex Responses OAuth transport. Thanks @scotthuang for #293.
 - MCP shell commands now support an opt-in timeout that safely terminates the launch-owned process group and bounds pipe draining without changing the legacy unlimited default. Thanks @SebTardif for #298.
 - Publish the Ollama provider guides referenced throughout the generated documentation instead of emitting broken links.
 - Refresh Screen Recording and Event Synthesizing grants in the Mac app's permissions checklist without requiring an app restart.

--- a/Core/PeekabooCore/Sources/PeekabooAutomation/Configuration/ConfigurationManager+Accessors.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAutomation/Configuration/ConfigurationManager+Accessors.swift
@@ -135,15 +135,16 @@ extension ConfigurationManager {
     }
 
     /// Whether any OpenAI authentication material is available — either an API
-    /// key (via `getOpenAIAPIKey()`) or a non-expired OAuth access token (via
-    /// `peekaboo config login openai`). Use this for agent-availability gates;
+    /// key or a usable/refreshable OAuth session created by
+    /// `peekaboo config login openai`. Use this for agent-availability gates;
     /// `getOpenAIAPIKey()` alone deliberately ignores OAuth tokens so they are
-    /// not misclassified as `x-api-key` material.
+    /// not misclassified as API-key material.
     public func hasOpenAIAuth() -> Bool {
         if self.getOpenAIAPIKey()?.isEmpty == false {
             return true
         }
-        return self.validOAuthAccessToken(prefix: "OPENAI") != nil
+        return self.validOAuthAccessToken(prefix: "OPENAI") != nil ||
+            self.hasOAuthRefreshToken(prefix: "OPENAI")
     }
 
     /// OpenAI credential for APIs that accept Bearer tokens but still require

--- a/Core/PeekabooCore/Sources/PeekabooAutomation/Configuration/ConfigurationManager+Credentials.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAutomation/Configuration/ConfigurationManager+Credentials.swift
@@ -89,14 +89,38 @@ extension ConfigurationManager {
     func validOAuthAccessToken(prefix: String) -> String? {
         self.withStateLock {
             self.loadCredentials()
-            guard let token = self.credentials["\(prefix)_ACCESS_TOKEN"] else { return nil }
-            guard let expiryString = self.credentials["\(prefix)_ACCESS_EXPIRES"],
-                  let expiryInt = Int(expiryString) else { return token }
-            let expiryDate = Date(timeIntervalSince1970: TimeInterval(expiryInt))
-            if expiryDate > Date() {
-                return token
+            let tokenKey = "\(prefix)_ACCESS_TOKEN"
+            let expiryKey = "\(prefix)_ACCESS_EXPIRES"
+
+            if let environmentToken = self.environmentValue(for: tokenKey),
+               self.isOAuthAccessTokenValid(
+                   environmentToken,
+                   expiry: self.environmentValue(for: expiryKey),
+               )
+            {
+                return environmentToken
+            }
+            if let storedToken = self.credentials[tokenKey],
+               self.isOAuthAccessTokenValid(storedToken, expiry: self.credentials[expiryKey])
+            {
+                return storedToken
             }
             return nil
+        }
+    }
+
+    private func isOAuthAccessTokenValid(_ token: String, expiry: String?) -> Bool {
+        guard !token.isEmpty else { return false }
+        guard let expiry, let expiryInterval = TimeInterval(expiry) else { return true }
+        return Date(timeIntervalSince1970: expiryInterval) > Date()
+    }
+
+    func hasOAuthRefreshToken(prefix: String) -> Bool {
+        self.withStateLock {
+            self.loadCredentials()
+            let key = "\(prefix)_REFRESH_TOKEN"
+            let token = self.environmentValue(for: key) ?? self.credentials[key]
+            return token?.isEmpty == false
         }
     }
 

--- a/Core/PeekabooCore/Sources/PeekabooAutomation/Configuration/ConfigurationManager+Credentials.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAutomation/Configuration/ConfigurationManager+Credentials.swift
@@ -93,7 +93,7 @@ extension ConfigurationManager {
             let expiryKey = "\(prefix)_ACCESS_EXPIRES"
 
             if let environmentToken = self.environmentValue(for: tokenKey),
-               self.isOAuthAccessTokenValid(
+                self.isOAuthAccessTokenValid(
                    environmentToken,
                    expiry: self.environmentValue(for: expiryKey),
                )
@@ -119,8 +119,10 @@ extension ConfigurationManager {
         self.withStateLock {
             self.loadCredentials()
             let key = "\(prefix)_REFRESH_TOKEN"
-            let token = self.environmentValue(for: key) ?? self.credentials[key]
-            return token?.isEmpty == false
+            if let environmentToken = self.environmentValue(for: key), !environmentToken.isEmpty {
+                return true
+            }
+            return self.credentials[key]?.isEmpty == false
         }
     }
 

--- a/Core/PeekabooCore/Tests/PeekabooTests/ConfigurationAccessorsOAuthTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/ConfigurationAccessorsOAuthTests.swift
@@ -94,6 +94,22 @@ struct ConfigurationAccessorsOAuthTests {
     }
 
     @Test
+    func `Empty environment refresh token does not mask stored OpenAI refresh token`() throws {
+        try withIsolatedConfigurationEnvironment { _ in
+            self.unsetAllOpenAIEnv()
+            self.manager.resetForTesting()
+            try self.manager.saveCredentials([
+                "OPENAI_ACCESS_TOKEN": "expired-openai-oauth-access-token",
+                "OPENAI_REFRESH_TOKEN": "stored-openai-oauth-refresh-token",
+                "OPENAI_ACCESS_EXPIRES": String(Int(Date().addingTimeInterval(-3600).timeIntervalSince1970)),
+            ])
+            setenv("OPENAI_REFRESH_TOKEN", "", 1)
+
+            #expect(self.manager.hasOpenAIAuth())
+        }
+    }
+
+    @Test
     func `OAuth access and expiry stay paired by source`() throws {
         try withIsolatedConfigurationEnvironment { _ in
             self.unsetAllOpenAIEnv()

--- a/Core/PeekabooCore/Tests/PeekabooTests/ConfigurationAccessorsOAuthTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/ConfigurationAccessorsOAuthTests.swift
@@ -79,6 +79,36 @@ struct ConfigurationAccessorsOAuthTests {
     }
 
     @Test
+    func `OpenAI availability accepts an expired access token with a refresh token`() throws {
+        try withIsolatedConfigurationEnvironment { _ in
+            self.unsetAllOpenAIEnv()
+            self.manager.resetForTesting()
+            try self.manager.saveCredentials([
+                "OPENAI_ACCESS_TOKEN": "expired-openai-oauth-access-token",
+                "OPENAI_REFRESH_TOKEN": "openai-oauth-refresh-token",
+                "OPENAI_ACCESS_EXPIRES": String(Int(Date().addingTimeInterval(-3600).timeIntervalSince1970)),
+            ])
+
+            #expect(self.manager.hasOpenAIAuth())
+        }
+    }
+
+    @Test
+    func `OAuth access and expiry stay paired by source`() throws {
+        try withIsolatedConfigurationEnvironment { _ in
+            self.unsetAllOpenAIEnv()
+            self.manager.resetForTesting()
+            try self.manager.saveCredentials([
+                "OPENAI_ACCESS_EXPIRES": String(Int(Date().addingTimeInterval(-3600).timeIntervalSince1970)),
+            ])
+            setenv("OPENAI_ACCESS_TOKEN", "valid-environment-access-token", 1)
+
+            #expect(self.manager.getOpenAITranscriptionCredential() == "valid-environment-access-token")
+            #expect(self.manager.hasOpenAIAuth())
+        }
+    }
+
+    @Test
     func `getOpenAITranscriptionCredential returns OAuth access token when no API key is stored`() throws {
         try withIsolatedConfigurationEnvironment { _ in
             self.unsetAllOpenAIEnv()

--- a/docs/oauth.md
+++ b/docs/oauth.md
@@ -13,7 +13,7 @@ Peekaboo supports OAuth for two providers:
 
 These flows avoid storing API keys and instead keep refresh/access tokens in `~/.peekaboo/credentials` (chmod 600).
 
-> Peekaboo shares the same credential layout as Tachikoma. Hosts can swap the profile directory (`TachikomaConfiguration.profileDirectoryName`) but **never copy environment keys into the file**; only explicit `config add`/`config login` writes.
+> Peekaboo shares the same credential layout as Tachikoma. Hosts can swap the profile directory (`TachikomaConfiguration.profileDirectoryName`). API keys from the environment are never copied into the file. If an OAuth session supplied through the environment expires, Peekaboo persists the refreshed access token and rotated refresh token so later requests continue the same refresh chain instead of reusing stale credentials.
 
 ## What happens during login
 1. Generate PKCE values and open the provider’s authorize URL in the browser (also printed for headless use).
@@ -24,23 +24,27 @@ These flows avoid storing API keys and instead keep refresh/access tokens in `~/
 4. No API key is written for OAuth flows.
 
 ## How requests are sent
+
 - Providers resolve OAuth tokens and API keys through the shared Tachikoma credential manager. If the access token is expired, Peekaboo refreshes once per request and updates the credentials file.
+- OpenAI OAuth requests use the ChatGPT Codex Responses backend and include the ChatGPT account identifier from the access token. Text and image inputs are supported, including `see --analyze`, `image --analyze`, and agent vision calls.
 - Anthropic requests include the beta header used for Claude Max: `anthropic-beta: oauth-2025-04-20,claude-code-20250219,interleaved-thinking-2025-05-14,fine-grained-tool-streaming-2025-05-14`.
-- If OAuth tokens are absent but an API key exists, the provider falls back to the API-key path.
-- OpenAI/Codex OAuth tokens may still be rejected by OpenAI API endpoints if the issued token lacks platform API scopes such as model or Responses access. In that case, use `peekaboo config add openai <api-key>` / `OPENAI_API_KEY` for `see --analyze`, `image --analyze`, and agent runs until the OAuth client is granted the required scopes.
+- An explicit OpenAI API key remains higher priority and uses the public OpenAI API rather than the Codex OAuth transport.
 
 ## Validating connectivity
+
 - `peekaboo config show --timeout 30` pings each configured provider and reports status (`ready (validated)`, `stored (validation failed: <reason>)`, `missing`).
 - `peekaboo config add <provider> <secret>` validates immediately; failures are stored but warned.
 
 ## Revoking access
+
 - **OpenAI/Codex**: revoke from your OpenAI account security page; then delete the stored tokens (`peekaboo config edit` or remove the keys from `~/.peekaboo/credentials`).
 - **Anthropic**: revoke from your Claude account; remove the stored tokens the same way.
 
 ## Headless / CI
+
 - If the browser cannot open, the CLI still prints the authorize URL; paste the resulting code back. Access/refresh storage and refresh logic are identical.
 
 ## Troubleshooting
+
 - If validation fails after login, run `peekaboo config show --timeout 10 --verbose` to see the provider error.
-- OpenAI errors mentioning missing scopes are server-side OAuth scope failures, not local credential loading failures. Configure an API key for API-backed OpenAI features.
 - Stale access tokens are refreshed automatically; if refresh fails, rerun `peekaboo config login <provider>`.

--- a/docs/oauth.md
+++ b/docs/oauth.md
@@ -13,7 +13,7 @@ Peekaboo supports OAuth for two providers:
 
 These flows avoid storing API keys and instead keep refresh/access tokens in `~/.peekaboo/credentials` (chmod 600).
 
-> Peekaboo shares the same credential layout as Tachikoma. Hosts can swap the profile directory (`TachikomaConfiguration.profileDirectoryName`). API keys from the environment are never copied into the file. If an OAuth session supplied through the environment expires, Peekaboo persists the refreshed access token and rotated refresh token so later requests continue the same refresh chain instead of reusing stale credentials.
+> Peekaboo shares the same credential layout as Tachikoma. Hosts can swap the profile directory (`TachikomaConfiguration.profileDirectoryName`). Credentials supplied through the environment are never copied into the file. Refreshed environment OAuth tokens remain in memory for the current process; use `peekaboo config login` when the rotated refresh chain must persist across launches.
 
 ## What happens during login
 1. Generate PKCE values and open the provider’s authorize URL in the browser (also printed for headless use).
@@ -25,7 +25,7 @@ These flows avoid storing API keys and instead keep refresh/access tokens in `~/
 
 ## How requests are sent
 
-- Providers resolve OAuth tokens and API keys through the shared Tachikoma credential manager. If the access token is expired, Peekaboo refreshes once per request and updates the credentials file.
+- Providers resolve OAuth tokens and API keys through the shared Tachikoma credential manager. If a stored access token is expired, Peekaboo refreshes it and atomically updates the credentials file. Environment-supplied OAuth sessions refresh only in memory.
 - OpenAI OAuth requests use the ChatGPT Codex Responses backend and include the ChatGPT account identifier from the access token. Text and image inputs are supported, including `see --analyze`, `image --analyze`, and agent vision calls.
 - Anthropic requests include the beta header used for Claude Max: `anthropic-beta: oauth-2025-04-20,claude-code-20250219,interleaved-thinking-2025-05-14,fine-grained-tool-streaming-2025-05-14`.
 - An explicit OpenAI API key remains higher priority and uses the public OpenAI API rather than the Codex OAuth transport.


### PR DESCRIPTION
## What problem this solves

Peekaboo already converts captures into provider-neutral image messages, but its OpenAI availability gate only accepted a currently valid OAuth access token. Once that token expired, Peekaboo reported OpenAI as unavailable and stopped before Tachikoma had a chance to use the refresh token.

### Previous call chain

```text
expired OpenAI access token + valid refresh token
  -> ConfigurationManager.hasOpenAIAuth()
  -> validOAuthAccessToken() == nil
  -> OpenAI reported unavailable
  -> Tachikoma refresh/vision path never reached
```

### New call chain

```text
expired OpenAI access token + valid refresh token
  -> ConfigurationManager.hasOpenAIAuth() == true
  -> Tachikoma refreshes the OAuth session
     - stored login: atomically persists the rotated chain
     - environment source: caches the rotated chain only in this process
  -> Codex Responses receives text + image
  -> visual answer returned
```

## Implementation

- treat a refreshable OpenAI OAuth session as available when the current access token has expired
- keep OAuth access tokens and expiry timestamps paired by credential source, rather than mixing environment and stored values
- bump Tachikoma to the Codex OAuth Responses vision implementation and its environment-credential boundary fix
- document OpenAI OAuth support for `see --analyze`, `image --analyze`, and agent vision
- document that environment OAuth refreshes stay process-local while `peekaboo config login` persists refresh rotation

## Evidence

### Red-green availability proof

The deterministic setup stores:

```text
OPENAI_ACCESS_TOKEN=<expired token>
OPENAI_ACCESS_EXPIRES=<one hour in the past>
OPENAI_REFRESH_TOKEN=<present>
```

**Red step:** the PR test was run with only the new refresh-token clause temporarily removed, reproducing the previous implementation.

```swift
return self.validOAuthAccessToken(prefix: "OPENAI") != nil
```

Observed result:

```text
Expectation failed: manager.hasOpenAIAuth()
Test failed after 0.008 seconds
```

**Green step:** restore the PR implementation:

```swift
return self.validOAuthAccessToken(prefix: "OPENAI") != nil ||
    self.hasOAuthRefreshToken(prefix: "OPENAI")
```

Observed result:

```text
Test passed after 0.007 seconds
```

Only that availability condition changed between the red and green runs. Both repositories were restored to clean state afterward.

Reproduction command:

```bash
/usr/bin/arch -arm64 swift test \
  --package-path Core/PeekabooCore \
  -Xswiftc -DPEEKABOO_SKIP_AUTOMATION \
  --filter "OpenAI availability accepts an expired access token with a refresh token"
```

### Real OAuth vision proof from the pinned Tachikoma dependency

[openclaw/Tachikoma#40](https://github.com/openclaw/Tachikoma/pull/40) includes protocol-level red/green evidence using the same valid ChatGPT OAuth token:

```text
Old public endpoint -> HTTP 401, missing api.responses.write scope
New Codex endpoint  -> deterministic 16x16 red PNG -> GPT-5.6 Sol returned "red"
Elapsed             -> 6.252 seconds
SSE completion      -> status=completed, total_tokens=55
```

The image is embedded in the live integration test; no host desktop was captured.

### Environment credential-boundary proof

The pinned Tachikoma commit `d4cd49f` adds direct tests proving that an environment-supplied OAuth refresh does not write to `~/.peekaboo/credentials`:

```text
cache refreshed environment credentials without persisting      passed
continue an environment refresh chain in memory                 passed
environment value changes invalidate the in-memory chain         passed
ignore-environment changes invalidate the in-memory chain        passed
refresh environment account without overwriting stored account  passed
```

The tests assert an empty credential store for environment-only sessions, unchanged stored values when a separate stored account exists, correct use of rotated refresh tokens, and cache invalidation when the source changes. Stored-login refreshes retain their separate atomic-persistence test.

## Dependency

> [!IMPORTANT]
> Depends on [openclaw/Tachikoma#40](https://github.com/openclaw/Tachikoma/pull/40). This PR must merge only after that dependency lands; then the Tachikoma gitlink must be repinned to the final upstream merge commit before Peekaboo merges.

## User impact

After the Tachikoma dependency lands, users authenticated through `peekaboo config login openai` can use OpenAI OAuth for image analysis and agent vision without configuring a separate OpenAI API key. Existing explicit API-key configurations retain priority. Hosts that inject OAuth through environment variables keep those credentials ephemeral and must provide fresh values after a process restart.

## Validation

- deterministic availability red/green: failed in 0.008 seconds before the clause, passed in 0.007 seconds with the fix
- `ConfigurationAccessorsOAuthTests` — 14 tests passed
- pinned Tachikoma `AuthManagerTests` — 19 tests passed
- pinned Tachikoma `OpenAIResponsesProviderTests` — 30 tests passed
- pinned Tachikoma full suite — 842 of 843 tests passed; the only failure is an unrelated existing real-network OpenAI audio test that timed out after 60 seconds
- previous Peekaboo head passed all five macOS CI jobs; the new submodule-pointer/docs head is tracked in [the current CI run](https://github.com/openclaw/Peekaboo/actions/runs/30263503589)
- `pnpm run lint:docs` — passed
- `git diff --check`
