### PR TITLE
feat(mcp): expose capture coordinate context

### DIFF
--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Capture/ScreenCaptureKitFrameSource.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Capture/ScreenCaptureKitFrameSource.swift
@@ -99,14 +99,8 @@ final class ScreenCaptureKitFrameSource: CaptureFrameSource {
             ],
             correlationId: correlationId)
 
-        let size: CGSize = if request.mode == .area {
-            request.displayBounds.size
-        } else {
-            CGSize(width: frame.image.width, height: frame.image.height)
-        }
-
         let metadata = CaptureMetadata(
-            size: size,
+            size: CGSize(width: frame.image.width, height: frame.image.height),
             mode: request.mode,
             displayInfo: DisplayInfo(
                 index: request.displayIndex,

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Capture/SingleShotFrameSource.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Capture/SingleShotFrameSource.swift
@@ -58,14 +58,8 @@ final class SingleShotFrameSource: CaptureFrameSource {
             ],
             correlationId: request.correlationId)
 
-        let size: CGSize = if request.mode == .area {
-            request.displayBounds.size
-        } else {
-            CGSize(width: image.width, height: image.height)
-        }
-
         let metadata = CaptureMetadata(
-            size: size,
+            size: CGSize(width: image.width, height: image.height),
             mode: request.mode,
             displayInfo: DisplayInfo(
                 index: request.displayIndex,

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Core/Protocols/ScreenCaptureServiceProtocol.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Core/Protocols/ScreenCaptureServiceProtocol.swift
@@ -345,9 +345,9 @@ public struct CaptureCoordinateContext: Sendable, Codable, Equatable {
         self.deliveredImageSize = metadata.size
         self.requestedScale = metadata.diagnostics?.requestedScale
         self.nativeScale = metadata.diagnostics?.nativeScale ?? metadata.displayInfo?.scaleFactor
-        self.outputScale = metadata.diagnostics?.outputScale ?? Self.inferredOutputScale(
+        self.outputScale = Self.inferredOutputScale(
             deliveredImageSize: metadata.size,
-            logicalBounds: logicalBounds)
+            logicalBounds: logicalBounds) ?? metadata.diagnostics?.outputScale
         self.display = metadata.displayInfo.map { DisplayIdentity(index: $0.index, name: $0.name) }
         self.window = metadata.windowInfo.map {
             WindowIdentity(

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Core/Protocols/ScreenCaptureServiceProtocol.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Core/Protocols/ScreenCaptureServiceProtocol.swift
@@ -144,7 +144,7 @@ public struct CaptureResult: Sendable, Codable {
 
 /// Metadata about a captured image
 public struct CaptureMetadata: Sendable, Codable {
-    /// Size of the captured image
+    /// Pixel size of the image delivered to the caller.
     public let size: CGSize
 
     /// Capture mode used
@@ -229,6 +229,153 @@ extension CaptureMetadata {
             displayInfo: self.displayInfo,
             timestamp: self.timestamp,
             diagnostics: diagnostics)
+    }
+
+    /// Return metadata updated for an image resized after capture.
+    ///
+    /// Capture engines populate `size` and `finalPixelSize` with their raster output. Callers that
+    /// subsequently resize that raster must keep both values aligned with the delivered image.
+    public func withDeliveredPixelSize(_ deliveredPixelSize: CGSize) -> CaptureMetadata {
+        let logicalBounds = self.windowInfo?.bounds ?? self.displayInfo?.bounds
+        let deliveredOutputScale: CGFloat? = if let logicalBounds, logicalBounds.width > 0 {
+            deliveredPixelSize.width / logicalBounds.width
+        } else if let diagnostics = self.diagnostics, diagnostics.finalPixelSize.width > 0 {
+            diagnostics.outputScale * deliveredPixelSize.width / diagnostics.finalPixelSize.width
+        } else {
+            nil
+        }
+        let updatedDiagnostics = self.diagnostics.map { diagnostics in
+            CaptureDiagnostics(
+                requestedScale: diagnostics.requestedScale,
+                nativeScale: diagnostics.nativeScale,
+                outputScale: deliveredOutputScale ?? diagnostics.outputScale,
+                scaleSource: diagnostics.scaleSource,
+                finalPixelSize: deliveredPixelSize,
+                engine: diagnostics.engine,
+                fallbackReason: diagnostics.fallbackReason)
+        }
+
+        return CaptureMetadata(
+            size: deliveredPixelSize,
+            mode: self.mode,
+            videoTimestampMs: self.videoTimestampMs,
+            applicationInfo: self.applicationInfo,
+            windowInfo: self.windowInfo,
+            displayInfo: self.displayInfo,
+            timestamp: self.timestamp,
+            diagnostics: updatedDiagnostics)
+    }
+}
+
+/// Coordinate metadata that binds an image raster to Peekaboo's canonical automation space.
+///
+/// The context is descriptive only: it does not perform coordinate conversion. Consumers can use
+/// the logical bounds and delivered image size to map image-local pixels without assuming a Retina
+/// scale factor.
+public struct CaptureCoordinateContext: Sendable, Codable, Equatable {
+    public static let currentVersion = 1
+
+    public let version: Int
+    public let referenceID: String?
+    public let logicalSpace: LogicalSpace
+    public let origin: Origin
+    public let logicalBounds: CGRect?
+    public let deliveredImageSize: CGSize
+    public let requestedScale: CaptureScalePreference?
+    public let nativeScale: CGFloat?
+    public let outputScale: CGFloat?
+    public let display: DisplayIdentity?
+    public let window: WindowIdentity?
+
+    public enum LogicalSpace: String, Sendable, Codable, Equatable {
+        case globalDisplayPoints = "global_display_points"
+    }
+
+    public enum Origin: String, Sendable, Codable, Equatable {
+        case topLeft = "top_left"
+    }
+
+    public struct DisplayIdentity: Sendable, Codable, Equatable {
+        public let index: Int
+        public let name: String?
+
+        public init(index: Int, name: String?) {
+            self.index = index
+            self.name = name
+        }
+    }
+
+    public struct WindowIdentity: Sendable, Codable, Equatable {
+        public let windowID: Int
+        public let title: String
+        public let index: Int
+        public let screenIndex: Int?
+        public let screenName: String?
+
+        public init(
+            windowID: Int,
+            title: String,
+            index: Int,
+            screenIndex: Int?,
+            screenName: String?)
+        {
+            self.windowID = windowID
+            self.title = title
+            self.index = index
+            self.screenIndex = screenIndex
+            self.screenName = screenName
+        }
+
+        private enum CodingKeys: String, CodingKey {
+            case windowID = "window_id"
+            case title
+            case index
+            case screenIndex = "screen_index"
+            case screenName = "screen_name"
+        }
+    }
+
+    public init(metadata: CaptureMetadata, referenceID: String? = nil) {
+        let logicalBounds = metadata.windowInfo?.bounds ?? metadata.displayInfo?.bounds
+        self.version = Self.currentVersion
+        self.referenceID = referenceID
+        self.logicalSpace = .globalDisplayPoints
+        self.origin = .topLeft
+        self.logicalBounds = logicalBounds
+        self.deliveredImageSize = metadata.size
+        self.requestedScale = metadata.diagnostics?.requestedScale
+        self.nativeScale = metadata.diagnostics?.nativeScale ?? metadata.displayInfo?.scaleFactor
+        self.outputScale = metadata.diagnostics?.outputScale ?? Self.inferredOutputScale(
+            deliveredImageSize: metadata.size,
+            logicalBounds: logicalBounds)
+        self.display = metadata.displayInfo.map { DisplayIdentity(index: $0.index, name: $0.name) }
+        self.window = metadata.windowInfo.map {
+            WindowIdentity(
+                windowID: $0.windowID,
+                title: $0.title,
+                index: $0.index,
+                screenIndex: $0.screenIndex,
+                screenName: $0.screenName)
+        }
+    }
+
+    private static func inferredOutputScale(deliveredImageSize: CGSize, logicalBounds: CGRect?) -> CGFloat? {
+        guard let logicalBounds, logicalBounds.width > 0 else { return nil }
+        return deliveredImageSize.width / logicalBounds.width
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case version
+        case referenceID = "reference_id"
+        case logicalSpace = "logical_space"
+        case origin
+        case logicalBounds = "logical_bounds"
+        case deliveredImageSize = "delivered_image_size"
+        case requestedScale = "requested_scale"
+        case nativeScale = "native_scale"
+        case outputScale = "output_scale"
+        case display
+        case window
     }
 }
 

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Server/PeekabooMCPServer.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Server/PeekabooMCPServer.swift
@@ -83,9 +83,7 @@ public actor PeekabooMCPServer {
             // Execute tool on main thread
             let response = try await self.toolContext.execute(tool: tool, arguments: arguments)
 
-            return CallTool.Result(
-                content: response.content,
-                isError: response.isError)
+            return Self.callToolResult(from: response)
         }
 
         // Resources list handler (empty for now, but prevents inspector errors)
@@ -133,6 +131,21 @@ public actor PeekabooMCPServer {
             let data = try JSONEncoder().encode(result)
             return try JSONDecoder().decode(Initialize.Result.self, from: data)
         }
+    }
+
+    static func callToolResult(from response: ToolResponse) -> CallTool.Result {
+        let metadata: Metadata? = if case let .object(fields)? = response.meta,
+                                     let coordinateContext = fields["coordinate_context"]
+        {
+            Metadata(additionalFields: ["coordinate_context": coordinateContext])
+        } else {
+            nil
+        }
+
+        return CallTool.Result(
+            content: response.content,
+            isError: response.isError,
+            _meta: metadata)
     }
 
     private func registerAllTools() async {

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/CaptureCoordinateContextMetadata.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/CaptureCoordinateContextMetadata.swift
@@ -1,0 +1,64 @@
+import CoreGraphics
+import MCP
+import PeekabooAutomationKit
+
+enum CaptureCoordinateContextMetadata {
+    static func value(for metadata: CaptureMetadata, referenceID: String? = nil) -> Value {
+        self.value(for: CaptureCoordinateContext(metadata: metadata, referenceID: referenceID))
+    }
+
+    static func value(for context: CaptureCoordinateContext) -> Value {
+        var payload: [String: Value] = [
+            "version": .int(context.version),
+            "reference_id": context.referenceID.map(Value.string) ?? .null,
+            "logical_space": .string(context.logicalSpace.rawValue),
+            "origin": .string(context.origin.rawValue),
+            "logical_bounds": context.logicalBounds.map(self.rectValue) ?? .null,
+            "delivered_image_size": self.sizeValue(context.deliveredImageSize),
+            "requested_scale": context.requestedScale.map { .string(self.scaleName($0)) } ?? .null,
+            "native_scale": context.nativeScale.map { .double(Double($0)) } ?? .null,
+            "output_scale": context.outputScale.map { .double(Double($0)) } ?? .null,
+        ]
+
+        payload["display"] = context.display.map { display in
+            .object([
+                "index": .int(display.index),
+                "name": display.name.map(Value.string) ?? .null,
+            ])
+        } ?? .null
+        payload["window"] = context.window.map { window in
+            .object([
+                "window_id": .int(window.windowID),
+                "title": .string(window.title),
+                "index": .int(window.index),
+                "screen_index": window.screenIndex.map(Value.int) ?? .null,
+                "screen_name": window.screenName.map(Value.string) ?? .null,
+            ])
+        } ?? .null
+
+        return .object(payload)
+    }
+
+    private static func scaleName(_ scale: CaptureScalePreference) -> String {
+        switch scale {
+        case .logical1x: "logical1x"
+        case .native: "native"
+        }
+    }
+
+    private static func rectValue(_ rect: CGRect) -> Value {
+        .object([
+            "x": .double(Double(rect.origin.x)),
+            "y": .double(Double(rect.origin.y)),
+            "width": .double(Double(rect.width)),
+            "height": .double(Double(rect.height)),
+        ])
+    }
+
+    private static func sizeValue(_ size: CGSize) -> Value {
+        .object([
+            "width": .double(Double(size.width)),
+            "height": .double(Double(size.height)),
+        ])
+    }
+}

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/ImageTool+Capture.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/ImageTool+Capture.swift
@@ -112,7 +112,7 @@ extension ImageTool {
             downscaledCaptures.append(CaptureResult(
                 imageData: result.data,
                 savedPath: capture.savedPath,
-                metadata: capture.metadata,
+                metadata: capture.metadata.withDeliveredPixelSize(result.size),
                 warning: capture.warning))
         }
 
@@ -132,6 +132,7 @@ extension ImageTool {
         let imagePath = try savedFiles.first?.path ?? saveTemporaryImage(firstCapture.imageData)
         let analysis = try await analyzeImage(at: imagePath, question: question)
         let baseMeta = ObservationDiagnosticsMetadata.merge(observation, into: .object([
+            "coordinate_context": CaptureCoordinateContextMetadata.value(for: firstCapture.metadata),
             "model": .string(analysis.modelUsed),
             "savedFiles": .array(savedFiles.map { Value.string($0.path) }),
             "question": .string(question),
@@ -151,9 +152,13 @@ extension ImageTool {
         captureResults: [CaptureResult],
         observation: DesktopObservationResult?) -> ToolResponse
     {
-        let baseMeta = ObservationDiagnosticsMetadata.merge(observation, into: .object([
+        var metadata: [String: Value] = [
             "savedFiles": .array(savedFiles.map { Value.string($0.path) }),
-        ]))
+        ]
+        if let firstCapture = captureResults.first {
+            metadata["coordinate_context"] = CaptureCoordinateContextMetadata.value(for: firstCapture.metadata)
+        }
+        let baseMeta = ObservationDiagnosticsMetadata.merge(observation, into: .object(metadata))
         let captureNote: String = if savedFiles.isEmpty {
             "Captured image"
         } else if savedFiles.count == 1, let label = savedFiles.first?.item_label {
@@ -206,7 +211,11 @@ extension ImageTool {
         return data as Data
     }
 
-    func downscale(imageData: Data, maxDimension: Int, format: ImageFormatOption) -> (data: Data, resized: Bool)? {
+    func downscale(
+        imageData: Data,
+        maxDimension: Int,
+        format: ImageFormatOption) -> (data: Data, resized: Bool, size: CGSize)?
+    {
         guard let source = CGImageSourceCreateWithData(imageData as CFData, nil) else { return nil }
 
         guard let properties = CGImageSourceCopyPropertiesAtIndex(source, 0, nil) as? [CFString: Any],
@@ -218,7 +227,7 @@ extension ImageTool {
 
         let longest = max(width, height)
         guard longest > CGFloat(maxDimension) else {
-            return (imageData, false)
+            return (imageData, false, CGSize(width: width, height: height))
         }
 
         let options: [CFString: Any] = [
@@ -235,6 +244,9 @@ extension ImageTool {
             return nil
         }
 
-        return (encodedData, true)
+        return (
+            encodedData,
+            true,
+            CGSize(width: thumbnail.width, height: thumbnail.height))
     }
 }

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/SeeTool.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/SeeTool.swift
@@ -267,6 +267,9 @@ public struct SeeTool: MCPTool {
     {
         ObservationDiagnosticsMetadata.merge(observation, into: .object([
             "snapshot_id": .string(snapshot.id),
+            "coordinate_context": CaptureCoordinateContextMetadata.value(
+                for: observation.capture.metadata,
+                referenceID: snapshot.id),
             "element_count": .double(Double(elements.count)),
             "actionable_count": .double(Double(elements.count(where: { $0.isActionable }))),
         ]))

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/UISnapshotStore.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/UISnapshotStore.swift
@@ -13,6 +13,7 @@ actor UISnapshot {
     let id: String
     private(set) var screenshotPath: String?
     private(set) var screenshotMetadata: CaptureMetadata?
+    private(set) var screenshotCoordinateContext: CaptureCoordinateContext?
     private(set) var uiElements: [UIElement] = []
     private(set) var createdAt: Date
     private(set) var lastAccessedAt: Date
@@ -28,6 +29,7 @@ actor UISnapshot {
     func setScreenshot(path: String, metadata: CaptureMetadata) {
         self.screenshotPath = path
         self.screenshotMetadata = metadata
+        self.screenshotCoordinateContext = CaptureCoordinateContext(metadata: metadata, referenceID: self.id)
         self.targetCache.withLock {
             $0.applicationName = metadata.applicationInfo?.name
             $0.windowTitle = metadata.windowInfo?.title

--- a/Core/PeekabooCore/Tests/PeekabooTests/CaptureModelsTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/CaptureModelsTests.swift
@@ -237,6 +237,30 @@ struct CaptureModelsTests {
     }
 
     @Test
+    func `Capture coordinate context prefers delivered raster ratio over stale diagnostics`() {
+        let metadata = CaptureMetadata(
+            size: CGSize(width: 3024, height: 1964),
+            mode: .screen,
+            displayInfo: DisplayInfo(
+                index: 0,
+                name: "Built-in Display",
+                bounds: CGRect(x: 0, y: 0, width: 1512, height: 982),
+                scaleFactor: 2),
+            diagnostics: CaptureDiagnostics(
+                requestedScale: .logical1x,
+                nativeScale: 2,
+                outputScale: 1,
+                scaleSource: "requestedLogicalScale",
+                finalPixelSize: CGSize(width: 3024, height: 1964)))
+
+        let context = CaptureCoordinateContext(metadata: metadata)
+
+        #expect(context.requestedScale == .logical1x)
+        #expect(context.nativeScale == 2)
+        #expect(context.outputScale == 2)
+    }
+
+    @Test
     func `DisplayInfo initialization and properties`() {
         let displayInfo = DisplayInfo(
             index: 2,

--- a/Core/PeekabooCore/Tests/PeekabooTests/CaptureModelsTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/CaptureModelsTests.swift
@@ -170,6 +170,73 @@ struct CaptureModelsTests {
     }
 
     @Test
+    func `Capture coordinate context describes delivered raster in logical space`() {
+        let logicalBounds = CGRect(x: 120, y: 80, width: 1512, height: 982)
+        let metadata = CaptureMetadata(
+            size: CGSize(width: 3024, height: 1964),
+            mode: .window,
+            windowInfo: ServiceWindowInfo(
+                windowID: 42,
+                title: "Player",
+                bounds: logicalBounds,
+                index: 1,
+                screenIndex: 0,
+                screenName: "Built-in Display"),
+            displayInfo: DisplayInfo(
+                index: 0,
+                name: "Built-in Display",
+                bounds: CGRect(x: 0, y: 0, width: 1512, height: 982),
+                scaleFactor: 2),
+            diagnostics: CaptureDiagnostics(
+                requestedScale: .native,
+                nativeScale: 2,
+                outputScale: 2,
+                scaleSource: "screenBackingScaleFactor",
+                finalPixelSize: CGSize(width: 3024, height: 1964)))
+
+        let context = CaptureCoordinateContext(metadata: metadata, referenceID: "snapshot-42")
+
+        #expect(context.version == 1)
+        #expect(context.referenceID == "snapshot-42")
+        #expect(context.logicalSpace == .globalDisplayPoints)
+        #expect(context.origin == .topLeft)
+        #expect(context.logicalBounds == logicalBounds)
+        #expect(context.deliveredImageSize == CGSize(width: 3024, height: 1964))
+        #expect(context.requestedScale == .native)
+        #expect(context.nativeScale == 2)
+        #expect(context.outputScale == 2)
+        #expect(context.display?.index == 0)
+        #expect(context.window?.windowID == 42)
+        #expect(context.window?.screenName == "Built-in Display")
+    }
+
+    @Test
+    func `Delivered pixel size updates metadata and effective output scale`() {
+        let metadata = CaptureMetadata(
+            size: CGSize(width: 3024, height: 1964),
+            mode: .screen,
+            displayInfo: DisplayInfo(
+                index: 0,
+                name: "Built-in Display",
+                bounds: CGRect(x: 0, y: 0, width: 1512, height: 982),
+                scaleFactor: 2),
+            diagnostics: CaptureDiagnostics(
+                requestedScale: .native,
+                nativeScale: 2,
+                outputScale: 2,
+                scaleSource: "screenBackingScaleFactor",
+                finalPixelSize: CGSize(width: 3024, height: 1964)))
+
+        let resized = metadata.withDeliveredPixelSize(CGSize(width: 1512, height: 982))
+
+        #expect(resized.size == CGSize(width: 1512, height: 982))
+        #expect(resized.diagnostics?.finalPixelSize == CGSize(width: 1512, height: 982))
+        #expect(resized.diagnostics?.nativeScale == 2)
+        #expect(resized.diagnostics?.outputScale == 1)
+        #expect(resized.diagnostics?.requestedScale == .native)
+    }
+
+    @Test
     func `DisplayInfo initialization and properties`() {
         let displayInfo = DisplayInfo(
             index: 2,

--- a/Core/PeekabooCore/Tests/PeekabooTests/MCP/MCPToolExecutionTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/MCP/MCPToolExecutionTests.swift
@@ -227,8 +227,25 @@ struct MCPToolExecutionTests {
     @Test
     func `Image tool downscales high-res inline image to custom max_dimension`() async throws {
         let highResPNG = Self.makePNGData(width: 3000, height: 2000)
+        let captureMetadata = CaptureMetadata(
+            size: CGSize(width: 3000, height: 2000),
+            mode: .screen,
+            displayInfo: DisplayInfo(
+                index: 0,
+                name: "Retina Display",
+                bounds: CGRect(x: 0, y: 0, width: 1500, height: 1000),
+                scaleFactor: 2),
+            diagnostics: CaptureDiagnostics(
+                requestedScale: .native,
+                nativeScale: 2,
+                outputScale: 2,
+                scaleSource: "screenBackingScaleFactor",
+                finalPixelSize: CGSize(width: 3000, height: 2000)))
         let screenCapture = await MainActor.run {
-            MockScreenCaptureService(screenRecordingGranted: true, imageData: highResPNG)
+            MockScreenCaptureService(
+                screenRecordingGranted: true,
+                imageData: highResPNG,
+                metadata: captureMetadata)
         }
         let context = await MCPToolTestHelpers.makeContext(screenCapture: screenCapture)
         let tool = ImageTool(context: context)
@@ -250,6 +267,11 @@ struct MCPToolExecutionTests {
         }
 
         #expect(Self.imageDimensions(from: responseData) == CGSize(width: 600, height: 400))
+        let coordinateContext = try #require(Self.coordinateContext(from: response))
+        #expect(Self.size(from: coordinateContext["delivered_image_size"]) == CGSize(width: 600, height: 400))
+        #expect(Self.rect(from: coordinateContext["logical_bounds"]) == CGRect(x: 0, y: 0, width: 1500, height: 1000))
+        #expect(Self.double(from: coordinateContext["native_scale"]) == 2)
+        #expect(Self.double(from: coordinateContext["output_scale"]) == 0.4)
     }
 
     @Test
@@ -302,6 +324,7 @@ struct MCPToolExecutionTests {
 
         let capture = try #require(result.captures.first)
         #expect(Self.imageDimensions(from: capture.imageData) == CGSize(width: 600, height: 400))
+        #expect(capture.metadata.size == CGSize(width: 600, height: 400))
         let savedData = try Data(contentsOf: URL(fileURLWithPath: outputPath))
         #expect(Self.imageDimensions(from: savedData) == CGSize(width: 600, height: 400))
     }
@@ -468,6 +491,20 @@ struct MCPToolExecutionTests {
         #expect(output.contains("help: \"Press to continue\""))
         #expect(output.contains("shortcut: Return"))
         #expect(output.contains("identifier: confirm-button"))
+
+        guard case let .object(meta) = response.meta,
+              case let .string(snapshotID)? = meta["snapshot_id"],
+              case let .object(coordinateContext)? = meta["coordinate_context"],
+              case let .string(referenceID)? = coordinateContext["reference_id"]
+        else {
+            Issue.record("Expected See metadata to contain a referenced coordinate context")
+            return
+        }
+        #expect(referenceID == snapshotID)
+        let storedSnapshot = await UISnapshotManager.shared.getSnapshot(id: snapshotID)
+        let storedContext = await storedSnapshot?.screenshotCoordinateContext
+        #expect(storedContext?.referenceID == snapshotID)
+        #expect(storedContext?.logicalSpace == .globalDisplayPoints)
     }
 
     @Test
@@ -1106,6 +1143,45 @@ struct MCPToolExecutionTests {
         }
     }
 
+    private static func coordinateContext(from response: ToolResponse) -> [String: Value]? {
+        guard case let .object(meta) = response.meta,
+              case let .object(context)? = meta["coordinate_context"]
+        else {
+            return nil
+        }
+        return context
+    }
+
+    private static func double(from value: Value?) -> Double? {
+        switch value {
+        case let .double(number): number
+        case let .int(number): Double(number)
+        default: nil
+        }
+    }
+
+    private static func size(from value: Value?) -> CGSize? {
+        guard case let .object(size)? = value,
+              let width = self.double(from: size["width"]),
+              let height = self.double(from: size["height"])
+        else {
+            return nil
+        }
+        return CGSize(width: width, height: height)
+    }
+
+    private static func rect(from value: Value?) -> CGRect? {
+        guard case let .object(rect)? = value,
+              let x = self.double(from: rect["x"]),
+              let y = self.double(from: rect["y"]),
+              let width = self.double(from: rect["width"]),
+              let height = self.double(from: rect["height"])
+        else {
+            return nil
+        }
+        return CGRect(x: x, y: y, width: width, height: height)
+    }
+
     private static func targetPID(from response: ToolResponse) -> Int32? {
         guard case let .object(meta) = response.meta,
               case let .double(pid)? = meta["target_pid"]
@@ -1550,6 +1626,7 @@ private final class MockElementActionAutomationService: MockAutomationService, E
 private final class MockScreenCaptureService: ScreenCaptureServiceProtocol {
     private let screenRecordingGranted: Bool
     private let imageData: Data
+    private let metadata: CaptureMetadata?
     private(set) var captureAttemptCount = 0
     private(set) var lastWindowID: CGWindowID?
     private(set) var lastAppIdentifier: String?
@@ -1559,11 +1636,13 @@ private final class MockScreenCaptureService: ScreenCaptureServiceProtocol {
     init(screenRecordingGranted: Bool) {
         self.screenRecordingGranted = screenRecordingGranted
         self.imageData = Self.validPNGData
+        self.metadata = nil
     }
 
-    init(screenRecordingGranted: Bool, imageData: Data) {
+    init(screenRecordingGranted: Bool, imageData: Data, metadata: CaptureMetadata? = nil) {
         self.screenRecordingGranted = screenRecordingGranted
         self.imageData = imageData
+        self.metadata = metadata
     }
 
     func captureScreen(
@@ -1638,7 +1717,7 @@ private final class MockScreenCaptureService: ScreenCaptureServiceProtocol {
     private func makeResult(mode: CaptureMode, window: ServiceWindowInfo? = nil) -> CaptureResult {
         CaptureResult(
             imageData: self.imageData,
-            metadata: CaptureMetadata(size: .zero, mode: mode, windowInfo: window))
+            metadata: self.metadata ?? CaptureMetadata(size: .zero, mode: mode, windowInfo: window))
     }
 
     private static let validPNGData = Data([

--- a/Core/PeekabooCore/Tests/PeekabooTests/MCP/PeekabooMCPServerTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/MCP/PeekabooMCPServerTests.swift
@@ -1,4 +1,7 @@
+import Foundation
+import MCP
 import PeekabooFoundation
+import TachikomaMCP
 import Testing
 @testable import PeekabooAgentRuntime
 @testable import PeekabooAutomation
@@ -25,6 +28,29 @@ struct PeekabooMCPServerTests {
         #expect(names.contains("paste"))
         #expect(names.contains("set_value"))
         #expect(names.contains("perform_action"))
+    }
+
+    @Test
+    func `server preserves tool response metadata on the MCP wire result`() throws {
+        let response = ToolResponse.text(
+            "Captured image",
+            meta: .object([
+                "coordinate_context": .object([
+                    "version": .int(1),
+                    "logical_space": .string("global_display_points"),
+                ]),
+                "internal_diagnostics": .string("not part of the public MCP contract"),
+            ]))
+
+        let result = PeekabooMCPServer.callToolResult(from: response)
+        let encoded = try JSONEncoder().encode(result)
+        let json = try #require(JSONSerialization.jsonObject(with: encoded) as? [String: Any])
+        let metadata = try #require(json["_meta"] as? [String: Any])
+        let coordinateContext = try #require(metadata["coordinate_context"] as? [String: Any])
+
+        #expect(coordinateContext["version"] as? Int == 1)
+        #expect(coordinateContext["logical_space"] as? String == "global_display_points")
+        #expect(metadata["internal_diagnostics"] == nil)
     }
 
     @Test

--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -132,6 +132,19 @@ The MCP `image` and `see` tools share target parsing with the desktop observatio
 
 The MCP `image` tool stores logical 1x captures by default. Pass `scale: "native"` or `retina: true` to request native display pixels. Set `max_dimension` to a positive integer to cap the longest output edge while preserving aspect ratio; inline `format: "data"` captures default to 1500 pixels when no cap is supplied.
 
+### Capture coordinate context
+
+The `image` and `see` tools include an additive, versioned `coordinate_context` object in response `_meta`. It describes how the delivered raster maps to Peekaboo's canonical top-left-origin global display coordinates, which are measured in logical points:
+
+- `logical_bounds`: the capture rectangle in global logical points;
+- `delivered_image_size`: the actual raster dimensions returned to the client, after any `max_dimension` resize;
+- `native_scale`: the display's native pixel-to-point scale when known;
+- `output_scale`: the delivered raster's effective pixel-to-point scale;
+- `display` and `window`: the resolved capture identities when available;
+- `reference_id`: the snapshot ID for `see` results, or `null` for standalone `image` results.
+
+Consumers should check `version` before interpreting the object. Version `1` uses `logical_space: "global_display_points"` and `origin: "top_left"`. To convert an image-local pixel `(px, py)` to a global logical point, scale it against `delivered_image_size` and add the `logical_bounds` origin; do not assume a fixed Retina factor. The fields are additive, so clients that do not understand them can continue ignoring `_meta`.
+
 ## Troubleshooting
 
 - Ensure Screen Recording + Accessibility permissions are granted (`peekaboo permissions status`).


### PR DESCRIPTION
## What

- add a versioned `CaptureCoordinateContext` describing global logical bounds, delivered raster size, scale diagnostics, origin convention, and display/window identity
- expose the context additively in MCP `image` and `see` response metadata
- bind `see` contexts to their snapshot ID and store the context with the existing UI snapshot
- keep post-capture metadata aligned after `max_dimension` resizing
- report actual raster dimensions for area captures from both ScreenCaptureKit frame sources
- document the MCP metadata contract and conversion guidance

## Why

Retina/native captures and post-capture resizing can make screenshot pixels diverge from Peekaboo's logical-point input coordinates. Clients need the actual delivered image dimensions and logical capture bounds to map coordinates without guessing a fixed backing scale.

This is PR 1 of the coordinate-safety roadmap in #309. It is metadata-only: existing `click.coords` semantics remain unchanged. All MCP response additions are optional/additive. `see` returns its snapshot ID as `reference_id`; standalone `image` results leave it `null` until capture-reference storage is introduced.

## Impact

- no request-schema or click behavior changes
- fixes stale `CaptureMetadata.size`/effective output scale after MCP downscaling
- fixes area capture metadata that could previously report logical dimensions for a native raster
- enables later typed coordinate mapping and referenced click support
- preserves only the public `coordinate_context` field when adapting tool responses to MCP `_meta`; internal metadata remains private

## Live MCP proof

Verified through a temporary JSON-RPC client against the current branch's locally built `peekaboo mcp --no-remote` binary. QQ Music was visibly open full-screen during all captures. The screenshots remained local under `/tmp`; only geometry and timing are reported here.

### `image`, QQ Music window, native scale

```text
isError: false
wall time: 0.499s
actual PNG: 3024x1898
logical_bounds: {x: -14, y: 33, width: 1512, height: 949}
delivered_image_size: 3024x1898
requested_scale: native
native_scale: 2
output_scale: 2
origin: top_left
logical_space: global_display_points
reference_id: null
```

### `image`, same QQ Music window, `max_dimension: 600`

```text
isError: false
wall time: 0.513s
actual PNG: 600x376
logical_bounds: {x: -14, y: 33, width: 1512, height: 949}
delivered_image_size: 600x376
requested_scale: native
native_scale: 2
output_scale: 0.3968253968253968
origin: top_left
logical_space: global_display_points
reference_id: null
```

### snapshot-bound `see`, display 0 with QQ Music visible full-screen

`see(app_target: "QQ音乐")` cannot currently obtain an AX window from this app, so this proof used `see(screen: 0)` and visually confirmed the captured content was QQ Music.

```text
isError: false
wall time: 0.950s
actual PNG: 3024x1964
logical_bounds: {x: 0, y: 0, width: 1512, height: 982}
delivered_image_size: 3024x1964
requested_scale: logical1x
native_scale: 2
actual output_scale: 2
origin: top_left
logical_space: global_display_points
snapshot_id: 1785746971900-7407
reference_id: 1785746971900-7407
```

All three validations matched the actual PNG headers. The live proof also caught two integration issues now fixed in `d453531`: the MCP server adapter previously dropped `ToolResponse.meta`, and actual delivered raster dimensions must take precedence over stale requested-scale diagnostics.

## Checks

- `pnpm run format`
- SwiftLint 0.65.0 arm64, `.swiftlint.yml`: 0 serious violations (13 pre-existing warnings)
- `arch -arm64 /bin/zsh -c 'pnpm run build:cli'`
- `arch -arm64 /bin/zsh -c 'pnpm run test:safe'` — 759 tests passed
- `arch -arm64 swift test --package-path Core/PeekabooCore --filter CaptureModelsTests --no-parallel` — 14 tests passed
- `arch -arm64 swift test --package-path Core/PeekabooCore --filter PeekabooMCPServerTests --no-parallel` — 6 tests passed
- `arch -arm64 swift test --package-path Core/PeekabooCore --filter MCPToolExecutionTests --no-parallel` — 49 tests passed

Part of #309.
