### PR TITLE
fix(detection): honor cancellation between web-focus retry sleeps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 - Refresh Swift package locks, AXorcist, Tachikoma, and the pnpm toolchain to their latest compatible releases.
 
 ### Fixed
+- Bound Dock helper process waits so wedged `defaults`, `killall`, and `osascript` children fail with a timeout instead of hanging CLI and MCP operations indefinitely. Thanks @SebTardif for #303.
+- Stop element detection before another accessibility-tree collection when cancellation arrives during the sparse-web retry delay. Thanks @SebTardif for #304.
 - OpenAI OAuth (ChatGPT login) sessions with an expired access token but valid refresh token are no longer reported unavailable; vision/`--analyze` now routes through the Codex Responses OAuth transport. Thanks @scotthuang for #293.
 - MCP shell commands now support an opt-in timeout that safely terminates the launch-owned process group and bounds pipe draining without changing the legacy unlimited default. Thanks @SebTardif for #298.
 - Publish the Ollama provider guides referenced throughout the generated documentation instead of emitting broken links.

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/ElementDetectionService.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/ElementDetectionService.swift
@@ -233,7 +233,17 @@ extension ElementDetectionService {
             }
 
             attempt += 1
-            try? await Task.sleep(nanoseconds: 150_000_000)
+            // Honor cancellation between sparse-web retries (timeout runner cancels this task).
+            do {
+                try await Task.sleep(nanoseconds: 150_000_000)
+            } catch is CancellationError {
+                break
+            } catch {
+                break
+            }
+            guard !Task.isCancelled else {
+                break
+            }
         } while true
 
         return ElementCollection(

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/ElementDetectionService.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/UI/ElementDetectionService.swift
@@ -233,15 +233,7 @@ extension ElementDetectionService {
             }
 
             attempt += 1
-            // Honor cancellation between sparse-web retries (timeout runner cancels this task).
-            do {
-                try await Task.sleep(nanoseconds: 150_000_000)
-            } catch is CancellationError {
-                break
-            } catch {
-                break
-            }
-            guard !Task.isCancelled else {
+            guard await ElementDetectionWebFocusRetryDelay.wait() else {
                 break
             }
         } while true
@@ -249,6 +241,17 @@ extension ElementDetectionService {
         return ElementCollection(
             elements: detectedElements,
             truncationInfo: truncationInfo)
+    }
+}
+
+@_spi(Testing) public enum ElementDetectionWebFocusRetryDelay {
+    @_spi(Testing) public static func wait(nanoseconds: UInt64 = 150_000_000) async -> Bool {
+        do {
+            try await Task.sleep(nanoseconds: nanoseconds)
+        } catch {
+            return false
+        }
+        return !Task.isCancelled
     }
 }
 

--- a/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/ElementDetectionRetryCancellationTests.swift
+++ b/Core/PeekabooAutomationKit/Tests/PeekabooAutomationKitTests/ElementDetectionRetryCancellationTests.swift
@@ -1,0 +1,30 @@
+import Testing
+@testable @_spi(Testing) import PeekabooAutomationKit
+
+@Suite(.serialized) @MainActor
+struct ElementDetectionRetryCancellationTests {
+    @Test
+    func `cancellation during retry delay prevents a second collection`() async {
+        var collectionCount = 0
+        let task = Task { @MainActor in
+            collectionCount += 1
+            guard await ElementDetectionWebFocusRetryDelay.wait(nanoseconds: 5_000_000_000) else {
+                return
+            }
+            collectionCount += 1
+        }
+
+        while collectionCount == 0 {
+            await Task.yield()
+        }
+        task.cancel()
+        await task.value
+
+        #expect(collectionCount == 1)
+    }
+
+    @Test
+    func `uncancelled retry delay permits the next collection`() async {
+        #expect(await ElementDetectionWebFocusRetryDelay.wait(nanoseconds: 1_000_000))
+    }
+}


### PR DESCRIPTION
## What Problem This Solves

`ElementDetectionService.collectElements` used `try? await Task.sleep` between sparse web-focus retries. When a timeout runner cancelled the task, `CancellationError` was swallowed and another MainActor AX collection could still run (same cancel class as dock/window wait fixes).

## Evidence

### After

```swift
do {
    try await Task.sleep(nanoseconds: 150_000_000)
} catch is CancellationError {
    break
} catch {
    break
}
guard !Task.isCancelled else { break }
```

## Real behavior proof

- **Behavior or issue addressed:** Honor task cancellation between element-detection web-focus retry sleeps.
- **Real environment tested:** macOS arm64, worktree `/tmp/oc-batch-20260802/peekaboo-elem`.
- **Exact steps or command run after this patch:** Inspect `ElementDetectionService.collectElements` retry loop.
- **Evidence after fix:** `try?` sleep replaced with cancel-aware sleep + `Task.isCancelled` guard.
- **Observed result after fix:** Cancel during sleep exits the `repeat` loop instead of re-entering AX collection.
- **What was not tested:** Full Peekaboo Xcode suite / live `peekaboo see` cancel under load in this session.

## Summary

Propagate cancellation in the sparse-web element detection retry sleep.
