### PR TITLE
fix(docs): publish Ollama provider guides

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ### Fixed
 - MCP shell commands now support an opt-in timeout that safely terminates the launch-owned process group and bounds pipe draining without changing the legacy unlimited default. Thanks @SebTardif for #298.
+- Publish the Ollama provider guides referenced throughout the generated documentation instead of emitting broken links.
 
 ## [3.9.8] - 2026-07-23
 

--- a/scripts/build-docs-site.mjs
+++ b/scripts/build-docs-site.mjs
@@ -152,7 +152,10 @@ const allPages = allMarkdown(docsDir).map((file) => {
   };
 });
 
-const pages = allPages.filter((page) => !buildExcludes.some((re) => re.test(page.rel)));
+const publicProviderPages = new Set(["providers/ollama.md", "providers/ollama-models.md"]);
+const pages = allPages.filter(
+  (page) => publicProviderPages.has(page.rel) || !buildExcludes.some((re) => re.test(page.rel)),
+);
 const pageMap = new Map(pages.map((page) => [page.rel, page]));
 
 const nav = sections


### PR DESCRIPTION
## Summary

- publish the two user-facing Ollama provider guides that the generated site already links to
- keep the older provider planning/status pages excluded from the public docs site
- add a 3.9.9 changelog entry

## Root cause

The documentation added links to the Ollama guides after the site generator's broad providers-directory exclusion was introduced. Markdown source validation therefore passed, but the generated site omitted both destination pages and reported four broken links.

## Proof

- `node scripts/docs-lint.mjs` — pass
- `node scripts/build-docs-site.mjs` — pass with no broken-link warnings
- generated `providers/ollama.html` and `providers/ollama-models.html` — present
- served site checks — agent, configuration, providers, Ollama, and Ollama-model pages all returned HTTP 200
- fragment checks — `endpoint-selection` and `privacy-boundary` present
- negative control — an unknown provider-guide URL returned HTTP 404
- Codex autoreview — clean, no actionable findings
- source-blind behavior contract — 5/5 clauses passed

## Risk

Low. The site generator exposes exactly two existing, maintainer-authored Ollama documents; all other provider-directory exclusions remain intact.
