### PR TITLE
docs: document SwiftLint and SwiftFormat prerequisites

### DIFF
--- a/docs/building.md
+++ b/docs/building.md
@@ -13,6 +13,7 @@ read_when:
 - Swift 6.2+ toolchain (Xcode 26.x or newer recommended)
 - Node.js 22+ (Corepack-enabled) — only needed for pnpm helper scripts; core Swift builds do not require Node.
 - pnpm (`corepack enable pnpm`)
+- SwiftLint and SwiftFormat for the repository validation helpers (`brew install swiftlint swiftformat`)
 
 See [platform-support.md](platform-support.md) for the support matrix across released binaries, apps,
 Swift packages, source builds, and pnpm helper scripts.
@@ -51,4 +52,3 @@ pnpm run prepare-release
 # Generate artifacts / publish
 ./scripts/release-binaries.sh --create-github-release --publish-npm
 ```
-


### PR DESCRIPTION
Closes #294

## What Problem This Solves

Fixes an issue where users building Peekaboo from source could miss that the repository validation helpers require SwiftLint and SwiftFormat.

## Why This Change Was Made

The build guide already lists the source-build prerequisites, so this adds the missing formatter and linter tools there with the Homebrew install command. This is intentionally documentation-only and does not change build scripts, lint configuration, or release behavior.

## User Impact

Developers following the source-build guide can install the expected validation tools before running the pnpm helper scripts, avoiding avoidable setup failures.

## Evidence

- `node scripts/docs-lint.mjs`
  - Result: `docs-lint: ok`
- `git diff --check`
  - Result: passed.
- GitHub reports the pushed commit signature as verified.

Disclosure: AI was used to understand the codebase and review the fix.
