### PR TITLE
fix(dock): bound Process waits so wedged dock helpers cannot hang

### DIFF
--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/DockService+Actions.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/DockService+Actions.swift
@@ -127,7 +127,7 @@ extension DockService {
         process.standardError = errorPipe
 
         try process.run()
-        try waitForProcessExit(process, timeoutSeconds: 15)
+        try DockService.waitForProcessExit(process, timeoutSeconds: 15)
 
         if process.terminationStatus != 0 {
             let errorData = errorPipe.fileHandleForReading.readDataToEndOfFile()
@@ -166,7 +166,7 @@ extension DockService {
         task.standardError = Pipe()
 
         try task.run()
-        try waitForProcessExit(task, timeoutSeconds: 30)
+        try DockService.waitForProcessExit(task, timeoutSeconds: 30)
 
         let data = pipe.fileHandleForReading.readDataToEndOfFile()
         let result = String(data: data, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/DockService+Actions.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/DockService+Actions.swift
@@ -127,7 +127,7 @@ extension DockService {
         process.standardError = errorPipe
 
         try process.run()
-        process.waitUntilExit()
+        try waitForProcessExit(process, timeoutSeconds: 15)
 
         if process.terminationStatus != 0 {
             let errorData = errorPipe.fileHandleForReading.readDataToEndOfFile()
@@ -166,7 +166,7 @@ extension DockService {
         task.standardError = Pipe()
 
         try task.run()
-        task.waitUntilExit()
+        try waitForProcessExit(task, timeoutSeconds: 30)
 
         let data = pipe.fileHandleForReading.readDataToEndOfFile()
         let result = String(data: data, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/DockService+Process.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/DockService+Process.swift
@@ -1,0 +1,49 @@
+import Foundation
+import PeekabooFoundation
+
+extension DockService {
+    /// Wait for a launched `Process` with a hard deadline.
+    ///
+    /// Foundation's `waitUntilExit()` can block forever if the child wedges. Dock
+    /// commands (`defaults`, `killall`, `osascript`) should never hang the CLI/MCP.
+    nonisolated static func waitForProcessExit(
+        _ process: Process,
+        timeoutSeconds: TimeInterval = 15) throws
+    {
+        let group = DispatchGroup()
+        group.enter()
+        let lock = NSLock()
+        var left = false
+        let leaveOnce: () -> Void = {
+            lock.lock()
+            defer { lock.unlock() }
+            guard !left else { return }
+            left = true
+            group.leave()
+        }
+
+        process.terminationHandler = { _ in leaveOnce() }
+        // Cover the race where the child exits before the handler is installed.
+        if !process.isRunning {
+            leaveOnce()
+        }
+
+        let waitResult = group.wait(timeout: .now() + timeoutSeconds)
+        guard waitResult == .timedOut else {
+            return
+        }
+
+        process.terminate()
+        let grace = group.wait(timeout: .now() + 1.0)
+        if grace == .timedOut {
+            let pid = process.processIdentifier
+            if pid > 0 {
+                kill(pid, SIGKILL)
+            }
+            _ = group.wait(timeout: .now() + 1.0)
+        }
+
+        throw PeekabooError.operationError(
+            message: "Command timed out after \(Int(timeoutSeconds))s")
+    }
+}

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/DockService+Process.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/DockService+Process.swift
@@ -10,37 +10,50 @@ extension DockService {
         _ process: Process,
         timeoutSeconds: TimeInterval = 15) throws
     {
-        let group = DispatchGroup()
-        group.enter()
-        let lock = NSLock()
-        var left = false
-        let leaveOnce: () -> Void = {
-            lock.lock()
-            defer { lock.unlock() }
-            guard !left else { return }
-            left = true
-            group.leave()
+        final class LeaveOnce: @unchecked Sendable {
+            private let lock = NSLock()
+            private let group = DispatchGroup()
+            private var left = false
+
+            init() {
+                self.group.enter()
+            }
+
+            func leave() {
+                self.lock.lock()
+                defer { self.lock.unlock() }
+                guard !self.left else { return }
+                self.left = true
+                self.group.leave()
+            }
+
+            func wait(timeoutSeconds: TimeInterval) -> DispatchTimeoutResult {
+                self.group.wait(timeout: .now() + timeoutSeconds)
+            }
         }
 
-        process.terminationHandler = { _ in leaveOnce() }
+        let once = LeaveOnce()
+        process.terminationHandler = { _ in
+            once.leave()
+        }
         // Cover the race where the child exits before the handler is installed.
         if !process.isRunning {
-            leaveOnce()
+            once.leave()
         }
 
-        let waitResult = group.wait(timeout: .now() + timeoutSeconds)
+        let waitResult = once.wait(timeoutSeconds: timeoutSeconds)
         guard waitResult == .timedOut else {
             return
         }
 
         process.terminate()
-        let grace = group.wait(timeout: .now() + 1.0)
+        let grace = once.wait(timeoutSeconds: 1.0)
         if grace == .timedOut {
             let pid = process.processIdentifier
             if pid > 0 {
                 kill(pid, SIGKILL)
             }
-            _ = group.wait(timeout: .now() + 1.0)
+            _ = once.wait(timeoutSeconds: 1.0)
         }
 
         throw PeekabooError.operationError(

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/DockService+Visibility.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/DockService+Visibility.swift
@@ -56,7 +56,7 @@ extension DockService {
                 process.standardError = pipe
 
                 try process.run()
-                process.waitUntilExit()
+                try DockService.waitForProcessExit(process, timeoutSeconds: 15)
 
                 if process.terminationStatus != 0 {
                     let data = pipe.fileHandleForReading.readDataToEndOfFile()

--- a/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/DockProcessWaitTests.swift
+++ b/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/DockProcessWaitTests.swift
@@ -1,0 +1,46 @@
+import Darwin
+import Foundation
+import PeekabooFoundation
+import Testing
+@testable import PeekabooAutomationKit
+
+@Suite(.serialized)
+struct DockProcessWaitTests {
+    @Test
+    func `normally exiting child returns its exit status`() throws {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/bin/sh")
+        process.arguments = ["-c", "sleep 0.05; exit 7"]
+
+        try process.run()
+        try DockService.waitForProcessExit(process, timeoutSeconds: 2)
+
+        #expect(!process.isRunning)
+        #expect(process.terminationReason == .exit)
+        #expect(process.terminationStatus == 7)
+    }
+
+    @Test
+    func `timed out child is killed and reaped`() throws {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/bin/sh")
+        process.arguments = ["-c", "trap '' TERM; exec /bin/sleep 30"]
+
+        try process.run()
+        let pid = process.processIdentifier
+        let startedAt = Date()
+
+        #expect(throws: PeekabooError.self) {
+            try DockService.waitForProcessExit(process, timeoutSeconds: 0.05)
+        }
+
+        #expect(Date().timeIntervalSince(startedAt) < 2)
+        #expect(!process.isRunning)
+        #expect(process.terminationReason == .uncaughtSignal)
+        #expect(process.terminationStatus == SIGKILL)
+
+        errno = 0
+        #expect(kill(pid, 0) == -1)
+        #expect(errno == ESRCH)
+    }
+}


### PR DESCRIPTION
## What Problem This Solves

Dock hide/show/add/remove run `defaults`, `killall`, and `osascript` via `Process.waitUntilExit()` with no deadline. A wedged child hangs CLI and MCP dock tools forever (same hang class as the ShellTool process bound that already landed).

## Evidence

### After

New `DockService.waitForProcessExit`:

- `terminationHandler` + `DispatchGroup.wait(timeout:)`
- On timeout: `terminate()`, 1s grace, then `SIGKILL`
- Throws `PeekabooError.operationError` with timeout message

Wired into:

- `DockService+Visibility.runCommand` (hide/show)
- `DockService+Actions.runProcess` (add/restart)
- `removeFromDockImpl` osascript path (30s)

## Real behavior proof

- **Behavior or issue addressed:** Bound dock helper process waits so wedged `defaults`/`killall`/`osascript` cannot hang dock commands.
- **Real environment tested:** macOS arm64, worktree `/tmp/oc-batch-20260802/peekaboo` on `fix/dock-process-timeout` from `origin/main`.
- **Exact steps or command run after this patch:** Code review of wait helper + call sites; shared pattern matches ShellTool/CaptureActionProcessRunner deadline philosophy.
- **Evidence after fix:** All dock `waitUntilExit` sites in Visibility/Actions now call `waitForProcessExit` with 15s (osascript remove 30s).
- **Observed result after fix:** No remaining unbounded `waitUntilExit` on those dock paths.
- **What was not tested:** Full Xcode suite in this session; no intentional wedged-child live hang (would require a stuck helper process).

## Summary

Add `DockService+Process.waitForProcessExit` and use it for dock process reaping.
