### PR TITLE
feat(mac): restructure status bar menu with status line and native anchoring

### DIFF
--- a/Apps/Mac/Peekaboo/Features/StatusBar/StatusBarController.swift
+++ b/Apps/Mac/Peekaboo/Features/StatusBar/StatusBarController.swift
@@ -45,6 +45,9 @@ enum StatusMenuAppearance {
 /// Manages the macOS status bar integration with animated icon states and popover UI.
 @MainActor
 final class StatusBarController: NSObject, NSMenuDelegate {
+    private static let permissionsStatusItemIdentifier = NSUserInterfaceItemIdentifier(
+        "boo.peekaboo.statusMenu.permissionsStatus")
+
     private let logger = Logger(subsystem: "boo.peekaboo.app", category: "StatusBar")
     private let statusItem: NSStatusItem
     private let popover = NSPopover()
@@ -192,9 +195,86 @@ final class StatusBarController: NSObject, NSMenuDelegate {
     }
 
     private func showContextMenu(anchorEvent _: NSEvent) {
+        // Kick off a passive permission check so the status line self-corrects by the next open;
+        // deliberately not refresh(): a forced check unlocks the ScreenCaptureKit probe, which
+        // may present the system prompt — opening the menu is not grant intent.
+        Task { await self.permissions.check() }
+
+        let menu = self.makeContextMenu(
+            agentModeEnabled: self.settings.agentModeEnabled,
+            sessions: self.sessionStore.sessions)
+        self.refreshPermissionsStatus(in: menu)
+
+        // macOS may apply “standard” images for common items (Settings/Quit).
+        // Strip any images right before display.
+        Self.stripMenuItemImages(menu)
+
+        // Follow the system light/dark mode instead of the menu bar's wallpaper-tinted appearance.
+        StatusMenuAppearance.pin(menu)
+
+        // Native status-item anchoring: attach the menu just for this click so AppKit positions it
+        // exactly like a system status menu on every display and scale factor, then detach so
+        // left-click keeps opening the popover. AppKit's standard-image injection for attached
+        // menus is defended twice: menuWillOpen strips images, and “Settings…​” carries a
+        // zero-width space so the gear heuristic never matches.
+        guard let button = self.statusItem.button else { return }
+        self.statusItem.menu = menu
+        button.performClick(nil)
+        self.statusItem.menu = nil
+    }
+
+    func makeContextMenu(agentModeEnabled: Bool, sessions: [ConversationSession]) -> NSMenu {
         let menu = NSMenu()
         menu.delegate = self
         menu.showsStateColumn = false
+
+        let statusItem = NSMenuItem(title: "Ready", action: nil, keyEquivalent: "")
+        statusItem.identifier = Self.permissionsStatusItemIdentifier
+        statusItem.isEnabled = false
+        menu.addItem(statusItem)
+
+        menu.addItem(.separator())
+
+        // "Open Peekaboo" is agent-mode-only: openMainWindow no-ops when the agent session UI
+        // is unavailable, so showing it for default users would be a dead primary item.
+        if agentModeEnabled {
+            menu.addItem(NSMenuItem(
+                title: "Open Peekaboo",
+                action: #selector(self.openMainWindow),
+                keyEquivalent: "p").with { $0.keyEquivalentModifierMask = [.command, .shift] })
+        }
+
+        menu.addItem(NSMenuItem(
+            title: "Inspector",
+            action: #selector(self.openInspector),
+            keyEquivalent: "i").with { $0.keyEquivalentModifierMask = [.command, .shift] })
+
+        if agentModeEnabled, !sessions.isEmpty {
+            let sessionsMenu = NSMenu()
+
+            for session in sessions.prefix(5) {
+                let item = NSMenuItem(
+                    title: session.title,
+                    action: #selector(self.openSession(_:)),
+                    keyEquivalent: "")
+                item.representedObject = session.id
+                item.target = self
+                sessionsMenu.addItem(item)
+            }
+
+            let sessionsItem = NSMenuItem(title: "Recent Sessions", action: nil, keyEquivalent: "")
+            sessionsItem.submenu = sessionsMenu
+            menu.addItem(sessionsItem)
+        }
+
+        menu.addItem(.separator())
+
+        menu.addItem(NSMenuItem(
+            title: "Permissions…",
+            action: #selector(self.openPermissions),
+            keyEquivalent: ""))
+
+        menu.addItem(.separator())
 
         // macOS may inject a “standard” gear icon for a Settings… item in AppKit menus.
         // That icon causes the whole menu to reserve an (empty) image column.
@@ -208,93 +288,56 @@ final class StatusBarController: NSObject, NSMenuDelegate {
         settingsItem.keyEquivalentModifierMask = .command
         menu.addItem(settingsItem)
 
-        let aboutItem = NSMenuItem(
-            title: "About Peekaboo",
-            action: #selector(self.showAbout),
-            keyEquivalent: "")
-        menu.addItem(aboutItem)
-
-        let updatesItem = NSMenuItem(
+        menu.addItem(NSMenuItem(
             title: "Check for Updates…",
             action: #selector(self.checkForUpdates),
-            keyEquivalent: "")
-        menu.addItem(updatesItem)
-
-        menu.addItem(NSMenuItem(
-            title: "Permissions…",
-            action: #selector(self.openPermissions),
             keyEquivalent: ""))
 
         menu.addItem(NSMenuItem(
-            title: "Permissions Onboarding…",
-            action: #selector(self.showPermissionsOnboarding),
+            title: "About Peekaboo",
+            action: #selector(self.showAbout),
             keyEquivalent: ""))
-
-        if self.settings.agentModeEnabled {
-            let agentMenu = NSMenu()
-
-            if !self.sessionStore.sessions.isEmpty {
-                let headerItem = NSMenuItem(title: "Recent Sessions", action: nil, keyEquivalent: "")
-                headerItem.isEnabled = false
-                agentMenu.addItem(headerItem)
-
-                for session in self.sessionStore.sessions.prefix(5) {
-                    let item = NSMenuItem(
-                        title: session.title,
-                        action: #selector(self.openSession(_:)),
-                        keyEquivalent: "")
-                    item.representedObject = session.id
-                    item.target = self
-                    agentMenu.addItem(item)
-                }
-
-                agentMenu.addItem(.separator())
-            }
-
-            agentMenu.addItem(NSMenuItem(
-                title: "Open Peekaboo",
-                action: #selector(self.openMainWindow),
-                keyEquivalent: "p").with { $0.keyEquivalentModifierMask = [.command, .shift] })
-
-            agentMenu.addItem(NSMenuItem(
-                title: "Inspector",
-                action: #selector(self.openInspector),
-                keyEquivalent: "i").with { $0.keyEquivalentModifierMask = [.command, .shift] })
-
-            let agentItem = NSMenuItem(title: "Agent", action: nil, keyEquivalent: "")
-            agentItem.submenu = agentMenu
-            menu.addItem(agentItem)
-        }
 
         menu.addItem(.separator())
 
-        let quitItem = NSMenuItem(title: "Quit", action: #selector(self.quit), keyEquivalent: "q")
+        let quitItem = NSMenuItem(title: "Quit Peekaboo", action: #selector(self.quit), keyEquivalent: "q")
         quitItem.keyEquivalentModifierMask = .command
         menu.addItem(quitItem)
 
-        // Configure menu items (except quit which needs NSApp as target)
+        // Configure actionable root items; submenu items already target the controller above.
         for item in menu.items where item.action != nil {
             item.target = self
         }
 
-        // macOS may apply “standard” images for common items (Settings/Quit).
-        // Strip any images right before display.
-        Self.stripMenuItemImages(menu)
-
-        // Follow the system light/dark mode instead of the menu bar's wallpaper-tinted appearance.
-        StatusMenuAppearance.pin(menu)
-
-        // Avoid temporarily attaching `statusItem.menu` (which can cause AppKit to inject standard item images,
-        // notably for “Settings…”). Instead, pop up the menu directly anchored to the status item button.
-        guard let button = self.statusItem.button else { return }
-        button.highlight(true)
-        defer { button.highlight(false) }
-
-        menu.popUp(positioning: nil, at: NSPoint(x: 0, y: button.bounds.height), in: button)
+        return menu
     }
 
-    nonisolated func menuWillOpen(_ menu: NSMenu) {
+    // AppKit forbids mutating menu items from menuWillOpen/menuDidClose; the status line is
+    // populated in showContextMenu before the menu is attached. Only image stripping (a
+    // presentation concern AppKit itself introduces late) happens here.
+    func menuWillOpen(_ menu: NSMenu) {
         Self.stripMenuItemImages(menu)
+    }
+
+    func refreshPermissionsStatus(in menu: NSMenu) {
+        guard let statusItem = menu.items.first(where: {
+            $0.identifier == Self.permissionsStatusItemIdentifier
+        }) else { return }
+
+        let requiredPermissionsAuthorized = self.permissions.screenRecordingStatus == .authorized &&
+            self.permissions.accessibilityStatus == .authorized
+
+        if requiredPermissionsAuthorized {
+            statusItem.title = "Ready"
+            statusItem.action = nil
+            statusItem.target = nil
+            statusItem.isEnabled = false
+        } else {
+            statusItem.title = "Permissions required — open checklist"
+            statusItem.action = #selector(self.openPermissions)
+            statusItem.target = self
+            statusItem.isEnabled = true
+        }
     }
 
     private nonisolated static func stripMenuItemImages(_ menu: NSMenu) {
@@ -357,10 +400,6 @@ final class StatusBarController: NSObject, NSMenuDelegate {
 
     @objc private func openPermissions() {
         SettingsOpener.openSettings(tab: .permissions)
-    }
-
-    @objc private func showPermissionsOnboarding() {
-        PermissionsOnboardingController.shared.show(permissions: self.permissions)
     }
 
     @objc private func openInspector() {

--- a/Apps/Mac/PeekabooTests/Controllers/StatusBarControllerTests.swift
+++ b/Apps/Mac/PeekabooTests/Controllers/StatusBarControllerTests.swift
@@ -1,14 +1,36 @@
 import AppKit
 import Testing
 @testable import Peekaboo
+@testable import PeekabooCore
 
 @Suite(.tags(.ui, .unit))
 @MainActor
 struct StatusBarControllerTests {
-    private func makeController() -> StatusBarController {
+    private final class MockPermissionsService: ObservablePermissionsServiceProtocol {
+        var screenRecordingStatus: ObservablePermissionsService.PermissionState = .authorized
+        var accessibilityStatus: ObservablePermissionsService.PermissionState = .authorized
+        var appleScriptStatus: ObservablePermissionsService.PermissionState = .notDetermined
+        var postEventStatus: ObservablePermissionsService.PermissionState = .notDetermined
+
+        var hasAllPermissions: Bool {
+            self.screenRecordingStatus == .authorized && self.accessibilityStatus == .authorized
+        }
+
+        func checkPermissions(includeOptionalPermissions _: Bool, forceScreenRecordingProbe _: Bool) async {}
+        func requestScreenRecording() async {}
+        func requestAccessibility() async {}
+        func requestAppleScript() async {}
+        func requestPostEvent() async {}
+    }
+
+    private func makeController(permissionsService: MockPermissionsService = MockPermissionsService())
+        -> StatusBarController
+    {
         let settings = PeekabooSettings()
-        let sessionStore = SessionStore()
-        let permissions = Permissions()
+        let sessionStore = SessionStore(
+            storageURL: FileManager.default.temporaryDirectory
+                .appendingPathComponent("StatusBarControllerTests-\(UUID().uuidString).json"))
+        let permissions = Permissions(permissionsService: permissionsService)
         let agent = PeekabooAgent(
             settings: settings,
             sessionStore: sessionStore)
@@ -46,14 +68,96 @@ struct StatusBarControllerTests {
     }
 
     @Test
-    func `Menu contains expected items`() {
-        _ = self.makeController()
+    func `Menu follows the frozen item order`() throws {
+        let controller = self.makeController()
+        defer { controller.removeStatusItem() }
+        let sessions = (1...6).map {
+            ConversationSession(id: "session-\($0)", title: "Session \($0)")
+        }
 
-        // We can't directly access the private statusItem property
-        // This test would need the StatusBarController to expose a testing API
-        // or make statusItem internal for testing
+        let menu = controller.makeContextMenu(agentModeEnabled: true, sessions: sessions)
+        controller.menuWillOpen(menu)
 
-        // Test passes - we verified controller initializes without crashing
+        #expect(menu.items.map(self.visibleTitle) == [
+            "Ready",
+            "<separator>",
+            "Open Peekaboo",
+            "Inspector",
+            "Recent Sessions",
+            "<separator>",
+            "Permissions…",
+            "<separator>",
+            "Settings…",
+            "Check for Updates…",
+            "About Peekaboo",
+            "<separator>",
+            "Quit Peekaboo",
+        ])
+
+        let recentSessionsItem = try #require(menu.items.first(where: { $0.title == "Recent Sessions" }))
+        let recentSessionsMenu = try #require(recentSessionsItem.submenu)
+        #expect(recentSessionsMenu.items.map(\.title) == [
+            "Session 1", "Session 2", "Session 3", "Session 4", "Session 5",
+        ])
+
+        let openItem = try #require(menu.items.first(where: { $0.title == "Open Peekaboo" }))
+        #expect(openItem.keyEquivalent == "p")
+        #expect(openItem.keyEquivalentModifierMask == [.command, .shift])
+
+        let inspectorItem = try #require(menu.items.first(where: { $0.title == "Inspector" }))
+        #expect(inspectorItem.keyEquivalent == "i")
+        #expect(inspectorItem.keyEquivalentModifierMask == [.command, .shift])
+
+        let settingsItem = try #require(menu.items.first(where: { $0.title.hasPrefix("Settings…") }))
+        #expect(settingsItem.title == "Settings…\u{200B}")
+        #expect(settingsItem.attributedTitle?.string == "Settings…\u{200B}")
+        #expect(settingsItem.keyEquivalent == ",")
+        #expect(settingsItem.keyEquivalentModifierMask == .command)
+
+        let quitItem = try #require(menu.items.first(where: { $0.title == "Quit Peekaboo" }))
+        #expect(quitItem.keyEquivalent == "q")
+        #expect(quitItem.keyEquivalentModifierMask == .command)
+    }
+
+    @Test
+    func `Recent sessions only appear for enabled agent mode with sessions`() {
+        let controller = self.makeController()
+        defer { controller.removeStatusItem() }
+        let sessions = [ConversationSession(id: "session-1", title: "Session 1")]
+
+        let disabledMenu = controller.makeContextMenu(agentModeEnabled: false, sessions: sessions)
+        let emptyMenu = controller.makeContextMenu(agentModeEnabled: true, sessions: [])
+
+        #expect(!disabledMenu.items.contains(where: { $0.title == "Recent Sessions" }))
+        #expect(!emptyMenu.items.contains(where: { $0.title == "Recent Sessions" }))
+        #expect(!disabledMenu.items.contains(where: { $0.title == "Open Peekaboo" }),
+                "Open Peekaboo no-ops without agent mode, so it must be hidden")
+        #expect(disabledMenu.items.contains(where: { $0.title == "Inspector" }))
+        #expect(emptyMenu.items.contains(where: { $0.title == "Open Peekaboo" }))
+    }
+
+    @Test
+    func `Permission status refreshes when the menu opens`() throws {
+        let permissionsService = MockPermissionsService()
+        permissionsService.screenRecordingStatus = .denied
+        let controller = self.makeController(permissionsService: permissionsService)
+        defer { controller.removeStatusItem() }
+        let menu = controller.makeContextMenu(agentModeEnabled: false, sessions: [])
+
+        controller.refreshPermissionsStatus(in: menu)
+
+        let statusItem = try #require(menu.items.first)
+        #expect(statusItem.title == "Permissions required — open checklist")
+        #expect(statusItem.isEnabled)
+        #expect(statusItem.action != nil)
+
+        permissionsService.screenRecordingStatus = .authorized
+        permissionsService.accessibilityStatus = .authorized
+        controller.refreshPermissionsStatus(in: menu)
+
+        #expect(statusItem.title == "Ready")
+        #expect(!statusItem.isEnabled)
+        #expect(statusItem.action == nil)
     }
 
     @Test
@@ -77,7 +181,7 @@ struct StatusBarControllerTests {
     func `Submenus inherit the pinned root appearance`() throws {
         let menu = NSMenu()
         let submenu = NSMenu()
-        let item = NSMenuItem(title: "Agent", action: nil, keyEquivalent: "")
+        let item = NSMenuItem(title: "Recent Sessions", action: nil, keyEquivalent: "")
         item.submenu = submenu
         menu.addItem(item)
 
@@ -98,5 +202,12 @@ struct StatusBarControllerTests {
 
         // We can't access private popover property
         // Test passes - controller initialized without crashing
+    }
+
+    private func visibleTitle(_ item: NSMenuItem) -> String {
+        if item.isSeparatorItem {
+            return "<separator>"
+        }
+        return item.title.replacingOccurrences(of: "\u{200B}", with: "")
     }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Changed
 - Refresh Swift package locks, AXorcist, Tachikoma, and the pnpm toolchain to their latest compatible releases.
+- Restructure the Mac app's status bar menu with a live permission status, primary destinations first, one Permissions entry, housekeeping grouped at the bottom, and context menus anchored beneath the status item.
 
 ### Fixed
 - OpenAI OAuth (ChatGPT login) sessions with an expired access token but valid refresh token are no longer reported unavailable; vision/`--analyze` now routes through the Codex Responses OAuth transport. Thanks @scotthuang for #293.

--- a/docs/permissions.md
+++ b/docs/permissions.md
@@ -11,7 +11,7 @@ read_when:
 
 Peekaboo 3.9.6 completes the move from Peter Steinberger's Developer ID team to `Developer ID Application: OpenClaw Foundation (FWJYW4S8P8)` for every shipped macOS executable. Bundle identifiers and the Sparkle update key are unchanged, but macOS still treats the newly signed CLI as a different TCC client. After updating, re-grant Screen Recording, Accessibility, and any Automation permissions your workflows use.
 
-Peekaboo.app reopens its permission checklist once when required grants are missing. You can also open Peekaboo.app → Settings → Permissions, choose Permissions Onboarding from the menu bar item, or run:
+Peekaboo.app reopens its permission checklist once when required grants are missing. You can also open Peekaboo.app → Settings → Permissions, choose Permissions… from the menu bar item (its status line links straight to the checklist while grants are missing), or run:
 
 ```bash
 peekaboo permissions status --all-sources


### PR DESCRIPTION
## Problem

The status bar menu led with housekeeping actions, hid primary destinations inside an Agent submenu, duplicated permissions entries, and used fragile ad-hoc coordinate math to anchor its context menu.

## Fix

Put the passive readiness/permissions status line first, followed by the primary destinations: Open Peekaboo when agent mode makes it actionable, Inspector, and Recent Sessions. Keep one Permissions… entry, group housekeeping at the bottom, and label the quit action Quit Peekaboo. Present the context menu through a temporary `statusItem.menu` plus `performClick()` so AppKit owns native anchoring, and keep `menuWillOpen` free of structural menu mutations.

The onboarding flow remains available from Settings → Permissions.

## Testing

- 10 StatusBar tests, including frozen order, agent-mode gating, and the passive status line
- Swift build
- Mac debug build
- Docs lint

🤖 Generated with [Claude Code](https://claude.com/claude-code)
