### PR TITLE
feat(mcp): add reference-bound click coordinates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [3.9.11] - Unreleased
 
+### Added
+- Add reference-bound image-pixel and normalized MCP click coordinates, building on capture context from @scotthuang in #310.
+
+### Fixed
+- Honor cancellation promptly and deterministically in daemon polling and CLI timeout helpers. Thanks @SebTardif in #311.
+
 ## [3.9.10] - 2026-08-02
 
 ### Changed

--- a/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Core/CaptureCoordinateMapper.swift
+++ b/Core/PeekabooAutomationKit/Sources/PeekabooAutomationKit/Services/Core/CaptureCoordinateMapper.swift
@@ -1,0 +1,74 @@
+import CoreGraphics
+import Foundation
+
+public enum CaptureCoordinateSpace: String, Sendable, Codable, CaseIterable {
+    case globalDisplayPoints = "global_display_points"
+    case imagePixels = "image_pixels"
+    case normalized
+
+    public var requiresReference: Bool {
+        self != .globalDisplayPoints
+    }
+}
+
+public enum CaptureCoordinateMappingError: LocalizedError, Equatable {
+    case invalidCoordinate
+    case missingLogicalBounds
+    case invalidDeliveredImageSize
+    case imagePointOutOfBounds
+    case normalizedPointOutOfBounds
+
+    public var errorDescription: String? {
+        switch self {
+        case .invalidCoordinate:
+            "Coordinates must contain finite numbers."
+        case .missingLogicalBounds:
+            "The coordinate reference has no logical capture bounds. Capture a fresh snapshot."
+        case .invalidDeliveredImageSize:
+            "The coordinate reference has an invalid delivered image size. Capture a fresh snapshot."
+        case .imagePointOutOfBounds:
+            "Image-pixel coordinates are outside the delivered image bounds."
+        case .normalizedPointOutOfBounds:
+            "Normalized coordinates must be between 0 and 1 inclusive."
+        }
+    }
+}
+
+public enum CaptureCoordinateMapper {
+    public static func globalPoint(
+        for point: CGPoint,
+        in space: CaptureCoordinateSpace,
+        context: CaptureCoordinateContext) throws -> CGPoint
+    {
+        guard point.x.isFinite, point.y.isFinite else {
+            throw CaptureCoordinateMappingError.invalidCoordinate
+        }
+        guard space != .globalDisplayPoints else { return point }
+        guard let bounds = context.logicalBounds, bounds.width > 0, bounds.height > 0 else {
+            throw CaptureCoordinateMappingError.missingLogicalBounds
+        }
+
+        switch space {
+        case .globalDisplayPoints:
+            return point
+        case .imagePixels:
+            let imageSize = context.deliveredImageSize
+            guard imageSize.width > 0, imageSize.height > 0 else {
+                throw CaptureCoordinateMappingError.invalidDeliveredImageSize
+            }
+            guard point.x >= 0, point.y >= 0, point.x < imageSize.width, point.y < imageSize.height else {
+                throw CaptureCoordinateMappingError.imagePointOutOfBounds
+            }
+            return CGPoint(
+                x: bounds.minX + point.x / imageSize.width * bounds.width,
+                y: bounds.minY + point.y / imageSize.height * bounds.height)
+        case .normalized:
+            guard (0...1).contains(point.x), (0...1).contains(point.y) else {
+                throw CaptureCoordinateMappingError.normalizedPointOutOfBounds
+            }
+            return CGPoint(
+                x: bounds.minX + point.x * bounds.width,
+                y: bounds.minY + point.y * bounds.height)
+        }
+    }
+}

--- a/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/ClickTool.swift
+++ b/Core/PeekabooCore/Sources/PeekabooAgentRuntime/MCP/Tools/ClickTool.swift
@@ -34,7 +34,16 @@ public struct ClickTool: MCPTool {
                     """),
                 "coords": SchemaBuilder.string(
                     description: """
-                    Optional. Click at specific coordinates in format 'x,y' (e.g., '100,200').
+                    Optional. Click at coordinates in format 'x,y'. Bare coordinates remain global logical points.
+                    """),
+                "coordinate_space": SchemaBuilder.string(
+                    description: """
+                    Optional. Coordinate basis for coords. image_pixels and normalized require coordinate_reference.
+                    """,
+                    enum: CaptureCoordinateSpace.allCases.map(\.rawValue)),
+                "coordinate_reference": SchemaBuilder.string(
+                    description: """
+                    Optional. Snapshot reference_id returned by see. Required for image_pixels and normalized coords.
                     """),
                 "snapshot": SchemaBuilder.string(
                     description: """
@@ -116,14 +125,7 @@ public struct ClickTool: MCPTool {
     private func resolveClickTarget(for request: ClickRequest) async throws -> ClickResolution {
         switch request.target {
         case let .coordinates(raw):
-            let point = try self.parseCoordinates(raw)
-            return ClickResolution(
-                location: point,
-                automationTarget: .coordinates(point),
-                elementDescription: nil,
-                targetProcessIdentifier: request.pid,
-                snapshotId: nil,
-                snapshotIdToInvalidate: request.snapshotId)
+            return try await self.resolveCoordinates(raw, request: request)
         case let .elementId(identifier):
             let snapshot = try await self.requireSnapshot(id: request.snapshotId)
             let element = try await self.requireElement(id: identifier, snapshot: snapshot)
@@ -225,6 +227,12 @@ public struct ClickTool: MCPTool {
         if let processId = effectiveTargetProcessIdentifier.map({ Int32($0) }) {
             metaDict["target_pid"] = .double(Double(processId))
         }
+        if let coordinateSpace = resolution.coordinateSpace {
+            metaDict["coordinate_space"] = .string(coordinateSpace.rawValue)
+        }
+        if let coordinateReference = resolution.coordinateReference {
+            metaDict["coordinate_reference"] = .string(coordinateReference)
+        }
 
         let summary = ToolEventSummary(
             targetApp: resolution.targetApp,
@@ -252,6 +260,81 @@ public struct ClickTool: MCPTool {
             throw ClickToolError("Invalid coordinates format. Use 'x,y' (e.g., '100,200').")
         }
         return CGPoint(x: x, y: y)
+    }
+
+    private func resolveCoordinates(_ raw: String, request: ClickRequest) async throws -> ClickResolution {
+        let point = try self.parseCoordinates(raw)
+        guard let coordinateSpace = request.coordinateSpace else {
+            return ClickResolution(
+                location: point,
+                automationTarget: .coordinates(point),
+                elementDescription: nil,
+                targetProcessIdentifier: request.pid,
+                snapshotId: nil,
+                snapshotIdToInvalidate: request.snapshotId)
+        }
+
+        guard let referenceID = request.coordinateReference else {
+            return ClickResolution(
+                location: point,
+                automationTarget: .coordinates(point),
+                elementDescription: nil,
+                targetProcessIdentifier: request.pid,
+                snapshotId: nil,
+                snapshotIdToInvalidate: request.snapshotId,
+                coordinateSpace: coordinateSpace)
+        }
+        guard let snapshot = await self.getSnapshot(id: referenceID) else {
+            throw ClickToolError(
+                "Coordinate reference '\(referenceID)' is stale or unavailable. Run 'see' to capture a fresh snapshot.")
+        }
+        guard let coordinateContext = await snapshot.screenshotCoordinateContext,
+              coordinateContext.referenceID == referenceID
+        else {
+            throw ClickToolError(
+                "Snapshot '\(referenceID)' has no matching coordinate context. Run 'see' to capture a fresh snapshot.")
+        }
+        try await self.validateWindowReference(coordinateContext)
+
+        let mappedPoint: CGPoint
+        do {
+            mappedPoint = try CaptureCoordinateMapper.globalPoint(
+                for: point,
+                in: coordinateSpace,
+                context: coordinateContext)
+        } catch {
+            throw ClickToolError(error.localizedDescription)
+        }
+
+        return ClickResolution(
+            location: mappedPoint,
+            automationTarget: .coordinates(mappedPoint),
+            elementDescription: nil,
+            targetApp: snapshot.applicationName,
+            windowTitle: snapshot.windowTitle,
+            targetProcessIdentifier: request.pid ?? snapshot.applicationProcessId,
+            snapshotId: snapshot.id,
+            coordinateSpace: coordinateSpace,
+            coordinateReference: referenceID)
+    }
+
+    private func validateWindowReference(_ coordinateContext: CaptureCoordinateContext) async throws {
+        guard let window = coordinateContext.window,
+              let capturedBounds = coordinateContext.logicalBounds
+        else { return }
+
+        let matches = try await self.context.windows.listWindows(target: .windowId(window.windowID))
+        guard let currentBounds = matches.first?.bounds else {
+            throw ClickToolError("Coordinate reference is stale because its captured window is no longer available.")
+        }
+        let tolerance: CGFloat = 1
+        guard abs(currentBounds.minX - capturedBounds.minX) <= tolerance,
+              abs(currentBounds.minY - capturedBounds.minY) <= tolerance,
+              abs(currentBounds.width - capturedBounds.width) <= tolerance,
+              abs(currentBounds.height - capturedBounds.height) <= tolerance
+        else {
+            throw ClickToolError("Coordinate reference is stale because its captured window moved or resized.")
+        }
     }
 
     private func requireSnapshot(id: String?) async throws -> UISnapshot {
@@ -294,19 +377,48 @@ private struct ClickRequest {
     let intent: ClickIntent
     let deliveryMode: ClickToolDeliveryMode
     let pid: Int32?
+    let coordinateSpace: CaptureCoordinateSpace?
+    let coordinateReference: String?
 
     init(arguments: ToolArguments) throws {
+        let rawCoordinateSpace = arguments.getString("coordinate_space")
+        let coordinateSpace = try rawCoordinateSpace.map { value in
+            guard let space = CaptureCoordinateSpace(rawValue: value) else {
+                throw ClickToolError(
+                    "Invalid coordinate_space '\(value)'. Use global_display_points, image_pixels, or normalized.")
+            }
+            return space
+        }
+        let coordinateReference = arguments.getString("coordinate_reference")
+
         if let coords = arguments.getString("coords") {
             self.target = .coordinates(coords)
+            if coordinateSpace == nil, coordinateReference != nil {
+                throw ClickToolError("coordinate_reference requires coordinate_space.")
+            }
+            if let coordinateSpace, coordinateSpace.requiresReference, coordinateReference == nil {
+                throw ClickToolError("\(coordinateSpace.rawValue) coordinates require coordinate_reference from see.")
+            }
         } else if let elementId = arguments.getString("on") {
+            guard coordinateSpace == nil, coordinateReference == nil else {
+                throw ClickToolError("coordinate_space and coordinate_reference are only valid with coords.")
+            }
             self.target = .elementId(elementId)
         } else if let query = arguments.getString("query") {
+            guard coordinateSpace == nil, coordinateReference == nil else {
+                throw ClickToolError("coordinate_space and coordinate_reference are only valid with coords.")
+            }
             self.target = .query(query)
         } else {
             throw ClickToolError("Must specify either 'query', 'on', or 'coords'.")
         }
 
         self.snapshotId = arguments.getString("snapshot")
+        if let snapshotId = self.snapshotId, let coordinateReference, snapshotId != coordinateReference {
+            throw ClickToolError("snapshot and coordinate_reference must match when both are provided.")
+        }
+        self.coordinateSpace = coordinateSpace
+        self.coordinateReference = coordinateReference
         let isDouble = arguments.getBool("double") ?? false
         let isRight = arguments.getBool("right") ?? false
         self.intent = ClickIntent(double: isDouble, right: isRight)
@@ -349,6 +461,8 @@ private struct ClickResolution {
     let targetProcessIdentifier: Int32?
     let snapshotId: String?
     let snapshotIdToInvalidate: String?
+    let coordinateSpace: CaptureCoordinateSpace?
+    let coordinateReference: String?
 
     init(
         location: CGPoint,
@@ -360,7 +474,9 @@ private struct ClickResolution {
         elementLabel: String? = nil,
         targetProcessIdentifier: Int32? = nil,
         snapshotId: String?,
-        snapshotIdToInvalidate: String? = nil)
+        snapshotIdToInvalidate: String? = nil,
+        coordinateSpace: CaptureCoordinateSpace? = nil,
+        coordinateReference: String? = nil)
     {
         self.location = location
         self.automationTarget = automationTarget
@@ -372,6 +488,8 @@ private struct ClickResolution {
         self.targetProcessIdentifier = targetProcessIdentifier
         self.snapshotId = snapshotId
         self.snapshotIdToInvalidate = snapshotIdToInvalidate ?? snapshotId
+        self.coordinateSpace = coordinateSpace
+        self.coordinateReference = coordinateReference
     }
 }
 

--- a/Core/PeekabooCore/Tests/PeekabooTests/CaptureModelsTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/CaptureModelsTests.swift
@@ -1,5 +1,6 @@
 import CoreGraphics
 import Foundation
+import PeekabooAutomationKit
 import Testing
 @testable import PeekabooAgentRuntime
 @testable import PeekabooAutomation
@@ -258,6 +259,37 @@ struct CaptureModelsTests {
         #expect(context.requestedScale == .logical1x)
         #expect(context.nativeScale == 2)
         #expect(context.outputScale == 2)
+    }
+
+    @Test
+    func `Capture coordinate mapper uses delivered raster dimensions`() throws {
+        let metadata = CaptureMetadata(
+            size: CGSize(width: 2000, height: 1000),
+            mode: .screen,
+            displayInfo: DisplayInfo(
+                index: 0,
+                name: "Display",
+                bounds: CGRect(x: 100, y: 50, width: 1000, height: 500),
+                scaleFactor: 2))
+        let context = CaptureCoordinateContext(metadata: metadata, referenceID: "snapshot")
+
+        let imagePoint = try CaptureCoordinateMapper.globalPoint(
+            for: CGPoint(x: 1000, y: 500),
+            in: .imagePixels,
+            context: context)
+        let normalizedPoint = try CaptureCoordinateMapper.globalPoint(
+            for: CGPoint(x: 0.25, y: 0.75),
+            in: .normalized,
+            context: context)
+
+        #expect(imagePoint == CGPoint(x: 600, y: 300))
+        #expect(normalizedPoint == CGPoint(x: 350, y: 425))
+        #expect(throws: CaptureCoordinateMappingError.imagePointOutOfBounds) {
+            try CaptureCoordinateMapper.globalPoint(
+                for: CGPoint(x: 2000, y: 500),
+                in: .imagePixels,
+                context: context)
+        }
     }
 
     @Test

--- a/Core/PeekabooCore/Tests/PeekabooTests/MCP/MCPToolExecutionTests.swift
+++ b/Core/PeekabooCore/Tests/PeekabooTests/MCP/MCPToolExecutionTests.swift
@@ -924,6 +924,110 @@ struct MCPToolExecutionTests {
     }
 
     @Test
+    func `Click tool maps referenced image pixels to global logical points`() async throws {
+        await UISnapshotManager.shared.removeAllSnapshots()
+        let automation = await MainActor.run { MockAutomationService(accessibilityGranted: true) }
+        let context = await MCPToolTestHelpers.makeContext(automation: automation)
+        let snapshot = await Self.makeCoordinateSnapshot()
+        let snapshotId = await snapshot.id
+
+        let response = try await ClickTool(context: context).execute(arguments: ToolArguments(raw: [
+            "coords": "1000,500",
+            "coordinate_space": "image_pixels",
+            "coordinate_reference": snapshotId,
+        ]))
+
+        #expect(response.isError == false)
+        let call = try #require(await MainActor.run { automation.targetedClickCalls.first })
+        #expect(call.snapshotId == snapshotId)
+        #expect(call.targetProcessIdentifier == 111)
+        guard case let .coordinates(point) = call.target else {
+            Issue.record("Expected mapped coordinate target")
+            return
+        }
+        #expect(point == CGPoint(x: 600, y: 300))
+    }
+
+    @Test
+    func `Click tool maps referenced normalized coordinates`() async throws {
+        await UISnapshotManager.shared.removeAllSnapshots()
+        let automation = await MainActor.run { MockAutomationService(accessibilityGranted: true) }
+        let context = await MCPToolTestHelpers.makeContext(automation: automation)
+        let snapshot = await Self.makeCoordinateSnapshot()
+        let snapshotId = await snapshot.id
+
+        let response = try await ClickTool(context: context).execute(arguments: ToolArguments(raw: [
+            "coords": "0.25,0.75",
+            "coordinate_space": "normalized",
+            "coordinate_reference": snapshotId,
+            "foreground": true,
+        ]))
+
+        #expect(response.isError == false)
+        let call = try #require(await MainActor.run { automation.clickCalls.first })
+        #expect(call.snapshotId == snapshotId)
+        guard case let .coordinates(point) = call.target else {
+            Issue.record("Expected mapped coordinate target")
+            return
+        }
+        #expect(point == CGPoint(x: 350, y: 425))
+    }
+
+    @Test
+    func `Click tool rejects missing stale and out-of-bounds coordinate references`() async throws {
+        await UISnapshotManager.shared.removeAllSnapshots()
+        let automation = await MainActor.run { MockAutomationService(accessibilityGranted: true) }
+        let context = await MCPToolTestHelpers.makeContext(automation: automation)
+        let snapshot = await Self.makeCoordinateSnapshot()
+        let snapshotId = await snapshot.id
+        let tool = ClickTool(context: context)
+
+        let missing = try await tool.execute(arguments: ToolArguments(raw: [
+            "coords": "100,100",
+            "coordinate_space": "image_pixels",
+        ]))
+        let stale = try await tool.execute(arguments: ToolArguments(raw: [
+            "coords": "100,100",
+            "coordinate_space": "image_pixels",
+            "coordinate_reference": "missing-snapshot",
+        ]))
+        let outOfBounds = try await tool.execute(arguments: ToolArguments(raw: [
+            "coords": "2000,500",
+            "coordinate_space": "image_pixels",
+            "coordinate_reference": snapshotId,
+        ]))
+        let windowSnapshot = await UISnapshotManager.shared.createSnapshot()
+        let windowSnapshotId = await windowSnapshot.id
+        await windowSnapshot.setScreenshot(
+            path: "/tmp/stale-window-snapshot.png",
+            metadata: CaptureMetadata(
+                size: CGSize(width: 1000, height: 500),
+                mode: .window,
+                applicationInfo: ServiceApplicationInfo(
+                    processIdentifier: 111,
+                    bundleIdentifier: "com.example.snapshot",
+                    name: "SnapshotApp"),
+                windowInfo: ServiceWindowInfo(
+                    windowID: 2_147_483_647,
+                    title: "Missing Window",
+                    bounds: CGRect(x: 100, y: 50, width: 1000, height: 500),
+                    index: 0)))
+        let staleWindow = try await tool.execute(arguments: ToolArguments(raw: [
+            "coords": "500,250",
+            "coordinate_space": "image_pixels",
+            "coordinate_reference": windowSnapshotId,
+            "foreground": true,
+        ]))
+
+        #expect(missing.isError)
+        #expect(stale.isError)
+        #expect(outOfBounds.isError)
+        #expect(staleWindow.isError)
+        #expect(await MainActor.run { automation.clickCalls.isEmpty })
+        #expect(await MainActor.run { automation.targetedClickCalls.isEmpty })
+    }
+
+    @Test
     func `Type tool preserves element target when focusing before typing`() async throws {
         let automation = await MainActor.run { MockAutomationService(accessibilityGranted: true) }
         let context = await MCPToolTestHelpers.makeContext(automation: automation)
@@ -1150,6 +1254,25 @@ struct MCPToolExecutionTests {
             return nil
         }
         return context
+    }
+
+    private static func makeCoordinateSnapshot() async -> UISnapshot {
+        let snapshot = await UISnapshotManager.shared.createSnapshot()
+        await snapshot.setScreenshot(
+            path: "/tmp/coordinate-snapshot.png",
+            metadata: CaptureMetadata(
+                size: CGSize(width: 2000, height: 1000),
+                mode: .screen,
+                applicationInfo: ServiceApplicationInfo(
+                    processIdentifier: 111,
+                    bundleIdentifier: "com.example.snapshot",
+                    name: "SnapshotApp"),
+                displayInfo: DisplayInfo(
+                    index: 0,
+                    name: "Display",
+                    bounds: CGRect(x: 100, y: 50, width: 1000, height: 500),
+                    scaleFactor: 2)))
+        return snapshot
     }
 
     private static func double(from value: Value?) -> Double? {

--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -145,6 +145,17 @@ The `image` and `see` tools include an additive, versioned `coordinate_context` 
 
 Consumers should check `version` before interpreting the object. Version `1` uses `logical_space: "global_display_points"` and `origin: "top_left"`. To convert an image-local pixel `(px, py)` to a global logical point, scale it against `delivered_image_size` and add the `logical_bounds` origin; do not assume a fixed Retina factor. The fields are additive, so clients that do not understand them can continue ignoring `_meta`.
 
+The `click` tool accepts screenshot-relative coordinates when they are explicitly bound to a `see` snapshot. Pass `coordinate_space: "image_pixels"` for delivered-raster pixels or `coordinate_space: "normalized"` for values from 0 through 1, plus the snapshot's `reference_id` as `coordinate_reference`. Missing, stale, out-of-bounds, or moved-window references fail without dispatching a click. Bare `coords` retain their existing global logical-point meaning. Screen-wide references are not tied to an application process, so use `foreground: true` (or supply an explicit `pid` for background delivery).
+
+```json
+{
+  "coords": "300,220",
+  "coordinate_space": "image_pixels",
+  "coordinate_reference": "snapshot-id-from-see",
+  "foreground": true
+}
+```
+
 ## Troubleshooting
 
 - Ensure Screen Recording + Accessibility permissions are granted (`peekaboo permissions status`).


### PR DESCRIPTION
## What

- add a shared mapper from delivered image pixels or normalized coordinates to global logical points
- extend MCP `click` with optional `coordinate_space` and `coordinate_reference` inputs
- require a live `see` snapshot reference for screenshot-relative coordinates
- reject missing, stale, out-of-bounds, and moved-window references before dispatch
- preserve bare `coords` as global logical points
- document the referenced-click workflow and reconcile the changelog for #310 and #311

## Why

PR #310 made capture geometry explicit, but clients still could not safely use screenshot coordinates as input. This completes the minimal safe contract from #309 without guessing Retina scale, changing legacy clicks, or expanding into window-local/structured-vision APIs.

## Proof

- `pnpm run format`
- `pnpm run lint` — 0 serious violations
- `pnpm run build:cli`
- `pnpm run test:safe` — 763 tests passed
- `swift test --package-path Core/PeekabooCore --filter CaptureModelsTests --no-parallel` — 15 passed
- `swift test --package-path Core/PeekabooCore --filter MCPToolExecutionTests --no-parallel` — 52 passed
- autoreview: clean, no accepted/actionable findings

Live MCP proof with a temporary TextEdit window:

```text
see bounds: x=745 y=333 width=880 height=448
normalized input: 0.5,0.5
expected center: 1185,557
result: [ok] Clicked at (1185, 557) in 0.04s
invalid reference: rejected as stale/unavailable
```

Closes #309.
