### PR TITLE
fix(cli): explain every denied bridge permission and its grant target

### DIFF
--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Core/BridgeCommand+Models.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Core/BridgeCommand+Models.swift
@@ -9,12 +9,22 @@ struct BridgeStatusReport: Codable {
     let candidates: [BridgeCandidateReport]
     let client: BridgeClientReport
 
-    var bridgeScreenRecordingHint: String? {
-        guard let candidate = self.candidates.first(where: { $0.screenRecordingDenied }) else { return nil }
+    /// The candidate summary prints `perm: SR=… AX=… AS=… ES=…`, so a denial is visible but its remedy
+    /// is not: the grant belongs to the host app behind the socket, never the CLI or terminal. Report
+    /// every denied permission, otherwise an AX/ES denial reads as unexplained.
+    var bridgeDeniedPermissionsHint: String? {
+        guard let candidate = self.candidates.first(where: { !$0.deniedPermissionNames.isEmpty }) else {
+            return nil
+        }
         let hostKind = candidate.hostKind ?? "Bridge host"
-        return "Hint: \(hostKind) at \(candidate.socketPath) does not have Screen Recording. Grant it to " +
-            "the host app, or run capture commands with --no-remote --capture-engine cg when the caller " +
-            "process already has permission."
+        let denied = candidate.deniedPermissionNames.joined(separator: ", ")
+        var hint = "Hint: \(hostKind) at \(candidate.socketPath) does not have \(denied). Grant it to " +
+            "that host app — granting the CLI or your terminal will not change this status."
+        if candidate.deniedPermissionNames.contains("Screen Recording") {
+            hint += " For capture, --no-remote --capture-engine cg works when the caller process already " +
+                "has permission."
+        }
+        return hint
     }
 }
 
@@ -49,11 +59,16 @@ struct BridgeCandidateReport: Codable {
         return nil
     }
 
-    var screenRecordingDenied: Bool {
-        if case let .success(handshake) = self.result {
-            return handshake.permissions?.screenRecording == false
+    /// Names match the `peekaboo permissions` labels so both surfaces describe the same grant.
+    var deniedPermissionNames: [String] {
+        guard case let .success(handshake) = self.result, let status = handshake.permissions else {
+            return []
         }
-        return false
+        var denied: [String] = []
+        if !status.screenRecording { denied.append("Screen Recording") }
+        if !status.accessibility { denied.append("Accessibility") }
+        if !status.postEvent { denied.append("Event Synthesizing") }
+        return denied
     }
 
     var humanSummary: String {

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Core/BridgeCommand+Models.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Core/BridgeCommand+Models.swift
@@ -59,7 +59,9 @@ struct BridgeCandidateReport: Codable {
         return nil
     }
 
-    /// Names match the `peekaboo permissions` labels so both surfaces describe the same grant.
+    /// Covers every permission `humanSummary` reports as SR/AX/AS/ES, so no denial the summary shows
+    /// can appear without a matching grant hint. Names match the `peekaboo permissions` labels where
+    /// they exist; AppleScript has no entry there and uses its System Settings name.
     var deniedPermissionNames: [String] {
         guard case let .success(handshake) = self.result, let status = handshake.permissions else {
             return []
@@ -67,6 +69,7 @@ struct BridgeCandidateReport: Codable {
         var denied: [String] = []
         if !status.screenRecording { denied.append("Screen Recording") }
         if !status.accessibility { denied.append("Accessibility") }
+        if !status.appleScript { denied.append("Automation (AppleScript)") }
         if !status.postEvent { denied.append("Event Synthesizing") }
         return denied
     }

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Core/BridgeCommand+Models.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Core/BridgeCommand+Models.swift
@@ -9,22 +9,23 @@ struct BridgeStatusReport: Codable {
     let candidates: [BridgeCandidateReport]
     let client: BridgeClientReport
 
-    /// The candidate summary prints `perm: SR=… AX=… AS=… ES=…`, so a denial is visible but its remedy
-    /// is not: the grant belongs to the host app behind the socket, never the CLI or terminal. Report
-    /// every denied permission, otherwise an AX/ES denial reads as unexplained.
-    var bridgeDeniedPermissionsHint: String? {
-        guard let candidate = self.candidates.first(where: { !$0.deniedPermissionNames.isEmpty }) else {
-            return nil
+    /// Every candidate summary prints `perm: SR=… AX=… AS=… ES=…`, so a denial is visible but its remedy
+    /// is not: the grant belongs to the host app behind that socket, never the CLI or terminal. One hint
+    /// per denied candidate — a single first-match hint leaves the other probed hosts unexplained.
+    var bridgeDeniedPermissionsHints: [String] {
+        self.candidates.compactMap { candidate in
+            let denied = candidate.deniedPermissionNames
+            guard !denied.isEmpty else { return nil }
+            let hostKind = candidate.hostKind ?? "Bridge host"
+            var hint = "Hint: \(hostKind) at \(candidate.socketPath) does not have " +
+                "\(denied.joined(separator: ", ")). Grant it to that host app — granting the CLI or your " +
+                "terminal will not change this status."
+            if denied.contains("Screen Recording") {
+                hint += " For capture, --no-remote --capture-engine cg works when the caller process " +
+                    "already has permission."
+            }
+            return hint
         }
-        let hostKind = candidate.hostKind ?? "Bridge host"
-        let denied = candidate.deniedPermissionNames.joined(separator: ", ")
-        var hint = "Hint: \(hostKind) at \(candidate.socketPath) does not have \(denied). Grant it to " +
-            "that host app — granting the CLI or your terminal will not change this status."
-        if candidate.deniedPermissionNames.contains("Screen Recording") {
-            hint += " For capture, --no-remote --capture-engine cg works when the caller process already " +
-                "has permission."
-        }
-        return hint
     }
 }
 
@@ -67,10 +68,18 @@ struct BridgeCandidateReport: Codable {
             return []
         }
         var denied: [String] = []
-        if !status.screenRecording { denied.append("Screen Recording") }
-        if !status.accessibility { denied.append("Accessibility") }
-        if !status.appleScript { denied.append("Automation (AppleScript)") }
-        if !status.postEvent { denied.append("Event Synthesizing") }
+        if !status.screenRecording {
+            denied.append("Screen Recording")
+        }
+        if !status.accessibility {
+            denied.append("Accessibility")
+        }
+        if !status.appleScript {
+            denied.append("Automation (AppleScript)")
+        }
+        if !status.postEvent {
+            denied.append("Event Synthesizing")
+        }
         return denied
     }
 
@@ -155,8 +164,7 @@ struct BridgeCandidateErrorReport: Codable {
             code: envelope.code.rawValue,
             message: envelope.message,
             details: envelope.details,
-            hint: hint
-        )
+            hint: hint)
     }
 
     static func other(_ error: any Error) -> BridgeCandidateErrorReport {
@@ -165,8 +173,7 @@ struct BridgeCandidateErrorReport: Codable {
             code: nil,
             message: error.localizedDescription,
             details: String(describing: error),
-            hint: nil
-        )
+            hint: nil)
     }
 
     var humanSummary: String {

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Core/BridgeCommand.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Core/BridgeCommand.swift
@@ -20,11 +20,10 @@ struct BridgeCommand: ParsableCommand {
           peekaboo bridge status --no-remote
         """,
         subcommands: [
-            StatusSubcommand.self
+            StatusSubcommand.self,
         ],
         defaultSubcommand: StatusSubcommand.self,
-        showHelpOnEmptyInvocation: true
-    )
+        showHelpOnEmptyInvocation: true)
 }
 
 extension BridgeCommand {
@@ -34,8 +33,7 @@ extension BridgeCommand {
             MainActorCommandDescription.describe {
                 CommandDescription(
                     commandName: "status",
-                    abstract: "Report which Bridge host would be used"
-                )
+                    abstract: "Report which Bridge host would be used")
             }
         }
 
@@ -91,9 +89,12 @@ extension BridgeCommand {
             print("===============")
             print("")
             print("Selected: \(report.selected.humanSummary)")
-            if let hint = report.bridgeDeniedPermissionsHint {
+            let deniedHints = report.bridgeDeniedPermissionsHints
+            if !deniedHints.isEmpty {
                 print("")
-                print(hint)
+                for hint in deniedHints {
+                    print(hint)
+                }
             }
 
             if report.remoteSkipped {

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Core/BridgeCommand.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Core/BridgeCommand.swift
@@ -91,7 +91,7 @@ extension BridgeCommand {
             print("===============")
             print("")
             print("Selected: \(report.selected.humanSummary)")
-            if let hint = report.bridgeScreenRecordingHint {
+            if let hint = report.bridgeDeniedPermissionsHint {
                 print("")
                 print(hint)
             }

--- a/Apps/CLI/Sources/PeekabooCLI/Commands/Core/PermissionsCommand.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Commands/Core/PermissionsCommand.swift
@@ -91,7 +91,7 @@ extension PermissionsCommand {
                 let sourceLabel = response.source == "bridge" ? "Peekaboo Bridge" : "local runtime"
                 print("Source: \(sourceLabel)")
                 response.permissions.forEach { print(PermissionHelpers.formatPermissionStatus($0)) }
-                if let hint = PermissionHelpers.bridgeScreenRecordingHint(for: response) {
+                if let hint = PermissionHelpers.bridgeDeniedPermissionsHint(for: response) {
                     print("")
                     print(hint)
                 }

--- a/Apps/CLI/Sources/PeekabooCLI/Helpers/PermissionHelpers.swift
+++ b/Apps/CLI/Sources/PeekabooCLI/Helpers/PermissionHelpers.swift
@@ -302,16 +302,24 @@ enum PermissionHelpers {
         return "\(permission.name) (\(requirement)): \(status)"
     }
 
-    static func bridgeScreenRecordingHint(for response: PermissionStatusResponse) -> String? {
-        guard response.source == "bridge",
-              response.permissions.contains(where: { permission in
-                  permission.name == "Screen Recording" && !permission.isGranted
-              })
-        else { return nil }
+    /// Bridge-sourced denials are the most common support confusion: the TCC grant must live on the
+    /// host app that answered, not on the CLI or the calling terminal. `grantInstructions` only names
+    /// the System Settings pane, so without this hint a denial sends people to grant the wrong bundle
+    /// and the status never changes. Covers every denied permission, not just Screen Recording.
+    static func bridgeDeniedPermissionsHint(for response: PermissionStatusResponse) -> String? {
+        guard response.source == "bridge" else { return nil }
+        let denied = response.permissions.filter { !$0.isGranted }
+        guard !denied.isEmpty else { return nil }
 
-        return "Hint: status came from the selected Peekaboo Bridge host. Grant Screen Recording to that " +
-            "host app, or run capture commands with --no-remote --capture-engine cg when the caller " +
-            "process already has permission."
+        var hint = "Hint: status came from the selected Peekaboo Bridge host. Grant " +
+            "\(denied.map(\.name).joined(separator: ", ")) to that host app — granting the CLI or your " +
+            "terminal will not change this status. Run peekaboo bridge status to see which host answered, " +
+            "or pass --no-remote to use the local runtime instead."
+        if denied.contains(where: { $0.name == "Screen Recording" }) {
+            hint += " For capture, --no-remote --capture-engine cg works when the caller process already " +
+                "has permission."
+        }
+        return hint
     }
 
     /// Format permissions for help display with dynamic status

--- a/Apps/CLI/Tests/CoreCLITests/BridgeStatusReportHintTests.swift
+++ b/Apps/CLI/Tests/CoreCLITests/BridgeStatusReportHintTests.swift
@@ -1,0 +1,84 @@
+import PeekabooBridge
+import PeekabooCore
+import Testing
+@testable import PeekabooCLI
+
+struct BridgeStatusReportHintTests {
+    private func candidate(
+        socketPath: String,
+        hostKind: PeekabooBridgeHostKind,
+        permissions: PermissionsStatus) -> BridgeCandidateReport
+    {
+        let handshake = PeekabooBridgeHandshakeResponse(
+            negotiatedVersion: PeekabooBridgeProtocolVersion(major: 1, minor: 1),
+            hostKind: hostKind,
+            build: nil,
+            supportedOperations: [],
+            permissions: permissions)
+        return BridgeCandidateReport(
+            socketPath: socketPath,
+            result: .success(BridgeHandshakeReport(from: handshake)))
+    }
+
+    private func report(candidates: [BridgeCandidateReport]) -> BridgeStatusReport {
+        BridgeStatusReport(
+            remoteSkipped: false,
+            remoteSkipReason: nil,
+            selected: .local(),
+            candidates: candidates,
+            client: BridgeClientReport(identity: PeekabooBridgeClientIdentity(
+                bundleIdentifier: nil,
+                teamIdentifier: nil,
+                processIdentifier: 1,
+                hostname: nil)))
+    }
+
+    @Test
+    func `every denied candidate gets its own grant hint`() {
+        let status = self.report(candidates: [
+            self.candidate(
+                socketPath: "/tmp/gui.sock",
+                hostKind: .gui,
+                permissions: PermissionsStatus(
+                    screenRecording: true,
+                    accessibility: true,
+                    appleScript: true,
+                    postEvent: false)),
+            self.candidate(
+                socketPath: "/tmp/helper.sock",
+                hostKind: .helper,
+                permissions: PermissionsStatus(
+                    screenRecording: false,
+                    accessibility: true,
+                    appleScript: true,
+                    postEvent: true)),
+        ])
+
+        // `bridge status` prints a perm line per candidate, so a first-match-only hint would leave the
+        // second host's denial visible but unexplained.
+        let hints = status.bridgeDeniedPermissionsHints
+        #expect(hints.count == 2)
+        #expect(hints[0].contains("/tmp/gui.sock"))
+        #expect(hints[0].contains("Event Synthesizing"))
+        #expect(hints[0].contains("--capture-engine cg") == false)
+        #expect(hints[1].contains("/tmp/helper.sock"))
+        #expect(hints[1].contains("Screen Recording"))
+        #expect(hints[1].contains("--capture-engine cg"))
+    }
+
+    @Test
+    func `fully granted candidates produce no hints`() {
+        let status = self.report(candidates: [
+            self.candidate(
+                socketPath: "/tmp/gui.sock",
+                hostKind: .gui,
+                permissions: PermissionsStatus(
+                    screenRecording: true,
+                    accessibility: true,
+                    appleScript: true,
+                    postEvent: true)),
+        ])
+
+        #expect(status.bridgeDeniedPermissionsHints.isEmpty)
+    }
+}

--- a/Apps/CLI/Tests/CoreCLITests/PermissionHelpersTests.swift
+++ b/Apps/CLI/Tests/CoreCLITests/PermissionHelpersTests.swift
@@ -97,10 +97,58 @@ struct PermissionHelpersTests {
             ]
         )
 
-        let hint = PermissionHelpers.bridgeScreenRecordingHint(for: response)
+        let hint = PermissionHelpers.bridgeDeniedPermissionsHint(for: response)
 
         #expect(hint?.contains("selected Peekaboo Bridge host") == true)
         #expect(hint?.contains("--no-remote --capture-engine cg") == true)
+    }
+
+    @Test
+    func `bridge hint explains remote event synthesizing denial`() {
+        let response = PermissionHelpers.PermissionStatusResponse(
+            source: "bridge",
+            permissions: [
+                PermissionHelpers.PermissionInfo(
+                    name: "Screen Recording",
+                    isRequired: true,
+                    isGranted: true,
+                    grantInstructions: "System Settings > Privacy & Security > Screen Recording"
+                ),
+                PermissionHelpers.PermissionInfo(
+                    name: "Event Synthesizing",
+                    isRequired: false,
+                    isGranted: false,
+                    grantInstructions: "System Settings > Privacy & Security > Accessibility"
+                ),
+            ]
+        )
+
+        let hint = PermissionHelpers.bridgeDeniedPermissionsHint(for: response)
+
+        // The whole point: a bridge-sourced denial must say the grant belongs to the host app,
+        // because granting the CLI or the terminal leaves the status unchanged.
+        #expect(hint?.contains("Event Synthesizing") == true)
+        #expect(hint?.contains("host app") == true)
+        #expect(hint?.contains("--no-remote") == true)
+        // Capture-only advice must not leak into a non-capture denial.
+        #expect(hint?.contains("--capture-engine cg") == false)
+    }
+
+    @Test
+    func `bridge hint stays quiet when every permission is granted`() {
+        let response = PermissionHelpers.PermissionStatusResponse(
+            source: "bridge",
+            permissions: [
+                PermissionHelpers.PermissionInfo(
+                    name: "Screen Recording",
+                    isRequired: true,
+                    isGranted: true,
+                    grantInstructions: "System Settings > Privacy & Security > Screen Recording"
+                ),
+            ]
+        )
+
+        #expect(PermissionHelpers.bridgeDeniedPermissionsHint(for: response) == nil)
     }
 
     @Test
@@ -117,6 +165,6 @@ struct PermissionHelpersTests {
             ]
         )
 
-        #expect(PermissionHelpers.bridgeScreenRecordingHint(for: response) == nil)
+        #expect(PermissionHelpers.bridgeDeniedPermissionsHint(for: response) == nil)
     }
 }


### PR DESCRIPTION
## Intent

When permission status comes from a Bridge host, a denial never said *which app* has to hold the TCC grant, and the only hint that existed fired for Screen Recording alone. So an Accessibility, Event Synthesizing, or AppleScript denial printed `Not Granted` plus a System Settings path and nothing else — and the natural reading is "grant it to the thing I just ran", i.e. the CLI or the terminal. That grant changes nothing, because the answering process is `/Applications/Peekaboo.app`.

I hit this for real: `peekaboo permissions` reported Event Synthesizing denied while the terminal already had it, `peekaboo type` kept failing, and the output gave no way to tell that the status belonged to a different bundle.

## Changes

- `PermissionHelpers.bridgeScreenRecordingHint` → `bridgeDeniedPermissionsHint`: fires for **any** denied permission when `source == "bridge"`, names every denied permission, says the grant belongs to the host app, and points at `peekaboo bridge status` (which host answered) and `--no-remote` (use the local runtime instead). The capture-only `--no-remote --capture-engine cg` advice is now appended only when Screen Recording is among the denials, instead of being the whole hint.
- `BridgeStatusReport.bridgeScreenRecordingHint` → `bridgeDeniedPermissionsHints: [String]`: `bridge status` prints a `perm: SR=… AX=… AS=… ES=…` line per probed candidate, so it now emits one grant hint per denied candidate. A single first-match hint left every other probed host's denial visible but unexplained.
- `BridgeCandidateReport.deniedPermissionNames` covers all four states the summary displays, including AppleScript, so no denial the summary shows can appear without a matching remedy.

No behavior change when `source == "local"` (the terminal's own grants are already the right target) or when everything is granted — both stay silent.

## Tests

```
swift build --package-path Apps/CLI
# Build complete!

swift test --package-path Apps/CLI --filter "BridgeStatusReportHintTests|PermissionHelpersTests"
# Test run with 10 tests in 2 suites passed after 0.043 seconds.
```

New coverage: multi-candidate hints (each denied host gets its own line, capture advice only on the Screen-Recording one), a non-capture denial asserting the capture flag does *not* leak into it, an all-granted candidate producing no hints, and the existing local-source silence case.

Both hint branches are unit-tested rather than shown live because this machine now has all three permissions granted on the bridge host, so neither hint can fire against the real socket.

Formatted with `swiftformat --config .swiftformat` and linted with `swiftlint` (clean) on the touched files. No doc updates — `docs/permissions.md` does not mention the bridge hint text.
